### PR TITLE
docs: add `CREATE EXTERNAL TABLE` example in datafusion crate

### DIFF
--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -196,11 +196,11 @@ impl TableProvider for HudiDataSource {
 /// // The factory can be used to create Hudi tables
 /// let table = factory.create_table(...)?;
 ///
-/// 
+///
 /// // Using `CREATE EXTERNAL TABLE` to register Hudi table:
 /// let test_table =  factory.create_table(...)?; // Table with path + url
 /// let ctx = SessionContext::new();
-/// 
+///
 /// // Register table in session using `CREATE EXTERNAL TABLE` command
 /// let create_table_sql = format!(
 ///     "CREATE EXTERNAL TABLE {} STORED AS HUDI LOCATION '{}' {}",

--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -193,8 +193,22 @@ impl TableProvider for HudiDataSource {
 /// // Initialize a new HudiTableFactory
 /// let factory = HudiTableFactory::new();
 ///     
-/// // The factory can now be used to create Hudi tables
+/// // The factory can be used to create Hudi tables
 /// let table = factory.create_table(...)?;
+///
+/// 
+/// // Using `CREATE EXTERNAL TABLE` to register Hudi table:
+/// let test_table =  factory.create_table(...)?; // Table with path + url
+/// let ctx = SessionContext::new();
+/// 
+/// // Register table in session using `CREATE EXTERNAL TABLE` command
+/// let create_table_sql = format!(
+///     "CREATE EXTERNAL TABLE {} STORED AS HUDI LOCATION '{}' {}",
+///     test_table.as_ref(),
+///     test_table.path(),
+///     concat_as_sql_options(options)
+/// );
+/// ctx.sql(create_table_sql.as_str()).await?; // Query against this table
 ///
 /// ```
 #[derive(Debug)]


### PR DESCRIPTION
## Description
Mentioned in #125 

Updated crate's docs to account for `CREATE EXTERNAL TABLE`