### PR TITLE
build: use exact versions for arrow and datafusion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,25 +35,25 @@ repository = "https://github.com/apache/hudi-rs"
 
 [workspace.dependencies]
 # arrow
-arrow = { version = "52.0.0", features = ["pyarrow"] }
-arrow-arith = { version = "52.0.0" }
-arrow-array = { version = "52.0.0" }
-arrow-buffer = { version = "52.0.0" }
-arrow-cast = { version = "52.0.0" }
-arrow-ipc = { version = "52.0.0" }
-arrow-json = { version = "52.0.0" }
-arrow-ord = { version = "52.0.0" }
-arrow-row = { version = "52.0.0" }
-arrow-schema = { version = "52.0.0", features = ["serde"] }
-arrow-select = { version = "52.0.0" }
-object_store = { version = "0.10.1", features = ["aws", "azure", "gcp"] }
-parquet = { version = "52.0.0", features = ["async", "object_store"] }
+arrow = { version = "= 52.0.0", features = ["pyarrow"] }
+arrow-arith = { version = "= 52.0.0" }
+arrow-array = { version = "= 52.0.0" }
+arrow-buffer = { version = "= 52.0.0" }
+arrow-cast = { version = "= 52.0.0" }
+arrow-ipc = { version = "= 52.0.0" }
+arrow-json = { version = "= 52.0.0" }
+arrow-ord = { version = "= 52.0.0" }
+arrow-row = { version = "= 52.0.0" }
+arrow-schema = { version = "= 52.0.0", features = ["serde"] }
+arrow-select = { version = "= 52.0.0" }
+object_store = { version = "= 0.10.1", features = ["aws", "azure", "gcp"] }
+parquet = { version = "= 52.0.0", features = ["async", "object_store"] }
 
 # datafusion
-datafusion = { version = "39.0.0" }
-datafusion-expr = { version = "39.0.0" }
-datafusion-common = { version = "39.0.0" }
-datafusion-physical-expr = { version = "39.0.0" }
+datafusion = { version = "= 39.0.0" }
+datafusion-expr = { version = "= 39.0.0" }
+datafusion-common = { version = "= 39.0.0" }
+datafusion-physical-expr = { version = "= 39.0.0" }
 
 # serde
 serde = { version = "1.0.203", features = ["derive"] }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Use the exact version for core dependencies, arrow and datafusion, to prevent incompatible minor upgrade done implicitly.

<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please link any related issues and PRs as well. -->

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
