### PR TITLE
style: enforce rust code style

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Check License Header
+      - name: Check license header
         uses: apache/skywalking-eyes/header@v0.6.0
+      - name: Check code style
+        run: make check
 
   build:
     runs-on: ${{ matrix.os }}
@@ -55,6 +56,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Unit Test
+      - name: Unit test
         run: cargo test --no-fail-fast --all-targets --all-features --workspace

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,16 +22,16 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-rust-version = "1.75.0"
+rust-version = "1.78.0"
 
 [workspace.dependencies]
 # arrow
 arrow = { version = "50" }
 arrow-arith = { version = "50" }
-arrow-array = { version = "50", features = ["chrono-tz"]}
+arrow-array = { version = "50", features = ["chrono-tz"] }
 arrow-buffer = { version = "50" }
 arrow-cast = { version = "50" }
 arrow-ipc = { version = "50" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ resolver = "2"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-rust-version = "1.78.0"
+rust-version = "1.75.0"
 
 [workspace.dependencies]
 # arrow

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+.EXPORT_ALL_VARIABLES:
+
+RUST_LOG = debug
+
+build:
+	cargo build
+
+check-fmt:
+	cargo fmt --all -- --check
+
+check-clippy:
+	cargo clippy --all-targets --all-features --workspace -- -D warnings
+
+check: check-fmt check-clippy

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -19,22 +19,13 @@
 
 use std::error::Error;
 use std::fmt::Debug;
-use std::io;
 
 use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum HudiFileGroupError {
-    #[error("Base File {0} has unsupported format: {1}")]
-    UnsupportedBaseFileFormat(String, String),
     #[error("Commit time {0} is already present in File Group {1}")]
     CommitTimeAlreadyExists(String, String),
-}
-
-#[derive(Debug, Error)]
-pub enum HudiTimelineError {
-    #[error("Error in reading commit metadata: {0}")]
-    FailToReadCommitMetadata(io::Error),
 }
 
 #[derive(Debug, Error)]
@@ -47,8 +38,6 @@ pub enum HudiFileSystemViewError {
 pub enum HudiCoreError {
     #[error("Failed to load file group")]
     FailToLoadFileGroup(#[from] HudiFileGroupError),
-    #[error("Failed to init timeline")]
-    FailToInitTimeline(#[from] HudiTimelineError),
     #[error("Failed to build file system view")]
     FailToBuildFileSystemView(#[from] HudiFileSystemViewError),
 }

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -18,11 +18,9 @@
  */
 
 use std::error::Error;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use arrow_schema::SchemaRef;
-
-use hudi_fs::test_utils::extract_test_table;
 
 use crate::table::file_system_view::FileSystemView;
 use crate::table::meta_client::MetaClient;
@@ -68,11 +66,18 @@ impl Table {
     }
 }
 
-#[test]
-fn load_snapshot_file_paths() {
-    let fixture_path = Path::new("fixtures/table/0.x_cow_partitioned.zip");
-    let target_table_path = extract_test_table(fixture_path);
-    let hudi_table = Table::new(target_table_path.as_path().to_str().unwrap());
-    assert_eq!(hudi_table.get_snapshot_file_paths().unwrap().len(), 5);
-    println!("{}", hudi_table.schema().to_string());
+#[cfg(test)]
+mod tests {
+    use crate::table::Table;
+    use hudi_fs::test_utils::extract_test_table;
+    use std::path::Path;
+
+    #[test]
+    fn load_snapshot_file_paths() {
+        let fixture_path = Path::new("fixtures/table/0.x_cow_partitioned.zip");
+        let target_table_path = extract_test_table(fixture_path);
+        let hudi_table = Table::new(target_table_path.as_path().to_str().unwrap());
+        assert_eq!(hudi_table.get_snapshot_file_paths().unwrap().len(), 5);
+        println!("{}", hudi_table.schema());
+    }
 }

--- a/crates/datafusion/src/bin/main.rs
+++ b/crates/datafusion/src/bin/main.rs
@@ -29,7 +29,9 @@ async fn main() -> Result<()> {
     let ctx = SessionContext::new();
     let hudi = HudiDataSource::new("/tmp/trips_table");
     ctx.register_table("trips_table", Arc::new(hudi))?;
-    let df: DataFrame = ctx.sql("SELECT * from trips_table where fare > 20.0").await?;
+    let df: DataFrame = ctx
+        .sql("SELECT * from trips_table where fare > 20.0")
+        .await?;
     df.show().await?;
     Ok(())
 }

--- a/crates/fs/src/file_systems.rs
+++ b/crates/fs/src/file_systems.rs
@@ -20,11 +20,9 @@
 use std::error::Error;
 use std::{fs::File, path::Path};
 
-use parquet::file::reader::{FileReader, Length, SerializedFileReader};
+use parquet::file::reader::{FileReader, SerializedFileReader};
 
-use crate::assert_approx_eq;
-
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct FileMetadata {
     pub path: String,
     pub name: String,
@@ -46,12 +44,19 @@ impl FileMetadata {
     }
 }
 
-#[test]
-fn read_file_metadata() {
-    let fixture_path = Path::new("fixtures/a.parquet");
-    let fm = FileMetadata::from_path(fixture_path).unwrap();
-    assert_eq!(fm.path, "fixtures/a.parquet");
-    assert_eq!(fm.name, "a.parquet");
-    assert_approx_eq!(fm.size, 866, 20);
-    assert_eq!(fm.num_records, 5);
+#[cfg(test)]
+mod tests {
+    use crate::assert_approx_eq;
+    use crate::file_systems::FileMetadata;
+    use std::path::Path;
+
+    #[test]
+    fn read_file_metadata() {
+        let fixture_path = Path::new("fixtures/a.parquet");
+        let fm = FileMetadata::from_path(fixture_path).unwrap();
+        assert_eq!(fm.path, "fixtures/a.parquet");
+        assert_eq!(fm.name, "a.parquet");
+        assert_approx_eq!(fm.size, 866, 20);
+        assert_eq!(fm.num_records, 5);
+    }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -16,6 +16,6 @@
 # under the License.
 
 [toolchain]
-channel = "1.78"
+channel = "1.75"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[toolchain]
+channel = "1.78"
+components = ["rustfmt", "clippy"]
+profile = "minimal"


### PR DESCRIPTION
Use `rustfmt` and `clippy` to enforce code style through CI check job.

Fixes #13 