### PR TITLE
feat: implement Rust and Python APIs to read file slices

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ rust-version = "1.75.0"
 
 [workspace.dependencies]
 # arrow
-arrow = { version = "50" }
+arrow = { version = "50", features = ["pyarrow"] }
 arrow-arith = { version = "50" }
 arrow-array = { version = "50", features = ["chrono-tz"] }
 arrow-buffer = { version = "50" }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -67,6 +67,7 @@ url = { workspace = true }
 async-recursion = { workspace = true }
 async-trait = { workspace = true }
 tokio = { workspace = true }
+futures = { workspace = true }
 
 # test
 tempfile = "3.10.1"

--- a/crates/core/src/file_group/mod.rs
+++ b/crates/core/src/file_group/mod.rs
@@ -21,33 +21,50 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::fmt::Formatter;
 
-use crate::storage::file_metadata::FileMetadata;
+use crate::storage::file_info::FileInfo;
+use crate::storage::file_stats::FileStats;
 use anyhow::{anyhow, Result};
 
 #[derive(Clone, Debug)]
 pub struct BaseFile {
     pub file_group_id: String,
     pub commit_time: String,
-    pub metadata: Option<FileMetadata>,
+    pub metadata: FileInfo,
+    pub stats: Option<FileStats>,
 }
 
 impl BaseFile {
-    pub fn new(file_name: &str) -> Self {
-        let (name, _) = file_name.rsplit_once('.').unwrap();
+    fn parse_file_name(file_name: &str) -> Result<(String, String)> {
+        let err_msg = format!("Failed to parse file name '{}' for base file.", file_name);
+        let (name, _) = file_name.rsplit_once('.').ok_or(anyhow!(err_msg.clone()))?;
         let parts: Vec<&str> = name.split('_').collect();
-        let file_group_id = parts[0].to_owned();
-        let commit_time = parts[2].to_owned();
-        Self {
-            file_group_id,
-            commit_time,
-            metadata: None,
-        }
+        let file_group_id = parts.first().ok_or(anyhow!(err_msg.clone()))?.to_string();
+        let commit_time = parts.get(2).ok_or(anyhow!(err_msg.clone()))?.to_string();
+        Ok((file_group_id, commit_time))
     }
 
-    pub fn from_file_metadata(file_metadata: FileMetadata) -> Self {
-        let mut base_file = Self::new(file_metadata.name.as_str());
-        base_file.metadata = Some(file_metadata);
-        base_file
+    pub fn from_file_name(file_name: &str) -> Result<Self> {
+        let (file_group_id, commit_time) = Self::parse_file_name(file_name)?;
+        Ok(Self {
+            file_group_id,
+            commit_time,
+            metadata: FileInfo::default(),
+            stats: None,
+        })
+    }
+
+    pub fn from_file_metadata(metadata: FileInfo) -> Result<Self> {
+        let (file_group_id, commit_time) = Self::parse_file_name(&metadata.name)?;
+        Ok(Self {
+            file_group_id,
+            commit_time,
+            metadata,
+            stats: None,
+        })
+    }
+
+    pub fn populate_stats(&mut self, stats: FileStats) {
+        self.stats = Some(stats)
     }
 }
 
@@ -58,11 +75,8 @@ pub struct FileSlice {
 }
 
 impl FileSlice {
-    pub fn base_file_path(&self) -> Option<&str> {
-        match &self.base_file.metadata {
-            None => None,
-            Some(file_metadata) => Some(file_metadata.path.as_str()),
-        }
+    pub fn base_file_path(&self) -> &str {
+        self.base_file.metadata.uri.as_str()
     }
 
     pub fn file_group_id(&self) -> &str {
@@ -102,9 +116,9 @@ impl FileGroup {
         }
     }
 
-    #[allow(dead_code)]
-    pub fn add_base_file_from_name(&mut self, file_name: &str) -> Result<&Self> {
-        let base_file = BaseFile::new(file_name);
+    #[cfg(test)]
+    fn add_base_file_from_name(&mut self, file_name: &str) -> Result<&Self> {
+        let base_file = BaseFile::from_file_name(file_name)?;
         self.add_base_file(base_file)
     }
 
@@ -131,6 +145,10 @@ impl FileGroup {
     pub fn get_latest_file_slice(&self) -> Option<&FileSlice> {
         return self.file_slices.values().next_back();
     }
+
+    pub fn get_latest_file_slice_mut(&mut self) -> Option<&mut FileSlice> {
+        return self.file_slices.values_mut().next_back();
+    }
 }
 
 #[cfg(test)]
@@ -139,9 +157,10 @@ mod tests {
 
     #[test]
     fn create_a_base_file_successfully() {
-        let base_file = BaseFile::new(
+        let base_file = BaseFile::from_file_name(
             "5a226868-2934-4f84-a16f-55124630c68d-0_0-7-24_20240402144910683.parquet",
-        );
+        )
+        .unwrap();
         assert_eq!(
             base_file.file_group_id,
             "5a226868-2934-4f84-a16f-55124630c68d-0"

--- a/crates/core/src/file_group/mod.rs
+++ b/crates/core/src/file_group/mod.rs
@@ -29,7 +29,7 @@ use anyhow::{anyhow, Result};
 pub struct BaseFile {
     pub file_group_id: String,
     pub commit_time: String,
-    pub metadata: FileInfo,
+    pub info: FileInfo,
     pub stats: Option<FileStats>,
 }
 
@@ -48,17 +48,17 @@ impl BaseFile {
         Ok(Self {
             file_group_id,
             commit_time,
-            metadata: FileInfo::default(),
+            info: FileInfo::default(),
             stats: None,
         })
     }
 
-    pub fn from_file_metadata(metadata: FileInfo) -> Result<Self> {
-        let (file_group_id, commit_time) = Self::parse_file_name(&metadata.name)?;
+    pub fn from_file_info(info: FileInfo) -> Result<Self> {
+        let (file_group_id, commit_time) = Self::parse_file_name(&info.name)?;
         Ok(Self {
             file_group_id,
             commit_time,
-            metadata,
+            info,
             stats: None,
         })
     }
@@ -76,7 +76,7 @@ pub struct FileSlice {
 
 impl FileSlice {
     pub fn base_file_path(&self) -> &str {
-        self.base_file.metadata.uri.as_str()
+        self.base_file.info.uri.as_str()
     }
 
     pub fn file_group_id(&self) -> &str {

--- a/crates/core/src/storage/file_info.rs
+++ b/crates/core/src/storage/file_info.rs
@@ -17,43 +17,9 @@
  * under the License.
  */
 
-use anyhow::anyhow;
-use anyhow::Result;
-use std::path::Path;
-
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct FileMetadata {
-    pub path: String,
+#[derive(Clone, Debug, Default)]
+pub struct FileInfo {
+    pub uri: String,
     pub name: String,
     pub size: usize,
-    pub num_records: Option<usize>,
-}
-
-impl FileMetadata {
-    pub fn new(path: String, name: String, size: usize) -> FileMetadata {
-        FileMetadata {
-            path,
-            name,
-            size,
-            num_records: None,
-        }
-    }
-}
-
-pub fn split_filename(filename: &str) -> Result<(String, String)> {
-    let path = Path::new(filename);
-
-    let stem = path
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .ok_or_else(|| anyhow!("No file stem found"))?
-        .to_string();
-
-    let extension = path
-        .extension()
-        .and_then(|e| e.to_str())
-        .unwrap_or_default()
-        .to_string();
-
-    Ok((stem, extension))
 }

--- a/crates/core/src/storage/file_stats.rs
+++ b/crates/core/src/storage/file_stats.rs
@@ -17,15 +17,7 @@
  * under the License.
  */
 
-use crate::table::Table;
-
-pub mod file_group;
-pub mod table;
-pub type HudiTable = Table;
-mod storage;
-pub mod test_utils;
-mod timeline;
-
-pub fn crate_version() -> &'static str {
-    env!("CARGO_PKG_VERSION")
+#[derive(Clone, Debug, Default)]
+pub struct FileStats {
+    pub num_records: i64,
 }

--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -229,21 +229,21 @@ mod tests {
             .list_files(None)
             .await
             .into_iter()
-            .map(|file_metadata| file_metadata.name)
+            .map(|file_info| file_info.name)
             .collect();
         assert_eq!(file_names_1, vec!["a.parquet"]);
         let file_names_2: Vec<String> = storage
             .list_files(Some("part1"))
             .await
             .into_iter()
-            .map(|file_metadata| file_metadata.name)
+            .map(|file_info| file_info.name)
             .collect();
         assert_eq!(file_names_2, vec!["b.parquet"]);
         let file_names_3: Vec<String> = storage
             .list_files(Some("part2/part22"))
             .await
             .into_iter()
-            .map(|file_metadata| file_metadata.name)
+            .map(|file_info| file_info.name)
             .collect();
         assert_eq!(file_names_3, vec!["c.parquet"]);
     }
@@ -267,13 +267,13 @@ mod tests {
         let base_url =
             Url::from_directory_path(canonicalize(Path::new("fixtures")).unwrap()).unwrap();
         let storage = Storage::new(base_url, HashMap::new());
-        let file_metadata = storage.get_file_info("a.parquet").await;
-        assert_eq!(file_metadata.name, "a.parquet");
+        let file_info = storage.get_file_info("a.parquet").await;
+        assert_eq!(file_info.name, "a.parquet");
         assert_eq!(
-            file_metadata.uri,
+            file_info.uri,
             storage.base_url.join("a.parquet").unwrap().to_string()
         );
-        assert_eq!(file_metadata.size, 866);
+        assert_eq!(file_info.size, 866);
     }
 
     #[tokio::test]

--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -275,4 +275,14 @@ mod tests {
         );
         assert_eq!(file_metadata.size, 866);
     }
+
+    #[tokio::test]
+    async fn storage_get_parquet_file_data() {
+        let base_url =
+            Url::from_directory_path(canonicalize(Path::new("fixtures")).unwrap()).unwrap();
+        let storage = Storage::new(base_url, HashMap::new());
+        let file_data = storage.get_parquet_file_data("a.parquet").await;
+        assert_eq!(file_data.len(), 1);
+        assert_eq!(file_data.first().unwrap().num_rows(), 5);
+    }
 }

--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -172,8 +172,8 @@ mod tests {
     use object_store::path::Path as ObjPath;
     use url::Url;
 
-    use crate::storage::{get_leaf_dirs, Storage};
     use crate::storage::utils::join_url_segments;
+    use crate::storage::{get_leaf_dirs, Storage};
 
     #[tokio::test]
     async fn storage_list_dirs() {
@@ -210,7 +210,10 @@ mod tests {
             .collect();
         let expected_paths: HashSet<ObjPath> = vec![".hoodie", "part1", "part2", "part3"]
             .into_iter()
-            .map(|dir| ObjPath::from_url_path(join_url_segments(&storage.base_url, &[dir]).unwrap().path()).unwrap())
+            .map(|dir| {
+                ObjPath::from_url_path(join_url_segments(&storage.base_url, &[dir]).unwrap().path())
+                    .unwrap()
+            })
             .collect();
         assert_eq!(first_level_dirs, expected_paths);
     }

--- a/crates/core/src/storage/utils.rs
+++ b/crates/core/src/storage/utils.rs
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use anyhow::{anyhow, Result};
+use std::path::Path;
+use url::{ParseError, Url};
+
+pub fn split_filename(filename: &str) -> Result<(String, String)> {
+    let path = Path::new(filename);
+
+    let stem = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| anyhow!("No file stem found"))?
+        .to_string();
+
+    let extension = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or_default()
+        .to_string();
+
+    Ok((stem, extension))
+}
+
+pub fn join_url_segments(base_url: &Url, segments: &[&str]) -> Result<Url> {
+    let mut url = base_url.clone();
+
+    if url.path().ends_with('/') {
+        url.path_segments_mut().unwrap().pop();
+    }
+
+    url.path_segments_mut()
+        .map_err(|_| ParseError::RelativeUrlWithoutBase)?
+        .extend(segments);
+
+    Ok(url)
+}

--- a/crates/core/src/table/fs_view.rs
+++ b/crates/core/src/table/fs_view.rs
@@ -60,15 +60,15 @@ impl FileSystemView {
 
     async fn get_file_groups(&self, partition_path: &str) -> Result<Vec<FileGroup>> {
         let storage = Storage::new(self.base_url.clone(), HashMap::new());
-        let file_metadata: Vec<FileInfo> = storage
+        let file_info: Vec<FileInfo> = storage
             .list_files(Some(partition_path))
             .await
             .into_iter()
             .filter(|f| f.name.ends_with(".parquet"))
             .collect();
         let mut fg_id_to_base_files: HashMap<String, Vec<BaseFile>> = HashMap::new();
-        for f in file_metadata {
-            let base_file = BaseFile::from_file_metadata(f)?;
+        for f in file_info {
+            let base_file = BaseFile::from_file_info(f)?;
             let fg_id = &base_file.file_group_id;
             fg_id_to_base_files
                 .entry(fg_id.to_owned())
@@ -148,7 +148,7 @@ async fn load_file_slice_stats(base_url: &Url, file_slice: &mut FileSlice) -> Re
         let storage = Storage::new(base_url.clone(), HashMap::new());
         let ptn = file_slice.partition_path.clone();
         let mut relative_path = PathBuf::from(ptn.unwrap_or("".to_string()));
-        let base_file_name = &base_file.metadata.name;
+        let base_file_name = &base_file.info.name;
         relative_path.push(base_file_name);
         let parquet_meta = storage
             .get_parquet_file_metadata(relative_path.to_str().unwrap())

--- a/crates/core/src/table/fs_view.rs
+++ b/crates/core/src/table/fs_view.rs
@@ -195,7 +195,8 @@ mod tests {
 
     #[tokio::test]
     async fn get_partition_paths() {
-        let fixture_path = canonicalize(Path::new("fixtures/table/0.x_cow_partitioned.zip")).unwrap();
+        let fixture_path =
+            canonicalize(Path::new("fixtures/table/0.x_cow_partitioned.zip")).unwrap();
         let base_url = Url::from_file_path(extract_test_table(&fixture_path)).unwrap();
         let fs_view = FileSystemView::new(base_url);
         let partition_paths = fs_view.get_partition_paths().await.unwrap();
@@ -209,7 +210,8 @@ mod tests {
 
     #[test]
     fn get_latest_file_slices() {
-        let fixture_path = canonicalize(Path::new("fixtures/table/0.x_cow_partitioned.zip")).unwrap();
+        let fixture_path =
+            canonicalize(Path::new("fixtures/table/0.x_cow_partitioned.zip")).unwrap();
         let base_url = Url::from_file_path(extract_test_table(&fixture_path)).unwrap();
         let mut fs_view = FileSystemView::new(base_url);
         fs_view.load_file_groups();

--- a/crates/core/src/table/fs_view.rs
+++ b/crates/core/src/table/fs_view.rs
@@ -18,30 +18,33 @@
  */
 
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
+use arrow::record_batch::RecordBatch;
+use url::Url;
 
 use crate::file_group::{BaseFile, FileGroup, FileSlice};
-use crate::storage::file_metadata::FileMetadata;
+use crate::storage::file_info::FileInfo;
+use crate::storage::file_stats::FileStats;
 use crate::storage::{get_leaf_dirs, Storage};
 
 #[derive(Clone, Debug)]
 pub struct FileSystemView {
-    pub base_path: PathBuf,
+    pub base_url: Url,
     partition_to_file_groups: HashMap<String, Vec<FileGroup>>,
 }
 
 impl FileSystemView {
-    pub fn new(base_path: &Path) -> Self {
+    pub fn new(base_url: Url) -> Self {
         FileSystemView {
-            base_path: base_path.to_path_buf(),
+            base_url,
             partition_to_file_groups: HashMap::new(),
         }
     }
 
     async fn get_partition_paths(&self) -> Result<Vec<String>> {
-        let storage = Storage::new(self.base_path.to_str().unwrap(), HashMap::new());
+        let storage = Storage::new(self.base_url.clone(), HashMap::new());
         let top_level_dirs: Vec<String> = storage
             .list_dirs(None)
             .await
@@ -56,8 +59,8 @@ impl FileSystemView {
     }
 
     async fn get_file_groups(&self, partition_path: &str) -> Result<Vec<FileGroup>> {
-        let storage = Storage::new(self.base_path.to_str().unwrap(), HashMap::new());
-        let file_metadata: Vec<FileMetadata> = storage
+        let storage = Storage::new(self.base_url.clone(), HashMap::new());
+        let file_metadata: Vec<FileInfo> = storage
             .list_files(Some(partition_path))
             .await
             .into_iter()
@@ -65,7 +68,7 @@ impl FileSystemView {
             .collect();
         let mut fg_id_to_base_files: HashMap<String, Vec<BaseFile>> = HashMap::new();
         for f in file_metadata {
-            let base_file = BaseFile::from_file_metadata(f);
+            let base_file = BaseFile::from_file_metadata(f)?;
             let fg_id = &base_file.file_group_id;
             fg_id_to_base_files
                 .entry(fg_id.to_owned())
@@ -84,8 +87,7 @@ impl FileSystemView {
         Ok(file_groups)
     }
 
-    pub fn get_latest_file_slices(&mut self) -> Vec<&FileSlice> {
-        let mut file_slices = Vec::new();
+    pub fn load_file_groups(&mut self) {
         let fs_view = self.clone();
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -96,6 +98,10 @@ impl FileSystemView {
         for (k, v) in result {
             self.partition_to_file_groups.insert(k, v);
         }
+    }
+
+    pub fn get_latest_file_slices(&self) -> Vec<&FileSlice> {
+        let mut file_slices = Vec::new();
         for fgs in self.partition_to_file_groups.values() {
             for fg in fgs {
                 if let Some(file_slice) = fg.get_latest_file_slice() {
@@ -105,6 +111,52 @@ impl FileSystemView {
         }
         file_slices
     }
+
+    pub fn get_latest_file_slices_with_stats(&mut self) -> Vec<&mut FileSlice> {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut file_slices = Vec::new();
+        let file_groups = &mut self.partition_to_file_groups.values_mut();
+        for fgs in file_groups {
+            for fg in fgs {
+                if let Some(file_slice) = fg.get_latest_file_slice_mut() {
+                    let wrapper = async { load_file_slice_stats(&self.base_url, file_slice).await };
+                    let _ = rt.block_on(wrapper);
+                    file_slices.push(file_slice)
+                }
+            }
+        }
+        file_slices
+    }
+
+    pub fn read_file_slice(&self, relative_path: &str) -> Vec<RecordBatch> {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let storage = Storage::new(self.base_url.clone(), HashMap::new());
+        let wrapper = async { storage.get_parquet_file_data(relative_path).await };
+        rt.block_on(wrapper)
+    }
+}
+
+async fn load_file_slice_stats(base_url: &Url, file_slice: &mut FileSlice) -> Result<()> {
+    let base_file = &mut file_slice.base_file;
+    if base_file.stats.is_none() {
+        let storage = Storage::new(base_url.clone(), HashMap::new());
+        let ptn = file_slice.partition_path.clone();
+        let mut relative_path = PathBuf::from(ptn.unwrap_or("".to_string()));
+        let base_file_name = &base_file.metadata.name;
+        relative_path.push(base_file_name);
+        let parquet_meta = storage
+            .get_parquet_file_metadata(relative_path.to_str().unwrap())
+            .await;
+        let num_records = parquet_meta.file_metadata().num_rows();
+        base_file.populate_stats(FileStats { num_records });
+    }
+    Ok(())
 }
 
 async fn get_partitions_and_file_groups(
@@ -133,17 +185,19 @@ async fn get_partitions_and_file_groups(
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
+    use std::fs::canonicalize;
     use std::path::Path;
 
-    use crate::test_utils::extract_test_table;
+    use url::Url;
 
     use crate::table::fs_view::FileSystemView;
+    use crate::test_utils::extract_test_table;
 
     #[tokio::test]
     async fn get_partition_paths() {
-        let fixture_path = Path::new("fixtures/table/0.x_cow_partitioned.zip");
-        let target_table_path = extract_test_table(fixture_path);
-        let fs_view = FileSystemView::new(&target_table_path);
+        let fixture_path = canonicalize(Path::new("fixtures/table/0.x_cow_partitioned.zip")).unwrap();
+        let base_url = Url::from_file_path(extract_test_table(&fixture_path)).unwrap();
+        let fs_view = FileSystemView::new(base_url);
         let partition_paths = fs_view.get_partition_paths().await.unwrap();
         let partition_path_set: HashSet<&str> =
             HashSet::from_iter(partition_paths.iter().map(|p| p.as_str()));
@@ -155,9 +209,10 @@ mod tests {
 
     #[test]
     fn get_latest_file_slices() {
-        let fixture_path = Path::new("fixtures/table/0.x_cow_partitioned.zip");
-        let target_table_path = extract_test_table(fixture_path);
-        let mut fs_view = FileSystemView::new(&target_table_path);
+        let fixture_path = canonicalize(Path::new("fixtures/table/0.x_cow_partitioned.zip")).unwrap();
+        let base_url = Url::from_file_path(extract_test_table(&fixture_path)).unwrap();
+        let mut fs_view = FileSystemView::new(base_url);
+        fs_view.load_file_groups();
         let file_slices = fs_view.get_latest_file_slices();
         assert_eq!(file_slices.len(), 5);
         let mut fg_ids = Vec::new();

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -17,16 +17,18 @@
  * under the License.
  */
 
-use anyhow::Result;
 use std::collections::HashMap;
-use std::fs::File;
 use std::io::{BufRead, BufReader};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::str::FromStr;
 
+use anyhow::Result;
+use arrow::record_batch::RecordBatch;
 use arrow_schema::SchemaRef;
+use url::Url;
 
 use crate::file_group::FileSlice;
+use crate::storage::Storage;
 use crate::table::config::BaseFileFormat;
 use crate::table::config::{ConfigKey, TableType};
 use crate::table::fs_view::FileSystemView;
@@ -38,26 +40,44 @@ mod fs_view;
 mod metadata;
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct Table {
-    pub base_path: PathBuf,
+    pub base_url: Url,
     pub props: HashMap<String, String>,
+    pub file_system_view: Option<FileSystemView>,
+    pub storage_options: HashMap<String, String>,
 }
 
 impl Table {
-    pub fn new(table_base_path: &str) -> Self {
-        let base_path = PathBuf::from(table_base_path);
-        let props_path = base_path.join(".hoodie").join("hoodie.properties");
-        match Self::load_properties(props_path.as_path()) {
-            Ok(props) => Self { base_path, props },
+    pub fn new(base_uri: &str, storage_options: HashMap<String, String>) -> Self {
+        let base_url = Url::from_file_path(PathBuf::from(base_uri).as_path()).unwrap();
+        match Self::load_properties(&base_url, ".hoodie/hoodie.properties", &storage_options) {
+            Ok(props) => Self {
+                base_url,
+                props,
+                file_system_view: None,
+                storage_options,
+            },
             Err(e) => {
                 panic!("Failed to load table properties: {}", e)
             }
         }
     }
 
-    fn load_properties(path: &Path) -> Result<HashMap<String, String>> {
-        let file = File::open(path)?;
-        let reader = BufReader::new(file);
+    fn load_properties(
+        base_url: &Url,
+        props_path: &str,
+        storage_options: &HashMap<String, String>,
+    ) -> Result<HashMap<String, String>> {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let storage = Storage::new(base_url.clone(), storage_options.clone());
+        let get_data = async { storage.get_file_data(props_path).await };
+        let data = rt.block_on(get_data);
+        let cursor = std::io::Cursor::new(data);
+        let reader = BufReader::new(cursor);
         let lines = reader.lines();
         let mut properties: HashMap<String, String> = HashMap::new();
         for line in lines {
@@ -81,58 +101,65 @@ impl Table {
         }
     }
 
-    pub fn get_timeline(&self) -> Result<Timeline> {
+    #[cfg(test)]
+    fn get_timeline(&self) -> Result<Timeline> {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .unwrap();
-        let f = async { Timeline::new(self.base_path.to_str().unwrap()).await };
-        rt.block_on(f)
+        let init_timeline = async { Timeline::new(self.base_url.clone()).await };
+        rt.block_on(init_timeline)
     }
 
-    pub fn schema(&self) -> SchemaRef {
+    pub fn get_latest_schema(&self) -> SchemaRef {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .unwrap();
-        let f = async { Timeline::new(self.base_path.to_str().unwrap()).await };
-        let timeline = rt.block_on(f);
+        let init_timeline = async { Timeline::new(self.base_url.clone()).await };
+        let timeline = rt.block_on(init_timeline);
         match timeline {
             Ok(timeline) => {
                 let rt = tokio::runtime::Builder::new_current_thread()
                     .enable_all()
                     .build()
                     .unwrap();
-                let wrapper = async { timeline.get_latest_schema().await };
-                let result = rt.block_on(wrapper);
-                match result {
+                let get_schema = async { timeline.get_latest_schema().await };
+                match rt.block_on(get_schema) {
                     Ok(schema) => SchemaRef::from(schema),
-                    Err(e) => {
-                        panic!("Failed to resolve table schema: {}", e)
-                    }
+                    Err(e) => panic!("Failed to resolve table schema: {}", e),
                 }
             }
-            Err(e) => {
-                panic!("Failed to resolve table schema: {}", e)
-            }
+            Err(e) => panic!("Failed to resolve table schema: {}", e),
         }
     }
 
-    pub fn get_latest_file_slices(&self) -> Result<Vec<FileSlice>> {
+    pub fn get_latest_file_slices(&mut self) -> Result<Vec<FileSlice>> {
         let mut file_slices = Vec::new();
-        let mut fs_view = FileSystemView::new(self.base_path.as_path());
-        for f in fs_view.get_latest_file_slices() {
+
+        if self.file_system_view.is_none() {
+            let mut new_fs_view = FileSystemView::new(self.base_url.clone());
+            new_fs_view.load_file_groups();
+            self.file_system_view = Some(new_fs_view);
+        }
+
+        let fs_view = self.file_system_view.as_mut().unwrap();
+
+        for f in fs_view.get_latest_file_slices_with_stats() {
             file_slices.push(f.clone());
         }
         Ok(file_slices)
     }
 
-    pub fn get_latest_file_paths(&self) -> Result<Vec<String>> {
+    pub fn read_file_slice(&self, relative_path: &str) -> Vec<RecordBatch> {
+        let fs_view = self.file_system_view.as_ref().unwrap();
+        fs_view.read_file_slice(relative_path)
+    }
+
+    pub fn get_latest_file_paths(&mut self) -> Result<Vec<String>> {
         let mut file_paths = Vec::new();
         for f in self.get_latest_file_slices()? {
-            if let Some(f) = f.base_file_path() {
-                file_paths.push(f.to_string());
-            }
+            file_paths.push(f.base_file_path().to_string());
         }
         Ok(file_paths)
     }
@@ -178,7 +205,7 @@ impl ProvidesTableMetadata for Table {
     }
 
     fn location(&self) -> String {
-        self.base_path.to_str().unwrap().to_string()
+        self.base_url.path().to_string()
     }
 
     fn partition_fields(&self) -> Vec<String> {
@@ -223,7 +250,10 @@ impl ProvidesTableMetadata for Table {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+    use std::fs::canonicalize;
     use std::path::Path;
+    use url::Url;
 
     use crate::table::config::BaseFileFormat::Parquet;
     use crate::table::config::TableType::CopyOnWrite;
@@ -234,17 +264,16 @@ mod tests {
     #[test]
     fn hudi_table_get_latest_file_paths() {
         let fixture_path = Path::new("fixtures/table/0.x_cow_partitioned.zip");
-        let target_table_path = extract_test_table(fixture_path);
-        let hudi_table = Table::new(target_table_path.to_str().unwrap());
+        let base_url = Url::from_file_path(extract_test_table(fixture_path)).unwrap();
+        let mut hudi_table = Table::new(&base_url.path(), HashMap::new());
         assert_eq!(hudi_table.get_timeline().unwrap().instants.len(), 2);
         assert_eq!(hudi_table.get_latest_file_paths().unwrap().len(), 5);
-        println!("{}", hudi_table.schema());
     }
 
     #[test]
     fn hudi_table_get_table_metadata() {
-        let fixture_path = Path::new("fixtures/table_metadata/sample_table_properties");
-        let table = Table::new(fixture_path.to_str().unwrap());
+        let base_path = canonicalize(Path::new("fixtures/table_metadata/sample_table_properties")).unwrap();
+        let table = Table::new(base_path.to_str().unwrap(), HashMap::new());
         assert_eq!(table.base_file_format(), Parquet);
         assert_eq!(table.checksum(), 3761586722);
         assert_eq!(table.database_name(), "default");
@@ -256,10 +285,7 @@ mod tests {
             table.key_generator_class(),
             "org.apache.hudi.keygen.SimpleKeyGenerator"
         );
-        assert_eq!(
-            table.location(),
-            "fixtures/table_metadata/sample_table_properties"
-        );
+        assert_eq!(table.location(), base_path.to_str().unwrap());
         assert_eq!(table.partition_fields(), vec!["city"]);
         assert_eq!(table.precombine_field(), "ts");
         assert!(table.populates_meta_fields());

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -262,6 +262,35 @@ mod tests {
     use crate::test_utils::extract_test_table;
 
     #[test]
+    fn hudi_table_get_latest_schema() {
+        let fixture_path = Path::new("fixtures/table/0.x_cow_partitioned.zip");
+        let base_url = Url::from_file_path(extract_test_table(fixture_path)).unwrap();
+        let hudi_table = Table::new(base_url.path(), HashMap::new());
+        let fields: Vec<String> = hudi_table
+            .get_latest_schema()
+            .all_fields()
+            .into_iter()
+            .map(|f| f.name().to_string())
+            .collect();
+        assert_eq!(
+            fields,
+            Vec::from([
+                "_hoodie_commit_time",
+                "_hoodie_commit_seqno",
+                "_hoodie_record_key",
+                "_hoodie_partition_path",
+                "_hoodie_file_name",
+                "ts",
+                "uuid",
+                "rider",
+                "driver",
+                "fare",
+                "city"
+            ])
+        );
+    }
+
+    #[test]
     fn hudi_table_get_latest_file_paths() {
         let fixture_path = Path::new("fixtures/table/0.x_cow_partitioned.zip");
         let base_url = Url::from_file_path(extract_test_table(fixture_path)).unwrap();

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -265,14 +265,15 @@ mod tests {
     fn hudi_table_get_latest_file_paths() {
         let fixture_path = Path::new("fixtures/table/0.x_cow_partitioned.zip");
         let base_url = Url::from_file_path(extract_test_table(fixture_path)).unwrap();
-        let mut hudi_table = Table::new(&base_url.path(), HashMap::new());
+        let mut hudi_table = Table::new(base_url.path(), HashMap::new());
         assert_eq!(hudi_table.get_timeline().unwrap().instants.len(), 2);
         assert_eq!(hudi_table.get_latest_file_paths().unwrap().len(), 5);
     }
 
     #[test]
     fn hudi_table_get_table_metadata() {
-        let base_path = canonicalize(Path::new("fixtures/table_metadata/sample_table_properties")).unwrap();
+        let base_path =
+            canonicalize(Path::new("fixtures/table_metadata/sample_table_properties")).unwrap();
         let table = Table::new(base_path.to_str().unwrap(), HashMap::new());
         assert_eq!(table.base_file_format(), Parquet);
         assert_eq!(table.checksum(), 3761586722);

--- a/crates/core/src/timeline/mod.rs
+++ b/crates/core/src/timeline/mod.rs
@@ -74,8 +74,8 @@ impl Timeline {
     async fn load_completed_commit_instants(base_url: &Url) -> Result<Vec<Instant>> {
         let storage = Storage::new(base_url.clone(), HashMap::new());
         let mut completed_commits = Vec::new();
-        for file_metadata in storage.list_files(Some(".hoodie")).await {
-            let (file_stem, file_ext) = split_filename(file_metadata.name.as_str())?;
+        for file_info in storage.list_files(Some(".hoodie")).await {
+            let (file_stem, file_ext) = split_filename(file_info.name.as_str())?;
             if file_ext == "commit" {
                 completed_commits.push(Instant {
                     state: State::Completed,

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -27,10 +27,22 @@ doc = false
 
 [dependencies]
 object_store = { workspace = true }
+# arrow
+arrow = { workspace = true, features = ["ffi", "pyarrow"] }
+arrow-arith = { workspace = true }
+arrow-array = { workspace = true , features = ["chrono-tz"]}
+arrow-buffer = { workspace = true }
+arrow-cast = { workspace = true }
+arrow-ipc = { workspace = true }
+arrow-json = { workspace = true }
+arrow-ord = { workspace = true }
+arrow-row = { workspace = true }
+arrow-schema = { workspace = true, features = ["serde"] }
+arrow-select = { workspace = true }
 
 [dependencies.pyo3]
-version = "0.21.2"
-features = ["extension-module", "abi3", "abi3-py38", "gil-refs"]
+version = "0.20.3"
+features = ["extension-module", "abi3", "abi3-py38"]
 
 [dependencies.hudi]
 path = "../crates/hudi"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -28,16 +28,16 @@ doc = false
 [dependencies]
 object_store = { workspace = true }
 # arrow
-arrow = { workspace = true, features = ["ffi", "pyarrow"] }
+arrow = { workspace = true }
 arrow-arith = { workspace = true }
-arrow-array = { workspace = true , features = ["chrono-tz"]}
+arrow-array = { workspace = true }
 arrow-buffer = { workspace = true }
 arrow-cast = { workspace = true }
 arrow-ipc = { workspace = true }
 arrow-json = { workspace = true }
 arrow-ord = { workspace = true }
 arrow-row = { workspace = true }
-arrow-schema = { workspace = true, features = ["serde"] }
+arrow-schema = { workspace = true }
 arrow-select = { workspace = true }
 
 [dependencies.pyo3]

--- a/python/hudi/_internal.pyi
+++ b/python/hudi/_internal.pyi
@@ -15,7 +15,9 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-from typing import List
+from typing import List, Dict, Optional
+
+import pyarrow
 
 __version__: str
 
@@ -23,8 +25,26 @@ __version__: str
 def rust_core_version() -> str: ...
 
 
+class HudiFileSlice:
+    file_group_id: str
+    partition_path: str
+    commit_time: str
+    base_file_name: str
+    base_file_path: str
+    base_file_size: int
+    num_records: int
+
+
 class BindingHudiTable:
 
-    def __init__(self, table_uri: str): ...
+    def __init__(
+            self,
+            table_uri: str,
+            storage_options: Optional[Dict[str, str]] = None,
+    ): ...
 
-    def get_latest_file_paths(self) -> List[str]: ...
+    def schema(self) -> "pyarrow.Schema": ...
+
+    def get_latest_file_slices(self) -> List[HudiFileSlice]: ...
+
+    def read_file_slice(self, relative_path) -> List["pyarrow.RecordBatch"]: ...

--- a/python/hudi/_utils.py
+++ b/python/hudi/_utils.py
@@ -14,8 +14,10 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
+from typing import List, Any, Iterator
 
-from ._internal import __version__ as __version__
-from ._internal import rust_core_version as rust_core_version
-from ._internal import HudiFileSlice as HudiFileSlice
-from .table import HudiTable as HudiTable
+
+def split_list(lst: List[Any], n: int) -> Iterator[List[Any]]:
+    split_size = (len(lst) + n - 1) // n
+    for i in range(0, len(lst), split_size):
+        yield lst[i: i + split_size]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -22,6 +22,7 @@ build-backend = "maturin"
 [project]
 name = "hudi"
 description = "Native Hudi Python binding based on hudi-rs"
+urls = { repository = "https://github.com/apache/hudi-rs/tree/main/python/" }
 readme = "README.md"
 requires-python = ">=3.8"
 license = "Apache License 2.0"
@@ -37,8 +38,22 @@ dependencies = [
     "pyarrow>=8"
 ]
 
+optional-dependencies = { devel = [
+    "pytest"
+] }
+
 dynamic = ["version"]
 
 [tool.maturin]
 module-name = "hudi._internal"
 features = ["pyo3/extension-module"]
+
+[tool.mypy]
+files = "hudi/*.py"
+exclude = "^tests"
+
+[tool.pytest.ini_options]
+testpaths = [
+    "tests",
+    "hudi",
+]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -17,34 +17,90 @@
  * under the License.
  */
 
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use arrow::pyarrow::ToPyArrow;
 use pyo3::prelude::*;
 
-use hudi::table::Table;
+use hudi::file_group::FileSlice;
+use hudi::HudiTable;
+
+#[pyclass]
+struct HudiFileSlice {
+    #[pyo3(get)]
+    file_group_id: String,
+    #[pyo3(get)]
+    partition_path: String,
+    #[pyo3(get)]
+    commit_time: String,
+    #[pyo3(get)]
+    base_file_name: String,
+    #[pyo3(get)]
+    base_file_path: String,
+    #[pyo3(get)]
+    base_file_size: usize,
+    #[pyo3(get)]
+    num_records: i64,
+}
+
+impl HudiFileSlice {
+    pub fn from_file_slice(f: FileSlice) -> Self {
+        let partition_path = f.partition_path.clone().unwrap_or("".to_string());
+        let mut p = PathBuf::from(&partition_path);
+        p.push(f.base_file.metadata.name.clone());
+        let base_file_path = p.to_str().unwrap().to_string();
+        Self {
+            file_group_id: f.file_group_id().to_string(),
+            partition_path,
+            commit_time: f.base_file.commit_time,
+            base_file_name: f.base_file.metadata.name,
+            base_file_path,
+            base_file_size: f.base_file.metadata.size,
+            num_records: f.base_file.stats.unwrap().num_records,
+        }
+    }
+}
 
 #[pyclass]
 struct BindingHudiTable {
-    _table: hudi::HudiTable,
+    _table: HudiTable,
 }
 
 #[pymethods]
 impl BindingHudiTable {
     #[new]
-    #[pyo3(signature = (table_uri))]
-    fn new(py: Python, table_uri: &str) -> PyResult<Self> {
+    #[pyo3(signature = (table_uri, storage_options = None))]
+    fn new(
+        py: Python,
+        table_uri: &str,
+        storage_options: Option<HashMap<String, String>>,
+    ) -> PyResult<Self> {
         py.allow_threads(|| {
             Ok(BindingHudiTable {
-                _table: Table::new(table_uri),
+                _table: HudiTable::new(table_uri, storage_options.unwrap_or_default()),
             })
         })
     }
 
-    pub fn get_latest_file_paths(&self) -> PyResult<Vec<String>> {
-        match self._table.get_latest_file_paths() {
-            Ok(paths) => Ok(paths),
+    pub fn schema(&self, py: Python) -> PyResult<PyObject> {
+        self._table.get_latest_schema().to_pyarrow(py)
+    }
+
+    pub fn get_latest_file_slices(&mut self) -> PyResult<Vec<HudiFileSlice>> {
+        match self._table.get_latest_file_slices() {
+            Ok(file_slices) => Ok(file_slices
+                .into_iter()
+                .map(HudiFileSlice::from_file_slice)
+                .collect()),
             Err(_e) => {
-                panic!("Failed to retrieve the latest file paths.")
+                panic!("Failed to retrieve the latest file slices.")
             }
         }
+    }
+
+    pub fn read_file_slice(&self, relative_path: &str, py: Python) -> PyResult<PyObject> {
+        self._table.read_file_slice(relative_path).to_pyarrow(py)
     }
 }
 
@@ -58,6 +114,7 @@ fn _internal(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     m.add_function(wrap_pyfunction!(rust_core_version, m)?)?;
 
+    m.add_class::<HudiFileSlice>()?;
     m.add_class::<BindingHudiTable>()?;
     Ok(())
 }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -48,15 +48,15 @@ impl HudiFileSlice {
     pub fn from_file_slice(f: FileSlice) -> Self {
         let partition_path = f.partition_path.clone().unwrap_or("".to_string());
         let mut p = PathBuf::from(&partition_path);
-        p.push(f.base_file.metadata.name.clone());
+        p.push(f.base_file.info.name.clone());
         let base_file_path = p.to_str().unwrap().to_string();
         Self {
             file_group_id: f.file_group_id().to_string(),
             partition_path,
             commit_time: f.base_file.commit_time,
-            base_file_name: f.base_file.metadata.name,
+            base_file_name: f.base_file.info.name,
             base_file_path,
-            base_file_size: f.base_file.metadata.size,
+            base_file_size: f.base_file.info.size,
             num_records: f.base_file.stats.unwrap().num_records,
         }
     }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -99,7 +99,7 @@ impl BindingHudiTable {
         }
     }
 
-    pub fn read_file_slice(&self, relative_path: &str, py: Python) -> PyResult<PyObject> {
+    pub fn read_file_slice(&mut self, relative_path: &str, py: Python) -> PyResult<PyObject> {
         self._table.read_file_slice(relative_path).to_pyarrow(py)
     }
 }

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -14,8 +14,3 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-
-from ._internal import __version__ as __version__
-from ._internal import rust_core_version as rust_core_version
-from ._internal import HudiFileSlice as HudiFileSlice
-from .table import HudiTable as HudiTable

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -15,7 +15,26 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-from ._internal import __version__ as __version__
-from ._internal import rust_core_version as rust_core_version
-from ._internal import HudiFileSlice as HudiFileSlice
-from .table import HudiTable as HudiTable
+import os
+import zipfile
+from pathlib import Path
+
+import pytest
+
+
+def _extract_testing_table(zip_file_path, target_path) -> str:
+    with zipfile.ZipFile(zip_file_path, "r") as zip_ref:
+        zip_ref.extractall(target_path)
+    return os.path.join(target_path, "trips_table")
+
+
+@pytest.fixture(
+    params=[
+        "0.x_cow_partitioned",
+    ]
+)
+def get_sample_table(request, tmp_path) -> str:
+    fixture_path = "../crates/core/fixtures/table"
+    table_name = request.param
+    zip_file_path = Path(fixture_path).joinpath(f"{table_name}.zip")
+    return _extract_testing_table(zip_file_path, tmp_path)

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -1,0 +1,45 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+import pyarrow as pa
+import pytest
+from hudi import HudiTable
+
+
+PYARROW_LE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0)
+pytestmark = pytest.mark.skipif(PYARROW_LE_8_0_0, reason="hudi only supported if pyarrow >= 8.0.0")
+
+
+def test_sample_table(get_sample_table):
+    table_path = get_sample_table
+    table = HudiTable(table_path, {})
+
+    assert table.schema().names == ['_hoodie_commit_time', '_hoodie_commit_seqno', '_hoodie_record_key', '_hoodie_partition_path', '_hoodie_file_name', 'ts', 'uuid', 'rider', 'driver', 'fare', 'city']
+
+    file_slices = table.get_latest_file_slices()
+    assert len(file_slices) == 5
+    assert set(f.commit_time for f in file_slices) == {'20240402123035233', '20240402144910683'}
+    print([f.num_records for f in file_slices])
+    file_slice_paths = [f.base_file_path for f in file_slices]
+    print(file_slice_paths)
+    batches = table.read_file_slice(file_slice_paths[0])
+    t = pa.Table.from_batches(batches)
+    print(t.num_rows, t.num_columns)
+
+    file_slices_gen = table.split_latest_file_slices(2)
+    assert len(next(file_slices_gen)) == 3
+    assert len(next(file_slices_gen)) == 2

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -17,8 +17,8 @@
 
 import pyarrow as pa
 import pytest
-from hudi import HudiTable
 
+from hudi import HudiTable
 
 PYARROW_LE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0)
 pytestmark = pytest.mark.skipif(PYARROW_LE_8_0_0, reason="hudi only supported if pyarrow >= 8.0.0")
@@ -28,17 +28,25 @@ def test_sample_table(get_sample_table):
     table_path = get_sample_table
     table = HudiTable(table_path, {})
 
-    assert table.schema().names == ['_hoodie_commit_time', '_hoodie_commit_seqno', '_hoodie_record_key', '_hoodie_partition_path', '_hoodie_file_name', 'ts', 'uuid', 'rider', 'driver', 'fare', 'city']
+    assert table.schema().names == ['_hoodie_commit_time', '_hoodie_commit_seqno', '_hoodie_record_key',
+                                    '_hoodie_partition_path', '_hoodie_file_name', 'ts', 'uuid', 'rider', 'driver',
+                                    'fare', 'city']
 
     file_slices = table.get_latest_file_slices()
     assert len(file_slices) == 5
     assert set(f.commit_time for f in file_slices) == {'20240402123035233', '20240402144910683'}
-    print([f.num_records for f in file_slices])
+    assert all(f.num_records == 1 for f in file_slices)
     file_slice_paths = [f.base_file_path for f in file_slices]
-    print(file_slice_paths)
+    assert set(file_slice_paths) == {'chennai/68d3c349-f621-4cd8-9e8b-c6dd8eb20d08-0_4-12-0_20240402123035233.parquet',
+                                'san_francisco/d9082ffd-2eb1-4394-aefc-deb4a61ecc57-0_1-9-0_20240402123035233.parquet',
+                                'san_francisco/780b8586-3ad0-48ef-a6a1-d2217845ce4a-0_0-8-0_20240402123035233.parquet',
+                                'san_francisco/5a226868-2934-4f84-a16f-55124630c68d-0_0-7-24_20240402144910683.parquet',
+                                'sao_paulo/ee915c68-d7f8-44f6-9759-e691add290d8-0_3-11-0_20240402123035233.parquet'}
+
     batches = table.read_file_slice(file_slice_paths[0])
     t = pa.Table.from_batches(batches)
-    print(t.num_rows, t.num_columns)
+    assert t.num_rows == 1
+    assert t.num_columns == 11
 
     file_slices_gen = table.split_latest_file_slices(2)
     assert len(next(file_slices_gen)) == 3


### PR DESCRIPTION
- Support python APIs to retrieve the latest file slices
- Support python APIs to read file slice as `pyarrow.RecordBatch`
- Implement Rust logic to fetch num records in parquet file
- Implement Rust logic to read parquet file into `arrow.RecordBatch`

Fixes #29 
