### PR TITLE
refactor: enhance `Filter` and related structs

### DIFF
--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -31,7 +31,7 @@ pub enum CoreError {
     Config(#[from] ConfigError),
 
     #[error("Data type error: {0}")]
-    DataType(String),
+    Schema(String),
 
     #[error("File group error: {0}")]
     FileGroup(String),

--- a/crates/core/src/expr/filter.rs
+++ b/crates/core/src/expr/filter.rs
@@ -20,6 +20,9 @@
 use crate::error::CoreError;
 use crate::expr::ExprOperator;
 use crate::Result;
+use arrow_array::{ArrayRef, Scalar, StringArray};
+use arrow_cast::{cast_with_options, CastOptions};
+use arrow_schema::{DataType, Field, Schema};
 use std::str::FromStr;
 
 #[derive(Debug, Clone)]
@@ -29,7 +32,14 @@ pub struct Filter {
     pub field_value: String,
 }
 
-impl Filter {}
+impl Filter {
+    pub fn negate(&self) -> Option<Self> {
+        self.operator.negate().map(|op| Self {
+            operator: op,
+            ..self.clone()
+        })
+    }
+}
 
 impl TryFrom<(&str, &str, &str)> for Filter {
     type Error = CoreError;
@@ -48,5 +58,117 @@ impl TryFrom<(&str, &str, &str)> for Filter {
             operator,
             field_value,
         })
+    }
+}
+
+pub struct FilterField {
+    pub name: String,
+}
+
+impl FilterField {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { name: name.into() }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn eq(&self, value: impl Into<String>) -> Filter {
+        Filter {
+            field_name: self.name.clone(),
+            operator: ExprOperator::Eq,
+            field_value: value.into(),
+        }
+    }
+
+    pub fn ne(&self, value: impl Into<String>) -> Filter {
+        Filter {
+            field_name: self.name.clone(),
+            operator: ExprOperator::Ne,
+            field_value: value.into(),
+        }
+    }
+
+    pub fn lt(&self, value: impl Into<String>) -> Filter {
+        Filter {
+            field_name: self.name.clone(),
+            operator: ExprOperator::Lt,
+            field_value: value.into(),
+        }
+    }
+
+    pub fn lte(&self, value: impl Into<String>) -> Filter {
+        Filter {
+            field_name: self.name.clone(),
+            operator: ExprOperator::Lte,
+            field_value: value.into(),
+        }
+    }
+
+    pub fn gt(&self, value: impl Into<String>) -> Filter {
+        Filter {
+            field_name: self.name.clone(),
+            operator: ExprOperator::Gt,
+            field_value: value.into(),
+        }
+    }
+
+    pub fn gte(&self, value: impl Into<String>) -> Filter {
+        Filter {
+            field_name: self.name.clone(),
+            operator: ExprOperator::Gte,
+            field_value: value.into(),
+        }
+    }
+}
+
+pub fn col(name: impl Into<String>) -> FilterField {
+    FilterField::new(name)
+}
+
+#[derive(Debug, Clone)]
+pub struct SchemableFilter {
+    pub field: Field,
+    pub operator: ExprOperator,
+    pub value: Scalar<ArrayRef>,
+}
+
+impl TryFrom<(Filter, &Schema)> for SchemableFilter {
+    type Error = CoreError;
+
+    fn try_from((filter, schema): (Filter, &Schema)) -> Result<Self, Self::Error> {
+        let field_name = filter.field_name.clone();
+        let field: &Field = schema.field_with_name(&field_name).map_err(|e| {
+            CoreError::Schema(format!("Field {} not found in schema: {:?}", field_name, e))
+        })?;
+
+        let operator = filter.operator;
+        let value = &[filter.field_value.as_str()];
+        let value = Self::cast_value(value, field.data_type())?;
+
+        let field = field.clone();
+        Ok(SchemableFilter {
+            field,
+            operator,
+            value,
+        })
+    }
+}
+
+impl SchemableFilter {
+    pub fn cast_value(value: &[&str; 1], data_type: &DataType) -> Result<Scalar<ArrayRef>> {
+        let cast_options = CastOptions {
+            safe: false,
+            format_options: Default::default(),
+        };
+
+        let value = StringArray::from(Vec::from(value));
+
+        Ok(Scalar::new(
+            cast_with_options(&value, data_type, &cast_options).map_err(|e| {
+                CoreError::Schema(format!("Unable to cast {:?}: {:?}", data_type, e))
+            })?,
+        ))
     }
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
- Rename `PartitionFilter` to `SchemableFilter` for generic use
- Fix missing `Operator::NotEq` support
- Add ergonomic functions for composing `Filter`s, such as `col("foo").eq("a")`

<!--- If it fixes an open issue, please link to the issue here. -->
Closes #160 

<!--- Please link any related issues and PRs as well. -->

Follow up #203

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
