### PR TITLE
ci: use cargo tarpaulin to generate code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,14 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    container:
+      image: xd009642/tarpaulin:0.29.1
+      options: --security-opt seccomp=unconfined
     steps:
       - uses: actions/checkout@v4
-      - name: Unit test
-        run: cargo test --no-fail-fast --all-targets --all-features --workspace
+      - name: Unit test with code coverage
+        run: cargo tarpaulin --verbose --no-fail-fast --all-features --workspace --out xml
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ __pycache__
 
 # macOS
 **/.DS_Store
+
+# coverage files
+*.profraw
+cobertura.xml


### PR DESCRIPTION
Use https://github.com/xd009642/tarpaulin to generate coverage file, which will be reported to https://app.codecov.io/gh/apache/hudi-rs

Fixes #6 