### PR TITLE
chore: disable labeler due to permission and policy

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,3 +46,5 @@ jobs:
 
       - name: Labeling
         uses: actions/labeler@v5
+        # disable until figuring out a way to do this without pull_request_target
+        if: false


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Disable due to `pull_request_target` is not allowed as per https://infra.apache.org/github-actions-policy.html

<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please link any related issues and PRs as well. -->

## How are the changes test-covered

- [x] N/A
- [ ] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
