### PR TITLE
feat: add demo app and integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,18 @@ jobs:
           path: ./cov-reports
           if-no-files-found: 'error'
 
+  integration-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-22.04 ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Integration tests
+        run: |
+          cd demo
+          ./run_app.sh
 
   publish-coverage:
     name: Publish coverage reports to codecov.io

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,11 +112,7 @@ jobs:
           if-no-files-found: 'error'
 
   integration-tests:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-22.04 ]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Integration tests

--- a/demo/.env
+++ b/demo/.env
@@ -15,21 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-/Cargo.lock
-/target
-**/target
 
-/.idea
-.vscode
-
-# python
-venv
-**/.python-version
-__pycache__
-
-# macOS
-**/.DS_Store
-
-# coverage files
-*.profraw
-cobertura.xml
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=minioadmin

--- a/demo/app/.gitignore
+++ b/demo/app/.gitignore
@@ -15,21 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-/Cargo.lock
-/target
-**/target
-
-/.idea
-.vscode
-
-# python
-venv
-**/.python-version
-__pycache__
-
-# macOS
-**/.DS_Store
-
-# coverage files
-*.profraw
-cobertura.xml
+venv/
+Cargo.lock
+**/target/

--- a/demo/app/python/src/__init__.py
+++ b/demo/app/python/src/__init__.py
@@ -1,0 +1,16 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.

--- a/demo/app/python/src/main.py
+++ b/demo/app/python/src/main.py
@@ -1,0 +1,52 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+from hudi import HudiTableBuilder
+import pyarrow as pa
+
+hudi_table = HudiTableBuilder.from_base_uri(
+    "s3://hudi-demo/v6_complexkeygen_hivestyle"
+).build()
+records = hudi_table.read_snapshot()
+
+arrow_table = pa.Table.from_batches(records)
+assert arrow_table.schema.names == [
+    "_hoodie_commit_time",
+    "_hoodie_commit_seqno",
+    "_hoodie_record_key",
+    "_hoodie_partition_path",
+    "_hoodie_file_name",
+    "id",
+    "name",
+    "isActive",
+    "intField",
+    "longField",
+    "floatField",
+    "doubleField",
+    "decimalField",
+    "dateField",
+    "timestampField",
+    "binaryField",
+    "arrayField",
+    "mapField",
+    "structField",
+    "byteField",
+    "shortField",
+]
+assert arrow_table.num_rows == 4
+
+print("Python API: read snapshot successfully!")

--- a/demo/app/rust/Cargo.toml
+++ b/demo/app/rust/Cargo.toml
@@ -15,21 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
-/Cargo.lock
-/target
-**/target
+[workspace]
+# keep this empty such that it won't be linked to the repo workspace
 
-/.idea
-.vscode
+[package]
+name = "app"
+version = "0.1.0"
+edition = "2021"
 
-# python
-venv
-**/.python-version
-__pycache__
-
-# macOS
-**/.DS_Store
-
-# coverage files
-*.profraw
-cobertura.xml
+[dependencies]
+tokio = "^1"
+datafusion = "^43"
+hudi = { path = "../../../crates/hudi", features = ["datafusion"] }

--- a/demo/app/rust/src/main.rs
+++ b/demo/app/rust/src/main.rs
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use std::sync::Arc;
+
+use datafusion::error::Result;
+use datafusion::prelude::{DataFrame, SessionContext};
+use hudi::HudiDataSource;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let ctx = SessionContext::new();
+    let hudi = HudiDataSource::new("s3://hudi-demo/v6_complexkeygen_hivestyle").await?;
+    ctx.register_table("v6_table", Arc::new(hudi))?;
+    let df: DataFrame = ctx.sql("SELECT * from v6_table").await?;
+    assert!(
+        df.schema()
+            .columns()
+            .iter()
+            .map(|c| c.name())
+            .collect::<Vec<_>>()
+            == vec![
+                "_hoodie_commit_time",
+                "_hoodie_commit_seqno",
+                "_hoodie_record_key",
+                "_hoodie_partition_path",
+                "_hoodie_file_name",
+                "id",
+                "name",
+                "isActive",
+                "intField",
+                "longField",
+                "floatField",
+                "doubleField",
+                "decimalField",
+                "dateField",
+                "timestampField",
+                "binaryField",
+                "arrayField",
+                "mapField",
+                "structField",
+                "byteField",
+                "shortField",
+            ]
+    );
+    assert!(df.count().await.unwrap() == 4);
+    println!("Rust API: read snapshot successfully!");
+    Ok(())
+}

--- a/demo/compose.yaml
+++ b/demo/compose.yaml
@@ -1,0 +1,68 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+---
+services:
+  minio:
+    image: quay.io/minio/minio:latest
+    container_name: minio
+    ports:
+      - 9000:9000
+      - 9001:9001
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+    healthcheck:
+      test: [ "CMD", "mc", "ready", "local" ]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  mc:
+    build:
+      context: ./infra/mc
+    container_name: mc
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+    depends_on:
+      minio:
+        condition: service_healthy
+    volumes:
+      - ../crates/tests/data:/opt/data:ro
+      - ./infra/mc/prepare_data.sh:/opt/prepare_data.sh
+    command:
+      - /bin/sh
+      - -c
+      - /opt/prepare_data.sh
+
+  runner:
+    build:
+      context: ./infra/runner
+    container_name: runner
+    volumes:
+      - ../.:/opt/hudi-rs
+    environment:
+      AWS_ACCESS_KEY_ID: ${MINIO_ROOT_USER}
+      AWS_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD}
+      AWS_ENDPOINT_URL: http://minio:9000
+      AWS_ALLOW_HTTP: true
+      AWS_REGION: us-east-1 # minio default
+
+networks:
+  app_network:
+    driver: bridge

