### PR TITLE
chore: fix has no write access from a forked repository when add label

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,7 +18,7 @@
 name: PR
 
 on:
-  pull_request:
+  pull_request_target:
     types: [ opened, edited, reopened, synchronize ]
     branches:
       - main


### PR DESCRIPTION
## Description

has no write access from a forked repository when add label.
![image](https://github.com/user-attachments/assets/fd9849dc-3f5e-4300-a113-1778f051f899)

as github advice https://github.com/actions/labeler?tab=readme-ov-file#permissions, use `pull_request_target`.

## How are the changes test-covered

- [ ] N/A
- [ ] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
