### PR TITLE
chore: add feature request template for GH issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Feature request 🚀
+description: Suggest an idea to help us improve
+labels: ['feat']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request!
+  - type: textarea
+    id: feat-description
+    attributes:
+      label: Description of the improvement
+      description: Tell us what improvement would you like to suggest
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: What should be the expected behavior.
+      placeholder: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Do you want to share any additional context about this bug?
+      placeholder: Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -42,5 +42,5 @@ body:
     id: additional-context
     attributes:
       label: Additional context
-      description: Do you want to share any additional context about this bug?
-      placeholder: Add any other context about the problem here.
+      description: Do you want to share any additional context about this improvement?
+      placeholder: Add any other context about the improvement here.


### PR DESCRIPTION
## Description

I noticed I can only file bug report, but can't file in a feature request.
This introduces a template for a feature request for GH issue.

## How are the changes test-covered

- [x] N/A
- [ ] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
