### PR TITLE
chore: configure pre-commit hooks for code formatting

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -47,5 +47,22 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check license header
         uses: apache/skywalking-eyes/header@v0.6.0
-      - name: Check code style
+      - name: Check rust code style
         run: cd python && make check-rust
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install python linter dependencies
+        working-directory: ./python
+        run: |
+          make setup-env
+          source venv/bin/activate
+          pip install ruff mypy
+      - name: Run python linter
+        working-directory: ./python
+        run: |
+          source venv/bin/activate
+          make check-python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+      - id: check-added-large-files
+      - id: check-merge-conflict
+
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.2.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.11.0
+    hooks:
+      - id: mypy
+
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --all -- --check
+        language: system
+        types: [rust]
+        pass_filenames: false

--- a/python/Makefile
+++ b/python/Makefile
@@ -48,6 +48,13 @@ check-rust: ## Run check on Rust
 	$(info --- Check Rust format ---)
 	cargo fmt --all -- --check
 
+.PHONY: check-python
+check-python: ## Run check on Python
+	$(info --- Check Python code quality ---)
+	ruff .
+	ruff format .
+	mypy .
+
 .PHONY: test-rust
 test-rust: ## Run tests on Rust
 	$(info --- Run Rust tests ---)

--- a/python/Makefile
+++ b/python/Makefile
@@ -30,6 +30,8 @@ setup-venv: ## Setup the virtualenv
 setup: ## Setup the requirements
 	$(info --- Setup dependencies ---)
 	pip install "$(MATURIN_VERSION)"
+    pip install pre-commit
+    pre-commit install
 
 .PHONY: build
 build: setup ## Build Python binding of delta-rs

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -49,9 +49,33 @@ dynamic = ["version"]
 [tool.maturin]
 module-name = "hudi._internal"
 
+[tool.ruff]
+target-version = 'py38'
+lint.mccabe = { max-complexity = 14 }
+lint.flake8-quotes = {inline-quotes = 'single', multiline-quotes = 'double'}
+lint.pydocstyle = { convention = 'google' }
+format.quote-style = 'single'
+lint.ignore = [
+    "Q000",
+    "Q001",
+    "Q002",
+    "Q003",
+    "COM812",
+    "COM819",
+    "D104",
+    "I001",
+    "UP006",
+    "UP007",
+    "UP037",
+    "E501", # Formatted code may exceed the line length, leading to line-too-long (E501) errors.
+]
+
 [tool.mypy]
 files = "hudi/*.py"
 exclude = "^tests"
+warn_unused_configs = true
+ignore_missing_imports = true
+strict = true
 
 [tool.pytest.ini_options]
 testpaths = [


### PR DESCRIPTION
## Description

This PR introduces pre-commit hooks to ensure consistent code formatting for both Python and Rust codebases. The changes include:

Pre-commit Hooks: Added pre-commit hooks for formatting Python and Rust code.
Code Formatting: Applied the new pre-commit hooks to format the existing code.
<!--- Describe your changes in detail -->

<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please link any related issues and PRs as well. -->
Related issues: [#73 ](https://github.com/apache/hudi-rs/issues/73)
## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
