### PR TITLE
fix: handle validating table when `DropsPartitionFields` not present

### DIFF
--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -289,7 +289,9 @@ impl Table {
             return Err(anyhow!("Only support table version 5 and 6."));
         }
 
-        let drops_partition_cols = hudi_configs.get(DropsPartitionFields)?.to::<bool>();
+        let drops_partition_cols = hudi_configs
+            .get_or_default(DropsPartitionFields)
+            .to::<bool>();
         if drops_partition_cols {
             return Err(anyhow!(
                 "Only support when `{}` is disabled",


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Some tables may not have `hoodie.datasource.write.drop.partition.columns`, the table validation should treat it as false by default.

<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please link any related issues and PRs as well. -->

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
