### PR TITLE
feat: implement datafusion TableProviderFactory

### DIFF
--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -179,9 +179,6 @@ mod tests {
     use std::path::Path;
     use std::sync::Arc;
 
-    // use datafusion::catalog::TableProviderFactory;
-    // use datafusion::execution::context::SessionState;
-    // use datafusion::execution::runtime_env::RuntimeEnv;
     use datafusion::execution::session_state::SessionStateBuilder;
     use datafusion::prelude::{SessionConfig, SessionContext};
     use datafusion_common::ScalarValue;

--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -373,4 +373,37 @@ mod tests {
             verify_data(&ctx, &sql, test_table.as_ref()).await
         }
     }
+
+    #[tokio::test]
+    async fn datafusion_read_external_hudi_table_with_replacecommits() {
+        for (test_table, planned_input_partitions) in
+            &[(V6SimplekeygenNonhivestyleOverwritetable, 1)]
+        {
+            println!(">>> testing for {}", test_table.as_ref());
+            let ctx = prepare_session_context_with_table_factory().await;
+            let base_path = test_table.path();
+
+            let create_table_sql = format!(
+                "CREATE EXTERNAL TABLE {} STORED AS HUDITABLE LOCATION '{}' OPTIONS ('hoodie.read.input.partitions' '2');",
+                test_table.as_ref(),
+                base_path
+            );
+
+            let _ = ctx
+                .sql(create_table_sql.as_str())
+                .await
+                .expect("Failed to register table");
+
+            let sql = format!(
+                r#"
+            SELECT id, name, isActive, structField.field2
+            FROM {} WHERE id % 2 = 0
+            AND structField.field2 > 30 ORDER BY name LIMIT 10"#,
+                test_table.as_ref()
+            );
+
+            verify_plan(&ctx, &sql, test_table.as_ref(), planned_input_partitions).await;
+            verify_data_with_replacecommits(&ctx, &sql, test_table.as_ref()).await
+        }
+    }
 }

--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -150,10 +150,10 @@ impl TableProvider for HudiDataSource {
     }
 }
 
-pub struct HudiTableProvider;
+pub struct HudiTableFactory;
 
 #[async_trait]
