### PR TITLE
build: bump up DataFusion to version 41, Arrow to 52.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ resolver = "2"
 version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
-rust-version = "1.75.0"
+rust-version = "1.76"
 keywords = ["apachehudi", "hudi", "datalake", "arrow"]
 readme = "README.md"
 description = "A native Rust library for Apache Hudi"
@@ -35,25 +35,25 @@ repository = "https://github.com/apache/hudi-rs"
 
 [workspace.dependencies]
 # arrow
-arrow = { version = "= 52.0.0", features = ["pyarrow"] }
-arrow-arith = { version = "= 52.0.0" }
-arrow-array = { version = "= 52.0.0" }
-arrow-buffer = { version = "= 52.0.0" }
-arrow-cast = { version = "= 52.0.0" }
-arrow-ipc = { version = "= 52.0.0" }
-arrow-json = { version = "= 52.0.0" }
-arrow-ord = { version = "= 52.0.0" }
-arrow-row = { version = "= 52.0.0" }
-arrow-schema = { version = "= 52.0.0", features = ["serde"] }
-arrow-select = { version = "= 52.0.0" }
-object_store = { version = "= 0.10.1", features = ["aws", "azure", "gcp"] }
-parquet = { version = "= 52.0.0", features = ["async", "object_store"] }
+arrow = { version = "= 52.2.0", features = ["pyarrow"] }
+arrow-arith = { version = "= 52.2.0" }
+arrow-array = { version = "= 52.2.0" }
+arrow-buffer = { version = "= 52.2.0" }
+arrow-cast = { version = "= 52.2.0" }
+arrow-ipc = { version = "= 52.2.0" }
+arrow-json = { version = "= 52.2.0" }
+arrow-ord = { version = "= 52.2.0" }
+arrow-row = { version = "= 52.2.0" }
+arrow-schema = { version = "= 52.2.0", features = ["serde"] }
+arrow-select = { version = "= 52.2.0" }
+object_store = { version = "= 0.10.2", features = ["aws", "azure", "gcp"] }
+parquet = { version = "= 52.2.0", features = ["async", "object_store"] }
 
 # datafusion
-datafusion = { version = "= 39.0.0" }
-datafusion-expr = { version = "= 39.0.0" }
-datafusion-common = { version = "= 39.0.0" }
-datafusion-physical-expr = { version = "= 39.0.0" }
+datafusion = { version = "= 41.0.0" }
+datafusion-expr = { version = "= 41.0.0" }
+datafusion-common = { version = "= 41.0.0" }
+datafusion-physical-expr = { version = "= 41.0.0" }
 
 # serde
 serde = { version = "1.0.203", features = ["derive"] }

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -303,7 +303,7 @@ mod tests {
             .get_schema()
             .await
             .unwrap()
-            .all_fields()
+            .flattened_fields()
             .into_iter()
             .map(|f| f.name().to_string())
             .collect();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -16,6 +16,6 @@
 # under the License.
 
 [toolchain]
-channel = "1.75"
+channel = "1.76"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
## Description

- Update the project dependencies to DataFusion 41.0.0 and Arrow 52.2.0.
- Rust version bump to 1.76

<!--- Describe your changes in detail -->

<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please link any related issues and PRs as well. -->

## How are the changes test-covered

- [x] All existing tests
