### PR TITLE
build(deps): update pyo3 requirement from 0.22.2 to 0.22.4

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -46,5 +46,5 @@ futures = { workspace = true }
 tokio = { workspace = true }
 
 [dependencies.pyo3]
-version = "0.22.2"
+version = "0.22.4"
 features = ["extension-module", "abi3", "abi3-py39", "anyhow"]


### PR DESCRIPTION
## Description

`pyo3` cannot be upgraded to 0.23.2 right now due to `arrow-rs`'s current version not having upgraded to `pyo3` in their latest release