-impl TableProviderFactory for HudiTableProvider {
+impl TableProviderFactory for HudiTableFactory {
     async fn create(
         &self,
         _state: &dyn Session,
@@ -179,6 +179,10 @@ mod tests {
     use std::path::Path;
     use std::sync::Arc;
 
+    // use datafusion::catalog::TableProviderFactory;
+    // use datafusion::execution::context::SessionState;
+    // use datafusion::execution::runtime_env::RuntimeEnv;
+    use datafusion::execution::session_state::SessionStateBuilder;
     use datafusion::prelude::{SessionConfig, SessionContext};
     use datafusion_common::ScalarValue;
     use url::Url;
@@ -193,6 +197,7 @@ mod tests {
     use utils::{get_bool_column, get_i32_column, get_str_column};
 
     use crate::HudiDataSource;
+    use crate::HudiTableFactory;
 
     #[tokio::test]
     async fn get_default_input_partitions() {
@@ -219,6 +224,24 @@ mod tests {
         ctx.register_table(test_table.as_ref(), Arc::new(hudi))
             .unwrap();
         ctx
+    }
+
+    async fn prepare_session_context_with_table_factory() -> SessionContext {
+        let config = SessionConfig::new().set(
+            "datafusion.sql_parser.enable_ident_normalization",
+            &ScalarValue::from(false),
+        );
+
+        let mut session_state = SessionStateBuilder::new()
+            .with_default_features()
+            .with_config(config)
+            .build();
+
+        session_state
+            .table_factories_mut()
+            .insert("HUDITABLE".to_string(), Arc::new(HudiTableFactory {}));
+
+        SessionContext::new_with_state(session_state)
     }
 
     async fn verify_plan(
@@ -315,6 +338,42 @@ mod tests {
 
             verify_plan(&ctx, &sql, test_table.as_ref(), planned_input_partitions).await;
             verify_data_with_replacecommits(&ctx, &sql, test_table.as_ref()).await
+        }
+    }
+
+    #[tokio::test]
+    async fn datafusion_read_external_hudi_table() {
+        for test_table in &[
+            V6ComplexkeygenHivestyle,
+            V6Nonpartitioned,
+            V6SimplekeygenNonhivestyle,
+            V6SimplekeygenHivestyleNoMetafields,
+            V6TimebasedkeygenNonhivestyle,
+        ] {
+            println!(">>> testing for {}", test_table.as_ref());
+            let ctx = prepare_session_context_with_table_factory().await;
+            let base_path = test_table.path();
+
+            let create_table_sql = format!(
+                "CREATE EXTERNAL TABLE {} STORED AS HUDITABLE LOCATION '{}'",
+                test_table.as_ref(),
+                base_path
+            );
+
+            let _ = ctx
+                .sql(create_table_sql.as_str())
+                .await
+                .expect("Failed to register table");
+
+            let sql = format!(
+                r#"
+            SELECT id, name, isActive, structField.field2
+            FROM {} WHERE id % 2 = 0
+            AND structField.field2 > 30 ORDER BY name LIMIT 10"#,
+                test_table.as_ref()
+            );
+
+            verify_data(&ctx, &sql, test_table.as_ref()).await
         }
     }
 }

--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -154,10 +154,14 @@ pub struct HudiTableProvider;
 
 #[async_trait]
 impl TableProviderFactory for HudiTableProvider {
-    async fn create(&self, _state: &dyn Session, cmd: &CreateExternalTable) -> Result<Arc<dyn TableProvider>> {
+    async fn create(
+        &self,
+        _state: &dyn Session,
+        cmd: &CreateExternalTable,
+    ) -> Result<Arc<dyn TableProvider>> {
         let table_provider = match cmd.options.is_empty() {
-            true => HudiDataSource::new(&*cmd.location).await?,
-            false => HudiDataSource::new_with_options(&*cmd.location, &cmd.options).await?,
+            true => HudiDataSource::new(&cmd.location).await?,
+            false => HudiDataSource::new_with_options(&cmd.location, &cmd.options).await?,
         };
         Ok(Arc::new(table_provider))
     }

--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -160,8 +160,14 @@ impl TableProviderFactory for HudiTableProvider {
         cmd: &CreateExternalTable,
     ) -> Result<Arc<dyn TableProvider>> {
         let table_provider = match cmd.options.is_empty() {
-            true => HudiDataSource::new(&cmd.location).await?,
-            false => HudiDataSource::new_with_options(&cmd.location, &cmd.options).await?,
+            true => HudiDataSource::new(cmd.to_owned().location.as_str()).await?,
+            false => {
+                HudiDataSource::new_with_options(
+                    cmd.to_owned().location.as_str(),
+                    cmd.to_owned().options,
+                )
+                .await?
+            }
         };
         Ok(Arc::new(table_provider))
     }

--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -156,8 +156,8 @@ pub struct HudiTableProvider;
 impl TableProviderFactory for HudiTableProvider {
     async fn create(&self, _state: &dyn Session, cmd: &CreateExternalTable) -> Result<Arc<dyn TableProvider>> {
         let table_provider = match cmd.options.is_empty() {
-            true => HudiTable::new(cmd.location()).await?,
-            false => HudiTable::new_with_options(cmd.location(), cmd.options()).await?,
+            true => HudiDataSource::new(&*cmd.location).await?,
+            false => HudiDataSource::new_with_options(&*cmd.location, &cmd.options).await?,
         };
         Ok(Arc::new(table_provider))
     }

--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -160,11 +160,11 @@ impl TableProviderFactory for HudiTableProvider {
         cmd: &CreateExternalTable,
     ) -> Result<Arc<dyn TableProvider>> {
         let table_provider = match cmd.options.is_empty() {
-            true => HudiDataSource::new(cmd.to_owned().location.as_str()).await?,
+            true => HudiDataSource::new(cmd.location.to_owned().as_str()).await?,
             false => {
                 HudiDataSource::new_with_options(
-                    cmd.to_owned().location.as_str(),
-                    cmd.to_owned().options,
+                    cmd.location.to_owned().as_str(),
+                    cmd.options.to_owned(),
                 )
                 .await?
             }

--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -24,7 +24,7 @@ use std::thread;
 
 use arrow_schema::SchemaRef;
 use async_trait::async_trait;
-use datafusion::catalog::Session;
+use datafusion::catalog::{Session, TableProviderFactory};
 use datafusion::datasource::listing::PartitionedFile;
 use datafusion::datasource::object_store::ObjectStoreUrl;
 use datafusion::datasource::physical_plan::parquet::ParquetExecBuilder;
@@ -35,7 +35,7 @@ use datafusion_common::config::TableParquetOptions;
 use datafusion_common::DFSchema;
 use datafusion_common::DataFusionError::Execution;
 use datafusion_common::Result;
-use datafusion_expr::{Expr, TableType};
+use datafusion_expr::{CreateExternalTable, Expr, TableType};
 use datafusion_physical_expr::create_physical_expr;
 
 use hudi_core::config::read::HudiReadConfig::InputPartitions;
@@ -147,6 +147,19 @@ impl TableProvider for HudiDataSource {
         }
 
         return Ok(exec_builder.build_arc());
+    }
+}
+
+pub struct HudiTableProvider;
+
+#[async_trait]
+impl TableProviderFactory for HudiTableProvider {
+    async fn create(&self, _state: &dyn Session, cmd: &CreateExternalTable) -> Result<Arc<dyn TableProvider>> {
+        let table_provider = match cmd.options.is_empty() {
+            true => HudiTable::new(cmd.location()).await?,
+            false => HudiTable::new_with_options(cmd.location(), cmd.options()).await?,
+        };
+        Ok(Arc::new(table_provider))
     }
 }
 


### PR DESCRIPTION
## Description

resolves: #150 

This allows datafusion users to register an external hudi table and query it like so:

```sql
CREATE EXTERNAL TABLE trips STORED AS HUDI LOCATION 'path';

SELECT * FROM trips;
```

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
