### PR TITLE
fix: register object store with datafusion

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -60,5 +60,19 @@ dashmap = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true }
 
+# datafusion
+datafusion = { workspace = true, optional = true }
+datafusion-expr = { workspace = true, optional = true }
+datafusion-common = { workspace = true, optional = true }
+datafusion-physical-expr = { workspace = true, optional = true }
+
 [dev-dependencies]
 hudi-tests = { path = "../tests" }
+
+[features]
+datafusion = [
+    "dep:datafusion",
+    "datafusion-expr",
+    "datafusion-common",
+    "datafusion-physical-expr",
+]

--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -44,7 +44,7 @@ pub mod utils;
 #[derive(Clone, Debug)]
 pub struct Storage {
     base_url: Arc<Url>,
-    pub object_store: Arc<dyn ObjectStore>,
+    object_store: Arc<dyn ObjectStore>,
 }
 
 impl Storage {
@@ -56,6 +56,11 @@ impl Storage {
             })),
             Err(e) => Err(anyhow!("Failed to create storage: {}", e)),
         }
+    }
+
+    #[cfg(feature = "datafusion")]
+    pub fn register_object_store(&self, runtime_env: Arc<datafusion::execution::runtime_env::RuntimeEnv>) {
+        runtime_env.register_object_store(self.base_url.as_ref(), self.object_store.clone());
     }
 
     #[cfg(test)]

--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -44,7 +44,7 @@ pub mod utils;
 #[derive(Clone, Debug)]
 pub struct Storage {
     base_url: Arc<Url>,
-    object_store: Arc<dyn ObjectStore>,
+    pub object_store: Arc<dyn ObjectStore>,
 }
 
 impl Storage {

--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -59,7 +59,10 @@ impl Storage {
     }
 
     #[cfg(feature = "datafusion")]
-    pub fn register_object_store(&self, runtime_env: Arc<datafusion::execution::runtime_env::RuntimeEnv>) {
+    pub fn register_object_store(
+        &self,
+        runtime_env: Arc<datafusion::execution::runtime_env::RuntimeEnv>,
+    ) {
         runtime_env.register_object_store(self.base_url.as_ref(), self.object_store.clone());
     }
 

--- a/crates/core/src/table/fs_view.rs
+++ b/crates/core/src/table/fs_view.rs
@@ -34,7 +34,7 @@ use crate::storage::{get_leaf_dirs, Storage};
 #[allow(dead_code)]
 pub struct FileSystemView {
     configs: Arc<HudiConfigs>,
-    storage: Arc<Storage>,
+    pub storage: Arc<Storage>,
     partition_to_file_groups: Arc<DashMap<String, Vec<FileGroup>>>,
 }
 

--- a/crates/core/src/table/fs_view.rs
+++ b/crates/core/src/table/fs_view.rs
@@ -34,7 +34,7 @@ use crate::storage::{get_leaf_dirs, Storage};
 #[allow(dead_code)]
 pub struct FileSystemView {
     configs: Arc<HudiConfigs>,
-    pub storage: Arc<Storage>,
+    pub(crate) storage: Arc<Storage>,
     partition_to_file_groups: Arc<DashMap<String, Vec<FileGroup>>>,
 }
 

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -93,6 +93,12 @@ impl Table {
         })
     }
 
+    #[cfg(feature = "datafusion")]
+    pub fn register_storage(&self, runtime_env: Arc<datafusion::execution::runtime_env::RuntimeEnv>) {
+        self.timeline.storage.register_object_store(runtime_env.clone());
+        self.file_system_view.storage.register_object_store(runtime_env.clone());
+    }
+
     async fn load_configs<I, K, V>(
         base_url: Arc<Url>,
         all_options: I,

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -94,9 +94,16 @@ impl Table {
     }
 
     #[cfg(feature = "datafusion")]
-    pub fn register_storage(&self, runtime_env: Arc<datafusion::execution::runtime_env::RuntimeEnv>) {
-        self.timeline.storage.register_object_store(runtime_env.clone());
-        self.file_system_view.storage.register_object_store(runtime_env.clone());
+    pub fn register_storage(
+        &self,
+        runtime_env: Arc<datafusion::execution::runtime_env::RuntimeEnv>,
+    ) {
+        self.timeline
+            .storage
+            .register_object_store(runtime_env.clone());
+        self.file_system_view
+            .storage
+            .register_object_store(runtime_env.clone());
     }
 
     async fn load_configs<I, K, V>(

--- a/crates/core/src/table/timeline.rs
+++ b/crates/core/src/table/timeline.rs
@@ -92,7 +92,7 @@ impl Instant {
 #[allow(dead_code)]
 pub struct Timeline {
     configs: Arc<HudiConfigs>,
-    storage: Arc<Storage>,
+    pub(crate) storage: Arc<Storage>,
     pub instants: Vec<Instant>,
 }
 

--- a/crates/datafusion/Cargo.toml
+++ b/crates/datafusion/Cargo.toml
@@ -28,7 +28,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-hudi-core = { version = "0.2.0", path = "../core" }
+hudi-core = { version = "0.2.0", path = "../core", features = ["datafusion"] }
 # arrow
 arrow-schema = { workspace = true }
 

--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -97,6 +97,17 @@ impl TableProvider for HudiDataSource {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
+        // register object store
+        state.runtime_env().clone().register_object_store(
+            &self.table.base_url,
+            self.table
+                .file_system_view
+                .storage
+                .clone()
+                .object_store
+                .clone(),
+        );
+
         let file_slices = self
             .table
             .split_file_slices(self.get_input_partitions())

--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -98,15 +98,7 @@ impl TableProvider for HudiDataSource {
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         // register object store
-        state.runtime_env().clone().register_object_store(
-            &self.table.base_url,
-            self.table
-                .file_system_view
-                .storage
-                .clone()
-                .object_store
-                .clone(),
-        );
+        self.table.register_storage(state.runtime_env().clone());
 
         let file_slices = self
             .table

--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -97,7 +97,6 @@ impl TableProvider for HudiDataSource {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        // register object store
         self.table.register_storage(state.runtime_env().clone());
 
         let file_slices = self


### PR DESCRIPTION
## Description

Reading Hudi tables from an object store, s3 in this case, was failing due to the object store not being registered with Datafusion. 

Before the changes in this PR, the following error was encountered:
```
Error: Internal("No suitable object store found for s3://test-hudi-rs/. See `RuntimeEnv::register_object_store`")
```

Datafusion requires the object store to be registered. Refer [here](https://github.com/apache/datafusion/blob/fa50636c6aec0f321212ed8678c77de25b71a8f9/datafusion/core/src/execution/context/mod.rs#L375).

## Note
- `Storage` and `FileSystemView` have public struct fields `object_store` and `storage`. There should be a better way to expose these to the `datafusion` crate to be able to register them.


## How are the changes test-covered

- [x] N/A
- [ ] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
