### PR TITLE
feat: implement datafusion TableProviderFactory

### DIFF
--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -152,11 +152,11 @@ impl TableProviderFactory for HudiTableProvider {
         cmd: &CreateExternalTable,
     ) -> Result<Arc<dyn TableProvider>> {
         let table_provider = match cmd.options.is_empty() {
-            true => HudiDataSource::new(cmd.to_owned().location.as_str()).await?,
+            true => HudiDataSource::new(cmd.location.to_owned().as_str()).await?,
             false => {
                 HudiDataSource::new_with_options(
-                    cmd.to_owned().location.as_str(),
-                    cmd.to_owned().options,
+                    cmd.location.to_owned().as_str(),
+                    cmd.options.to_owned(),
                 )
                 .await?
             }

--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -148,8 +148,8 @@ pub struct HudiTableProvider;
 impl TableProviderFactory for HudiTableProvider {
     async fn create(&self, _state: &dyn Session, cmd: &CreateExternalTable) -> Result<Arc<dyn TableProvider>> {
         let table_provider = match cmd.options.is_empty() {
-            true => HudiTable::new(cmd.location()).await?,
-            false => HudiTable::new_with_options(cmd.location(), cmd.options()).await?,
+            true => HudiDataSource::new(&*cmd.location).await?,
+            false => HudiDataSource::new_with_options(&*cmd.location, &cmd.options).await?,
         };
         Ok(Arc::new(table_provider))
     }

--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -152,8 +152,14 @@ impl TableProviderFactory for HudiTableProvider {
         cmd: &CreateExternalTable,
     ) -> Result<Arc<dyn TableProvider>> {
         let table_provider = match cmd.options.is_empty() {
-            true => HudiDataSource::new(&cmd.location).await?,
-            false => HudiDataSource::new_with_options(&cmd.location, &cmd.options).await?,
+            true => HudiDataSource::new(cmd.to_owned().location.as_str()).await?,
+            false => {
+                HudiDataSource::new_with_options(
+                    cmd.to_owned().location.as_str(),
+                    cmd.to_owned().options,
+                )
+                .await?
+            }
         };
         Ok(Arc::new(table_provider))
     }

--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -146,10 +146,14 @@ pub struct HudiTableProvider;
 
 #[async_trait]
 impl TableProviderFactory for HudiTableProvider {
-    async fn create(&self, _state: &dyn Session, cmd: &CreateExternalTable) -> Result<Arc<dyn TableProvider>> {
+    async fn create(
+        &self,
+        _state: &dyn Session,
+        cmd: &CreateExternalTable,
+    ) -> Result<Arc<dyn TableProvider>> {
         let table_provider = match cmd.options.is_empty() {
-            true => HudiDataSource::new(&*cmd.location).await?,
-            false => HudiDataSource::new_with_options(&*cmd.location, &cmd.options).await?,
+            true => HudiDataSource::new(&cmd.location).await?,
+            false => HudiDataSource::new_with_options(&cmd.location, &cmd.options).await?,
         };
         Ok(Arc::new(table_provider))
     }

--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -171,9 +171,6 @@ mod tests {
     use std::path::Path;
     use std::sync::Arc;
 
-    // use datafusion::catalog::TableProviderFactory;
-    // use datafusion::execution::context::SessionState;
-    // use datafusion::execution::runtime_env::RuntimeEnv;
     use datafusion::execution::session_state::SessionStateBuilder;
     use datafusion::prelude::{SessionConfig, SessionContext};
     use datafusion_common::ScalarValue;


### PR DESCRIPTION
## Description

resolves: #150 

This allows datafusion users to register an external hudi table and query it like so:
```sql
CREATE EXTERNAL TABLE trips STORED AS HUDITABLE LOCATION tbl/path;
SELECT * FROM trips;
```

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
