### PR TITLE
feat: support time travel with read option

### DIFF
--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -59,7 +59,7 @@ pub trait ConfigParser: AsRef<str> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum HudiConfigValue {
     Boolean(bool),
     Integer(isize),
@@ -156,5 +156,16 @@ impl HudiConfigs {
         parser: impl ConfigParser<Output = HudiConfigValue>,
     ) -> HudiConfigValue {
         parser.parse_value_or_default(&self.raw_configs)
+    }
+
+    pub fn try_get(
+        &self,
+        parser: impl ConfigParser<Output = HudiConfigValue>,
+    ) -> Option<HudiConfigValue> {
+        let res = parser.parse_value(&self.raw_configs);
+        match res {
+            Ok(v) => Some(v),
+            Err(_) => parser.default_value(),
+        }
     }
 }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -129,11 +129,6 @@ impl BindingHudiTable {
     pub fn read_snapshot(&self, py: Python) -> PyResult<PyObject> {
         rt().block_on(self._table.read_snapshot())?.to_pyarrow(py)
     }
-
-    pub fn read_snapshot_as_of(&self, timestamp: &str, py: Python) -> PyResult<PyObject> {
-        rt().block_on(self._table.read_snapshot_as_of(timestamp))?
-            .to_pyarrow(py)
-    }
 }
 
 #[cfg(not(tarpaulin))]

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -65,7 +65,9 @@ def test_sample_table(get_sample_table):
                              {'_hoodie_commit_time': '20240402123035233', 'ts': 1695516137016,
                               'uuid': 'e3cf430c-889d-4015-bc98-59bdce1e530c', 'fare': 34.15}]
 
-    batches = table.read_snapshot_as_of("20240402123035233")
+    table = HudiTable(table_path, {
+        "hoodie.read.as.of.timestamp": "20240402123035233"})
+    batches = table.read_snapshot()
     t = pa.Table.from_batches(batches).select([0, 5, 6, 9]).sort_by("ts")
     assert t.to_pylist() == [{'_hoodie_commit_time': '20240402123035233', 'ts': 1695046462179,
                               'uuid': '9909a8b1-2d15-4d3d-8ec9-efc48c536a00', 'fare': 33.9},


### PR DESCRIPTION
Support passing option `hoodie.read.as.of.timestamp` and perform time travel query.

Fixes #39 