### PR TITLE
chore(ci): fix PR title linting to support change scope

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           npm i -g conventional-changelog-conventionalcommits
           npm i -g commitlint@latest
-          echo ${{ github.event.pull_request.title }} | npx commitlint
+          echo "${{ github.event.pull_request.title }}" | npx commitlint
 
       - name: Labeling
         uses: actions/labeler@v5


### PR DESCRIPTION
## Description
`line 3: syntax error near unexpected token '('`

The syntax error near the unexpected token '(') is due to the parentheses being treated as part of the shell's syntax. Enclosing the entire string in quotes should fix it.

fixes: #136

## How are the changes test-covered

- [x] N/A
- [ ] Automated tests (unit and/or integration tests)
- [x] Manual tests
  - [ ] Details are described below
