### PR TITLE
fix: improve api to get file slices splits

### DIFF
--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -105,7 +105,7 @@ impl TableProvider for HudiDataSource {
         let file_slices = self
             .table
             // TODO: implement supports_filters_pushdown() to pass filters to Hudi table API
-            .split_file_slices(self.get_input_partitions(), &[])
+            .get_file_slices_splits(self.get_input_partitions(), &[])
             .await
             .map_err(|e| Execution(format!("Failed to get file slices from Hudi table: {}", e)))?;
         let mut parquet_file_groups: Vec<Vec<PartitionedFile>> = Vec::new();

--- a/python/hudi/__init__.py
+++ b/python/hudi/__init__.py
@@ -16,8 +16,13 @@
 #  under the License.
 
 
-from hudi._internal import HudiFileGroupReader as HudiFileGroupReader
-from hudi._internal import HudiFileSlice as HudiFileSlice
-from hudi._internal import HudiTable as HudiTable
+from hudi._internal import HudiFileGroupReader, HudiFileSlice, HudiTable
 from hudi._internal import __version__ as __version__
-from hudi.table.builder import HudiTableBuilder as HudiTableBuilder
+from hudi.table.builder import HudiTableBuilder
+
+__all__ = [
+    "HudiFileGroupReader",
+    "HudiFileSlice",
+    "HudiTable",
+    "HudiTableBuilder",
+]

--- a/python/hudi/_internal.pyi
+++ b/python/hudi/_internal.pyi
@@ -141,11 +141,11 @@ class HudiTable:
             Dict[str, str]: A dictionary of storage options.
         """
         ...
-    def split_file_slices(
+    def get_file_slices_splits(
         self, n: int, filters: Optional[List[Tuple[str, str, str]]]
     ) -> List[List[HudiFileSlice]]:
         """
-        Splits the file slices into 'n' parts, optionally filtered by given filters.
+        Retrieves all file slices in the Hudi table in 'n' splits, optionally filtered by given filters.
 
         Parameters:
             n (int): The number of parts to split the file slices into.

--- a/python/src/internal.rs
+++ b/python/src/internal.rs
@@ -157,7 +157,7 @@ impl HudiTable {
     }
 
     #[pyo3(signature = (n, filters=None))]
-    fn split_file_slices(
+    fn get_file_slices_splits(
         &self,
         n: usize,
         filters: Option<Vec<(String, String, String)>>,
@@ -166,7 +166,7 @@ impl HudiTable {
         py.allow_threads(|| {
             let file_slices = rt().block_on(
                 self.inner
-                    .split_file_slices(n, vec_to_slice!(filters.unwrap_or_default())),
+                    .get_file_slices_splits(n, vec_to_slice!(filters.unwrap_or_default())),
             )?;
             Ok(file_slices
                 .iter()

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -80,7 +80,7 @@ def test_read_table_can_read_from_batches(get_sample_table):
     assert t.num_rows == 1
     assert t.num_columns == 11
 
-    file_slices_gen = iter(table.split_file_slices(2))
+    file_slices_gen = iter(table.get_file_slices_splits(2))
     assert len(next(file_slices_gen)) == 3
     assert len(next(file_slices_gen)) == 2
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Rename api `split_file_slices()` to `get_file_slices_splits()` and handle empty table case.

<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please link any related issues and PRs as well. -->

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
