### PR TITLE
build(deps): upgrade Datafusion, Arrow, and Rust versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ resolver = "2"
 version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
-rust-version = "1.76"
+rust-version = "1.79"
 keywords = ["apachehudi", "hudi", "datalake", "arrow"]
 readme = "README.md"
 description = "A native Rust library for Apache Hudi"
@@ -35,25 +35,25 @@ repository = "https://github.com/apache/hudi-rs"
 
 [workspace.dependencies]
 # arrow
-arrow = { version = "= 53.1.0", features = ["pyarrow"] }
-arrow-arith = { version = "= 53.1.0" }
-arrow-array = { version = "= 53.1.0" }
-arrow-buffer = { version = "= 53.1.0" }
-arrow-cast = { version = "= 53.1.0" }
-arrow-ipc = { version = "= 53.1.0" }
-arrow-json = { version = "= 53.1.0" }
-arrow-ord = { version = "= 53.1.0" }
-arrow-row = { version = "= 53.1.0" }
-arrow-schema = { version = "= 53.1.0", features = ["serde"] }
-arrow-select = { version = "= 53.1.0" }
+arrow = { version = "= 53.3.0", features = ["pyarrow"] }
+arrow-arith = { version = "= 53.3.0" }
+arrow-array = { version = "= 53.3.0" }
+arrow-buffer = { version = "= 53.3.0" }
+arrow-cast = { version = "= 53.3.0" }
+arrow-ipc = { version = "= 53.3.0" }
+arrow-json = { version = "= 53.3.0" }
+arrow-ord = { version = "= 53.3.0" }
+arrow-row = { version = "= 53.3.0" }
+arrow-schema = { version = "= 53.3.0", features = ["serde"] }
+arrow-select = { version = "= 53.3.0" }
 object_store = { version = "= 0.11.1", features = ["aws", "azure", "gcp"] }
-parquet = { version = "= 53.1.0", features = ["async", "object_store"] }
+parquet = { version = "= 53.3.0", features = ["async", "object_store"] }
 
 # datafusion
-datafusion = { version = "= 42.2.0" }
-datafusion-expr = { version = "= 42.2.0" }
-datafusion-common = { version = "= 42.2.0" }
-datafusion-physical-expr = { version = "= 42.2.0" }
+datafusion = { version = "= 43.0.0" }
+datafusion-expr = { version = "= 43.0.0" }
+datafusion-common = { version = "= 43.0.0" }
+datafusion-physical-expr = { version = "= 43.0.0" }
 
 # serde
 percent-encoding = { version = "2.3.1" }

--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -152,6 +152,7 @@ impl TableProvider for HudiDataSource {
     }
 }
 
+#[derive(Debug)]
 pub struct HudiTableFactory {}
 
 impl HudiTableFactory {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -16,6 +16,6 @@
 # under the License.
 
 [toolchain]
-channel = "1.76"
+channel = "1.79"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
## Description

Closes #196 

<!--- Describe your changes in detail -->
Upgrade versions for Df and arrow.

And upgrade rust to 1.79

<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please link any related issues and PRs as well. -->

## How are the changes test-covered

- [x] N/A
- [ ] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