--- a/demo/infra/mc/Dockerfile
+++ b/demo/infra/mc/Dockerfile
@@ -15,21 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-/Cargo.lock
-/target
-**/target
+FROM alpine
 
-/.idea
-.vscode
+RUN apk update && apk add --no-cache \
+	wget ca-certificates bash unzip
 
-# python
-venv
-**/.python-version
-__pycache__
+RUN cd /usr/local/bin && \
+  wget -q --show-progress https://dl.min.io/client/mc/release/linux-amd64/mc && \
+  chmod +x mc
 
-# macOS
-**/.DS_Store
-
-# coverage files
-*.profraw
-cobertura.xml
+WORKDIR /opt/data

--- a/demo/infra/mc/prepare_data.sh
+++ b/demo/infra/mc/prepare_data.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -14,22 +16,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+#
 
-/Cargo.lock
-/target
-**/target
+mc alias set local http://minio:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
 
-/.idea
-.vscode
+# create a bucket named `hudi-demo`
+mc mb local/hudi-demo
 
-# python
-venv
-**/.python-version
-__pycache__
+# unzip the data
+mkdir /tmp/tables
+for zip in /opt/data/tables/*.zip; do unzip -o "$zip" -d "/tmp/tables/"; done
 
-# macOS
-**/.DS_Store
-
-# coverage files
-*.profraw
-cobertura.xml
+# copy the data to the bucket
+mc cp -r /tmp/tables/* local/hudi-demo/

--- a/demo/infra/runner/Dockerfile
+++ b/demo/infra/runner/Dockerfile
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 FROM rust:1.79
 
 RUN apt-get update && apt-get install -y python3-dev python3-venv

--- a/demo/infra/runner/Dockerfile
+++ b/demo/infra/runner/Dockerfile
@@ -1,0 +1,15 @@
+FROM rust:1.79
+
+RUN apt-get update && apt-get install -y python3-dev python3-venv
+
+RUN python3 -m venv /opt/venv
+
+ENV PATH="/opt/venv/bin:$PATH"
+
+ENV VIRTUAL_ENV=/opt/venv
+
+RUN pip install --no-cache-dir --upgrade pip
+
+WORKDIR /opt
+
+CMD tail -f /dev/null

--- a/demo/run_app.sh
+++ b/demo/run_app.sh
@@ -34,8 +34,8 @@ if [ $attempt -eq $max_attempts ]; then
   exit 1
 fi
 
-# Run the python app
-docker exec -it runner /bin/bash -c "
+# install dependencies and run the app
+docker exec -T runner /bin/bash -c "
   cd /opt/hudi-rs/python && \
   make setup develop && \
   cd /opt/hudi-rs/demo/app && \

--- a/demo/run_app.sh
+++ b/demo/run_app.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -14,22 +16,29 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+#
 
-/Cargo.lock
-/target
-**/target
+docker compose up --build -d
 
-/.idea
-.vscode
+max_attempts=30
+attempt=0
 
-# python
-venv
-**/.python-version
-__pycache__
+until [ "$(docker inspect -f '{{.State.Status}}' runner)" = "running" ] || [ $attempt -eq $max_attempts ]; do
+  attempt=$(( $attempt + 1 ))
+  echo "Waiting for container... (attempt $attempt of $max_attempts)"
+  sleep 1
+done
 
-# macOS
-**/.DS_Store
+if [ $attempt -eq $max_attempts ]; then
+  echo "Container failed to become ready in time"
+  exit 1
+fi
 
-# coverage files
-*.profraw
-cobertura.xml
+# Run the python app
+docker exec -it runner /bin/bash -c "
+  cd /opt/hudi-rs/python && \
+  make setup develop && \
+  cd /opt/hudi-rs/demo/app && \
+  cargo run --manifest-path=rust/Cargo.toml && \
+  python -m python.src.main
+  "

--- a/demo/run_app.sh
+++ b/demo/run_app.sh
@@ -35,7 +35,7 @@ if [ $attempt -eq $max_attempts ]; then
 fi
 
 # install dependencies and run the app
-docker exec -T runner /bin/bash -c "
+docker compose exec -T runner /bin/bash -c "
   cd /opt/hudi-rs/python && \
   make setup develop && \
   cd /opt/hudi-rs/demo/app && \


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

- Add `demo/` to show an e2e docker setup for querying a test hudi table stored on minio. Show both rust and python usage examples.
- Make assertions in the demo apps and make them run with CI as integration tests.

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #81 

<!--- Please link any related issues and PRs as well. -->

Reworked based on #112 

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
