### PR TITLE
build(deps): upgrade arrow dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,19 +35,19 @@ repository = "https://github.com/apache/hudi-rs"
 
 [workspace.dependencies]
 # arrow
-arrow = { version = "= 53.0.0", features = ["pyarrow"] }
-arrow-arith = { version = "= 53.0.0" }
-arrow-array = { version = "= 53.0.0" }
-arrow-buffer = { version = "= 53.0.0" }
-arrow-cast = { version = "= 53.0.0" }
-arrow-ipc = { version = "= 53.0.0" }
-arrow-json = { version = "= 53.0.0" }
-arrow-ord = { version = "= 53.0.0" }
-arrow-row = { version = "= 53.0.0" }
-arrow-schema = { version = "= 53.0.0", features = ["serde"] }
-arrow-select = { version = "= 53.0.0" }
+arrow = { version = "= 53.1.0", features = ["pyarrow"] }
+arrow-arith = { version = "= 53.1.0" }
+arrow-array = { version = "= 53.1.0" }
+arrow-buffer = { version = "= 53.1.0" }
+arrow-cast = { version = "= 53.1.0" }
+arrow-ipc = { version = "= 53.1.0" }
+arrow-json = { version = "= 53.1.0" }
+arrow-ord = { version = "= 53.1.0" }
+arrow-row = { version = "= 53.1.0" }
+arrow-schema = { version = "= 53.1.0", features = ["serde"] }
+arrow-select = { version = "= 53.1.0" }
 object_store = { version = "= 0.11.0", features = ["aws", "azure", "gcp"] }
-parquet = { version = "= 53.0.0", features = ["async", "object_store"] }
+parquet = { version = "= 53.1.0", features = ["async", "object_store"] }
 
 # datafusion
 datafusion = { version = "= 42.0.0" }


### PR DESCRIPTION
## Description

bump arrow from 53.0.0 to 53.1.0

resolves: #143

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
