### PR TITLE
feat: implement incremental query for COW tables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,8 @@ datafusion-physical-expr = { version = "= 43.0.0" }
 
 # serde
 percent-encoding = { version = "2.3.1" }
-serde = { version = "1", features = ["std", "derive"] }
-serde_json = { version = "1" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0" }
 
 # "stdlib"
 thiserror = { version = "2.0.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ datafusion-physical-expr = { version = "= 43.0.0" }
 
 # serde
 percent-encoding = { version = "2.3.1" }
-serde = { version = "1.0.203", features = ["derive"] }
+serde = { version = "1", features = ["std", "derive"] }
 serde_json = { version = "1" }
 
 # "stdlib"

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -30,6 +30,9 @@ pub enum CoreError {
     #[error("Config error: {0}")]
     Config(#[from] ConfigError),
 
+    #[error("Commit metadata error: {0}")]
+    CommitMetadata(String),
+
     #[error("Data type error: {0}")]
     Schema(String),
 

--- a/crates/core/src/file_group/builder.rs
+++ b/crates/core/src/file_group/builder.rs
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+use crate::error::CoreError;
+use crate::file_group::FileGroup;
+use crate::Result;
+use serde_json::{Map, Value};
+use std::collections::HashSet;
+use std::path::Path;
+
+pub fn build_file_groups(commit_metadata: &Map<String, Value>) -> Result<HashSet<FileGroup>> {
+    let partition_stats = commit_metadata
+        .get("partitionToWriteStats")
+        .and_then(|v| v.as_object())
+        .ok_or(CoreError::CommitMetadata("Invalid or missing partitionToWriteStats object".into()))?;
+
+    let mut file_groups = HashSet::new();
+
+    for (partition, write_stats_array) in partition_stats {
+        let write_stats = write_stats_array
+            .as_array()
+            .ok_or(CoreError::CommitMetadata("Invalid write stats array".into()))?;
+
+        let partition = (!partition.is_empty()).then(|| partition.to_string());
+
+        for stat in write_stats {
+            let file_group_id = stat
+                .get("fileId")
+                .and_then(|v| v.as_str())
+                .ok_or(CoreError::CommitMetadata("Invalid fileId in write stats".into()))?;
+
+            let path = stat
+                .get("path")
+                .and_then(|v| v.as_str())
+                .ok_or(CoreError::CommitMetadata("Invalid path in write stats".into()))?;
+
+            let file_name = Path::new(path)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .ok_or(CoreError::CommitMetadata("Invalid file name in path".into()))?;
+
+            let file_group = FileGroup::new_with_base_file_name(
+                file_group_id.to_string(),
+                partition.clone(),
+                file_name,
+            )?;
+            file_groups.insert(file_group);
+        }
+    }
+
+    Ok(file_groups)
+}
+
+pub fn build_replaced_file_groups(
+    commit_metadata: &Map<String, Value>,
+) -> Result<HashSet<FileGroup>> {
+    let partition_to_replaced = commit_metadata
+        .get("partitionToReplaceFileIds")
+        .and_then(|v| v.as_object())
+        .ok_or(CoreError::CommitMetadata(
+            "Invalid or missing partitionToReplaceFileIds object".into(),
+        ))?;
+
+    let mut file_groups = HashSet::new();
+
+    for (partition, file_group_ids_value) in partition_to_replaced {
+        let file_group_ids = file_group_ids_value
+            .as_array()
+            .ok_or(CoreError::CommitMetadata("Invalid file group ids array".into()))?;
+
+        let partition = (!partition.is_empty()).then(|| partition.to_string());
+
+        for file_group_id in file_group_ids {
+            let id = file_group_id
+                .as_str()
+                .ok_or(CoreError::CommitMetadata("Invalid file group id string".into()))?;
+
+            let file_group = FileGroup::new(id.to_string(), partition.clone());
+            file_groups.insert(file_group);
+        }
+    }
+
+    Ok(file_groups)
+}

--- a/crates/core/src/file_group/builder.rs
+++ b/crates/core/src/file_group/builder.rs
@@ -27,32 +27,42 @@ pub fn build_file_groups(commit_metadata: &Map<String, Value>) -> Result<HashSet
     let partition_stats = commit_metadata
         .get("partitionToWriteStats")
         .and_then(|v| v.as_object())
-        .ok_or(CoreError::CommitMetadata("Invalid or missing partitionToWriteStats object".into()))?;
+        .ok_or(CoreError::CommitMetadata(
+            "Invalid or missing partitionToWriteStats object".into(),
+        ))?;
 
     let mut file_groups = HashSet::new();
 
     for (partition, write_stats_array) in partition_stats {
         let write_stats = write_stats_array
             .as_array()
-            .ok_or(CoreError::CommitMetadata("Invalid write stats array".into()))?;
+            .ok_or(CoreError::CommitMetadata(
+                "Invalid write stats array".into(),
+            ))?;
 
         let partition = (!partition.is_empty()).then(|| partition.to_string());
 
         for stat in write_stats {
-            let file_group_id = stat
-                .get("fileId")
-                .and_then(|v| v.as_str())
-                .ok_or(CoreError::CommitMetadata("Invalid fileId in write stats".into()))?;
+            let file_group_id =
+                stat.get("fileId")
+                    .and_then(|v| v.as_str())
+                    .ok_or(CoreError::CommitMetadata(
+                        "Invalid fileId in write stats".into(),
+                    ))?;
 
-            let path = stat
-                .get("path")
-                .and_then(|v| v.as_str())
-                .ok_or(CoreError::CommitMetadata("Invalid path in write stats".into()))?;
+            let path =
+                stat.get("path")
+                    .and_then(|v| v.as_str())
+                    .ok_or(CoreError::CommitMetadata(
+                        "Invalid path in write stats".into(),
+                    ))?;
 
             let file_name = Path::new(path)
                 .file_name()
                 .and_then(|name| name.to_str())
-                .ok_or(CoreError::CommitMetadata("Invalid file name in path".into()))?;
+                .ok_or(CoreError::CommitMetadata(
+                    "Invalid file name in path".into(),
+                ))?;
 
             let file_group = FileGroup::new_with_base_file_name(
                 file_group_id.to_string(),
@@ -81,14 +91,16 @@ pub fn build_replaced_file_groups(
     for (partition, file_group_ids_value) in partition_to_replaced {
         let file_group_ids = file_group_ids_value
             .as_array()
-            .ok_or(CoreError::CommitMetadata("Invalid file group ids array".into()))?;
+            .ok_or(CoreError::CommitMetadata(
+                "Invalid file group ids array".into(),
+            ))?;
 
         let partition = (!partition.is_empty()).then(|| partition.to_string());
 
         for file_group_id in file_group_ids {
-            let id = file_group_id
-                .as_str()
-                .ok_or(CoreError::CommitMetadata("Invalid file group id string".into()))?;
+            let id = file_group_id.as_str().ok_or(CoreError::CommitMetadata(
+                "Invalid file group id string".into(),
+            ))?;
 
             let file_group = FileGroup::new(id.to_string(), partition.clone());
             file_groups.insert(file_group);

--- a/crates/core/src/file_group/builder.rs
+++ b/crates/core/src/file_group/builder.rs
@@ -105,7 +105,6 @@ mod tests {
 
     mod test_build_file_groups {
         use super::super::*;
-        use crate::file_group::builder::build_file_groups;
         use serde_json::{json, Map, Value};
 
         #[test]
@@ -265,6 +264,17 @@ mod tests {
             assert!(result.is_ok());
             let file_groups = result.unwrap();
             assert_eq!(file_groups.len(), 2);
+
+            let expected_partitions = HashSet::from_iter(vec![
+                "byteField=20/shortField=100",
+                "byteField=10/shortField=300",
+            ]);
+            let actual_partitions = HashSet::<&str>::from_iter(
+                file_groups
+                    .iter()
+                    .map(|fg| fg.partition_path.as_ref().unwrap().as_str()),
+            );
+            assert_eq!(actual_partitions, expected_partitions);
         }
     }
 
@@ -422,10 +432,11 @@ mod tests {
             assert_eq!(file_groups.len(), 3);
 
             let expected_partitions = HashSet::from_iter(vec!["10", "20", "30"]);
-            let actual_partitions: HashSet<&str> = file_groups
-                .iter()
-                .map(|fg| fg.partition_path.as_ref().unwrap().as_str())
-                .collect();
+            let actual_partitions = HashSet::<&str>::from_iter(
+                file_groups
+                    .iter()
+                    .map(|fg| fg.partition_path.as_ref().unwrap().as_str()),
+            );
             assert_eq!(actual_partitions, expected_partitions);
         }
     }

--- a/crates/core/src/file_group/builder.rs
+++ b/crates/core/src/file_group/builder.rs
@@ -27,42 +27,34 @@ pub fn build_file_groups(commit_metadata: &Map<String, Value>) -> Result<HashSet
     let partition_stats = commit_metadata
         .get("partitionToWriteStats")
         .and_then(|v| v.as_object())
-        .ok_or(CoreError::CommitMetadata(
-            "Invalid or missing partitionToWriteStats object".into(),
-        ))?;
+        .ok_or_else(|| {
+            CoreError::CommitMetadata("Invalid or missing partitionToWriteStats object".into())
+        })?;
 
     let mut file_groups = HashSet::new();
 
     for (partition, write_stats_array) in partition_stats {
         let write_stats = write_stats_array
             .as_array()
-            .ok_or(CoreError::CommitMetadata(
-                "Invalid write stats array".into(),
-            ))?;
+            .ok_or_else(|| CoreError::CommitMetadata("Invalid write stats array".into()))?;
 
         let partition = (!partition.is_empty()).then(|| partition.to_string());
 
         for stat in write_stats {
-            let file_group_id =
-                stat.get("fileId")
-                    .and_then(|v| v.as_str())
-                    .ok_or(CoreError::CommitMetadata(
-                        "Invalid fileId in write stats".into(),
-                    ))?;
+            let file_group_id = stat
+                .get("fileId")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| CoreError::CommitMetadata("Invalid fileId in write stats".into()))?;
 
-            let path =
-                stat.get("path")
-                    .and_then(|v| v.as_str())
-                    .ok_or(CoreError::CommitMetadata(
-                        "Invalid path in write stats".into(),
-                    ))?;
+            let path = stat
+                .get("path")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| CoreError::CommitMetadata("Invalid path in write stats".into()))?;
 
             let file_name = Path::new(path)
                 .file_name()
                 .and_then(|name| name.to_str())
-                .ok_or(CoreError::CommitMetadata(
-                    "Invalid file name in path".into(),
-                ))?;
+                .ok_or_else(|| CoreError::CommitMetadata("Invalid file name in path".into()))?;
 
             let file_group = FileGroup::new_with_base_file_name(
                 file_group_id.to_string(),
@@ -82,25 +74,23 @@ pub fn build_replaced_file_groups(
     let partition_to_replaced = commit_metadata
         .get("partitionToReplaceFileIds")
         .and_then(|v| v.as_object())
-        .ok_or(CoreError::CommitMetadata(
-            "Invalid or missing partitionToReplaceFileIds object".into(),
-        ))?;
+        .ok_or_else(|| {
+            CoreError::CommitMetadata("Invalid or missing partitionToReplaceFileIds object".into())
+        })?;
 
     let mut file_groups = HashSet::new();
 
     for (partition, file_group_ids_value) in partition_to_replaced {
         let file_group_ids = file_group_ids_value
             .as_array()
-            .ok_or(CoreError::CommitMetadata(
-                "Invalid file group ids array".into(),
-            ))?;
+            .ok_or_else(|| CoreError::CommitMetadata("Invalid file group ids array".into()))?;
 
         let partition = (!partition.is_empty()).then(|| partition.to_string());
 
         for file_group_id in file_group_ids {
-            let id = file_group_id.as_str().ok_or(CoreError::CommitMetadata(
-                "Invalid file group id string".into(),
-            ))?;
+            let id = file_group_id
+                .as_str()
+                .ok_or_else(|| CoreError::CommitMetadata("Invalid file group id string".into()))?;
 
             let file_group = FileGroup::new(id.to_string(), partition.clone());
             file_groups.insert(file_group);

--- a/crates/core/src/file_group/mod.rs
+++ b/crates/core/src/file_group/mod.rs
@@ -67,12 +67,19 @@ impl BaseFile {
     }
 
     /// Construct [BaseFile] with the base file name.
+    ///
+    /// TODO: refactor such that file info size is optional and no one expects it.
     pub fn from_file_name(file_name: &str) -> Result<Self> {
         let (file_group_id, commit_time) = Self::parse_file_name(file_name)?;
+        let info = FileInfo {
+            name: file_name.to_string(),
+            size: 0,
+            uri: "".to_string(),
+        };
         Ok(Self {
             file_group_id,
             commit_time,
-            info: FileInfo::default(),
+            info,
             stats: None,
         })
     }
@@ -100,6 +107,7 @@ pub struct FileSlice {
 }
 
 impl FileSlice {
+    #[cfg(test)]
     pub fn base_file_path(&self) -> &str {
         self.base_file.info.uri.as_str()
     }

--- a/crates/core/src/file_group/mod.rs
+++ b/crates/core/src/file_group/mod.rs
@@ -20,6 +20,7 @@
 //!
 //! A set of data/base files + set of log files, that make up a unit for all operations.
 
+pub mod builder;
 pub mod reader;
 
 use crate::error::CoreError;
@@ -187,8 +188,17 @@ impl FileGroup {
         }
     }
 
-    #[cfg(test)]
-    fn add_base_file_from_name(&mut self, file_name: &str) -> Result<&Self> {
+    pub fn new_with_base_file_name(
+        id: String,
+        partition_path: Option<String>,
+        file_name: &str,
+    ) -> Result<Self> {
+        let mut file_group = Self::new(id, partition_path);
+        file_group.add_base_file_from_name(file_name)?;
+        Ok(file_group)
+    }
+
+    pub fn add_base_file_from_name(&mut self, file_name: &str) -> Result<&Self> {
         let base_file = BaseFile::from_file_name(file_name)?;
         self.add_base_file(base_file)
     }

--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -179,10 +179,7 @@ impl Storage {
         for dir in dir_paths {
             dirs.push(
                 dir.filename()
-                    .ok_or(InvalidPath(format!(
-                        "Failed to get file name from: {:?}",
-                        dir
-                    )))?
+                    .ok_or_else(|| InvalidPath(format!("Failed to get file name from: {:?}", dir)))?
                     .to_string(),
             )
         }
@@ -211,10 +208,12 @@ impl Storage {
             let name = obj_meta
                 .location
                 .filename()
-                .ok_or(InvalidPath(format!(
-                    "Failed to get file name from {:?}",
-                    obj_meta.location
-                )))?
+                .ok_or_else(|| {
+                    InvalidPath(format!(
+                        "Failed to get file name from {:?}",
+                        obj_meta.location
+                    ))
+                })?
                 .to_string();
             let uri = join_url_segments(&prefix_url, &[&name])?.to_string();
             file_info.push(FileInfo {
@@ -249,10 +248,9 @@ pub async fn get_leaf_dirs(storage: &Storage, subdir: Option<&str>) -> Result<Ve
                 next_subdir.push(curr);
             }
             next_subdir.push(child_dir);
-            let next_subdir = next_subdir.to_str().ok_or(InvalidPath(format!(
-                "Failed to convert path: {:?}",
-                next_subdir
-            )))?;
+            let next_subdir = next_subdir
+                .to_str()
+                .ok_or_else(|| InvalidPath(format!("Failed to convert path: {:?}", next_subdir)))?;
             let curr_leaf_dir = get_leaf_dirs(storage, Some(next_subdir)).await?;
             leaf_dirs.extend(curr_leaf_dir);
         }

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -877,18 +877,16 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_complex_keygen_hive_style() {
+        async fn test_complex_keygen_hive_style() -> Result<()> {
             let base_url = TestTable::V6ComplexkeygenHivestyle.url();
-            let hudi_table = Table::new(base_url.path()).await.unwrap();
+            let hudi_table = Table::new(base_url.path()).await?;
 
-            let filter_gte_10 = Filter::try_from(("byteField", ">=", "10")).unwrap();
-            let filter_lt_20 = Filter::try_from(("byteField", "<", "20")).unwrap();
-            let filter_ne_100 = Filter::try_from(("shortField", "!=", "100")).unwrap();
-
-            let records = hudi_table
-                .read_snapshot(&[filter_gte_10, filter_lt_20, filter_ne_100])
-                .await
-                .unwrap();
+            let filters = &[
+                Filter::try_from(("byteField", ">=", "10"))?,
+                Filter::try_from(("byteField", "<", "20"))?,
+                Filter::try_from(("shortField", "!=", "100"))?,
+            ];
+            let records = hudi_table.read_snapshot(filters).await?;
             assert_eq!(records.len(), 1);
             assert_eq!(records[0].num_rows(), 2);
 
@@ -915,6 +913,8 @@ mod tests {
                 "a22e8257-e249-45e9-ba46-115bc85adcba-0_0-161-223_20240418173235694.parquet",
             ]);
             assert_eq!(actual_file_names, expected_file_names);
+
+            Ok(())
         }
     }
 

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -276,6 +276,7 @@ impl Table {
     }
 
     /// Get records that were inserted or updated between the given timestamps. Records that were updated multiple times should have their latest states within the time span being returned.
+    #[allow(dead_code)]
     pub async fn read_incremental_records(
         &self,
         start_timestamp: &str,

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -345,7 +345,6 @@ mod tests {
     use crate::storage::util::join_url_segments;
     use crate::storage::Storage;
     use crate::table::Filter;
-    use arrow_array::{Array, StringArray};
     use hudi_tests::{assert_not, TestTable};
     use std::collections::HashSet;
     use std::fs::canonicalize;
@@ -860,133 +859,155 @@ mod tests {
         assert_eq!(actual, expected);
     }
 
-    #[tokio::test]
-    async fn hudi_table_read_snapshot_for_complex_keygen_hive_style() {
-        let base_url = TestTable::V6ComplexkeygenHivestyle.url();
-        let hudi_table = Table::new(base_url.path()).await.unwrap();
+    mod test_snapshot_queries {
+        use super::super::*;
+        use arrow_array::{Array, StringArray};
+        use hudi_tests::TestTable;
+        use std::collections::HashSet;
 
-        let filter_gte_10 = Filter::try_from(("byteField", ">=", "10")).unwrap();
-        let filter_lt_20 = Filter::try_from(("byteField", "<", "20")).unwrap();
-        let filter_ne_100 = Filter::try_from(("shortField", "!=", "100")).unwrap();
+        #[tokio::test]
+        async fn test_empty() -> Result<()> {
+            let base_url = TestTable::V6Empty.url();
+            let hudi_table = Table::new(base_url.path()).await?;
 
-        let records = hudi_table
-            .read_snapshot(&[filter_gte_10, filter_lt_20, filter_ne_100])
-            .await
-            .unwrap();
-        assert_eq!(records.len(), 1);
-        assert_eq!(records[0].num_rows(), 2);
-        let actual_partition_paths: HashSet<&str> = HashSet::from_iter(
-            records[0]
-                .column_by_name("_hoodie_partition_path")
-                .unwrap()
-                .as_any()
-                .downcast_ref::<StringArray>()
-                .unwrap()
-                .iter()
-                .map(|s| s.unwrap())
-                .collect::<Vec<_>>(),
-        );
-        let expected_partition_paths: HashSet<&str> =
-            HashSet::from_iter(vec!["byteField=10/shortField=300"]);
-        assert_eq!(actual_partition_paths, expected_partition_paths);
+            let records = hudi_table.read_snapshot(&[]).await?;
+            assert!(records.is_empty());
 
-        let actual_file_names: HashSet<&str> = HashSet::from_iter(
-            records[0]
-                .column_by_name("_hoodie_file_name")
-                .unwrap()
-                .as_any()
-                .downcast_ref::<StringArray>()
-                .unwrap()
-                .iter()
-                .map(|s| s.unwrap())
-                .collect::<Vec<_>>(),
-        );
-        let expected_file_names: HashSet<&str> = HashSet::from_iter(vec![
-            "a22e8257-e249-45e9-ba46-115bc85adcba-0_0-161-223_20240418173235694.parquet",
-        ]);
-        assert_eq!(actual_file_names, expected_file_names);
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_complex_keygen_hive_style() {
+            let base_url = TestTable::V6ComplexkeygenHivestyle.url();
+            let hudi_table = Table::new(base_url.path()).await.unwrap();
+
+            let filter_gte_10 = Filter::try_from(("byteField", ">=", "10")).unwrap();
+            let filter_lt_20 = Filter::try_from(("byteField", "<", "20")).unwrap();
+            let filter_ne_100 = Filter::try_from(("shortField", "!=", "100")).unwrap();
+
+            let records = hudi_table
+                .read_snapshot(&[filter_gte_10, filter_lt_20, filter_ne_100])
+                .await
+                .unwrap();
+            assert_eq!(records.len(), 1);
+            assert_eq!(records[0].num_rows(), 2);
+
+            let partition_paths = StringArray::from(
+                records[0]
+                    .column_by_name("_hoodie_partition_path")
+                    .unwrap()
+                    .to_data(),
+            );
+            let actual_partition_paths =
+                HashSet::<&str>::from_iter(partition_paths.iter().map(|s| s.unwrap()));
+            let expected_partition_paths = HashSet::from_iter(vec!["byteField=10/shortField=300"]);
+            assert_eq!(actual_partition_paths, expected_partition_paths);
+
+            let file_names = StringArray::from(
+                records[0]
+                    .column_by_name("_hoodie_file_name")
+                    .unwrap()
+                    .to_data(),
+            );
+            let actual_file_names =
+                HashSet::<&str>::from_iter(file_names.iter().map(|s| s.unwrap()));
+            let expected_file_names: HashSet<&str> = HashSet::from_iter(vec![
+                "a22e8257-e249-45e9-ba46-115bc85adcba-0_0-161-223_20240418173235694.parquet",
+            ]);
+            assert_eq!(actual_file_names, expected_file_names);
+        }
     }
 
-    #[tokio::test]
-    async fn hudi_table_read_incremental_records_for_simplekeygen_nonhivestyle_overwritetable(
-    ) -> Result<()> {
-        let base_url = TestTable::V6SimplekeygenNonhivestyleOverwritetable.url();
-        let hudi_table = Table::new(base_url.path()).await?;
+    mod test_incremental_queries {
+        use super::super::*;
+        use arrow_array::{Array, StringArray};
+        use hudi_tests::TestTable;
+        use std::collections::HashSet;
 
-        // read records changed from the first commit (exclusive) to the second commit (inclusive)
-        let records = hudi_table
-            .read_incremental_records("20240707001301554", Some("20240707001302376"))
-            .await?;
-        assert_eq!(records.len(), 2);
-        assert_eq!(records[0].num_rows(), 1);
-        assert_eq!(records[1].num_rows(), 1);
+        #[tokio::test]
+        async fn test_empty() -> Result<()> {
+            let base_url = TestTable::V6Empty.url();
+            let hudi_table = Table::new(base_url.path()).await?;
 
-        // verify the partition paths
-        let partition_paths = arrow::compute::concat(&[
-            records[0].column_by_name("_hoodie_partition_path").unwrap(),
-            records[1].column_by_name("_hoodie_partition_path").unwrap(),
-        ])?
-        .to_data();
-        let partition_paths = StringArray::from(partition_paths);
-        let actual_partition_paths: HashSet<&str> = HashSet::from_iter(
-            partition_paths
-                .iter()
-                .map(|s| s.unwrap())
-                .collect::<Vec<_>>(),
-        );
-        let expected_partition_paths = HashSet::from_iter(vec!["10", "30"]);
-        assert_eq!(actual_partition_paths, expected_partition_paths);
+            let records = hudi_table.read_incremental_records("0", None).await?;
+            assert!(records.is_empty());
 
-        // verify the file names
-        let file_names = arrow::compute::concat(&[
-            records[0].column_by_name("_hoodie_file_name").unwrap(),
-            records[1].column_by_name("_hoodie_file_name").unwrap(),
-        ])?
-        .to_data();
-        let file_names = StringArray::from(file_names);
-        let actual_file_names: HashSet<&str> =
-            HashSet::from_iter(file_names.iter().map(|s| s.unwrap()).collect::<Vec<_>>());
-        let expected_file_names = HashSet::from_iter(vec![
-            "d398fae1-c0e6-4098-8124-f55f7098bdba-0_1-95-136_20240707001302376.parquet",
-            "4f2685a3-614f-49ca-9b2b-e1cb9fb61f27-0_0-95-135_20240707001302376.parquet",
-        ]);
-        assert_eq!(actual_file_names, expected_file_names);
+            Ok(())
+        }
 
-        // read records changed from the first commit (exclusive) to
-        // the latest (an insert overwrite table's replacecommit)
-        let records = hudi_table
-            .read_incremental_records("20240707001301554", None)
-            .await?;
-        assert_eq!(records.len(), 1);
-        assert_eq!(records[0].num_rows(), 1);
+        #[tokio::test]
+        async fn test_simplekeygen_nonhivestyle_overwritetable() -> Result<()> {
+            let base_url = TestTable::V6SimplekeygenNonhivestyleOverwritetable.url();
+            let hudi_table = Table::new(base_url.path()).await?;
 
-        // verify the partition paths
-        let partition_paths = arrow::compute::concat(&[records[0]
-            .column_by_name("_hoodie_partition_path")
-            .unwrap()])?
-        .to_data();
-        let partition_paths = StringArray::from(partition_paths);
-        let actual_partition_paths: HashSet<&str> = HashSet::from_iter(
-            partition_paths
-                .iter()
-                .map(|s| s.unwrap())
-                .collect::<Vec<_>>(),
-        );
-        let expected_partition_paths = HashSet::from_iter(vec!["30"]);
-        assert_eq!(actual_partition_paths, expected_partition_paths);
+            // read records changed from the first commit (exclusive) to the second commit (inclusive)
+            let records = hudi_table
+                .read_incremental_records("20240707001301554", Some("20240707001302376"))
+                .await?;
+            assert_eq!(records.len(), 2);
+            assert_eq!(records[0].num_rows(), 1);
+            assert_eq!(records[1].num_rows(), 1);
 
-        // verify the file names
-        let file_names =
-            arrow::compute::concat(&[records[0].column_by_name("_hoodie_file_name").unwrap()])?
-                .to_data();
-        let file_names = StringArray::from(file_names);
-        let actual_file_names: HashSet<&str> =
-            HashSet::from_iter(file_names.iter().map(|s| s.unwrap()).collect::<Vec<_>>());
-        let expected_file_names = HashSet::from_iter(vec![
-            "ebcb261d-62d3-4895-90ec-5b3c9622dff4-0_0-111-154_20240707001303088.parquet",
-        ]);
-        assert_eq!(actual_file_names, expected_file_names);
+            // verify the partition paths
+            let partition_paths = StringArray::from(
+                arrow::compute::concat(&[
+                    records[0].column_by_name("_hoodie_partition_path").unwrap(),
+                    records[1].column_by_name("_hoodie_partition_path").unwrap(),
+                ])?
+                .to_data(),
+            );
+            let actual_partition_paths =
+                HashSet::<&str>::from_iter(partition_paths.iter().map(|s| s.unwrap()));
+            let expected_partition_paths = HashSet::from_iter(vec!["10", "30"]);
+            assert_eq!(actual_partition_paths, expected_partition_paths);
 
-        Ok(())
+            // verify the file names
+            let file_names = StringArray::from(
+                arrow::compute::concat(&[
+                    records[0].column_by_name("_hoodie_file_name").unwrap(),
+                    records[1].column_by_name("_hoodie_file_name").unwrap(),
+                ])?
+                .to_data(),
+            );
+            let actual_file_names =
+                HashSet::<&str>::from_iter(file_names.iter().map(|s| s.unwrap()));
+            let expected_file_names = HashSet::from_iter(vec![
+                "d398fae1-c0e6-4098-8124-f55f7098bdba-0_1-95-136_20240707001302376.parquet",
+                "4f2685a3-614f-49ca-9b2b-e1cb9fb61f27-0_0-95-135_20240707001302376.parquet",
+            ]);
+            assert_eq!(actual_file_names, expected_file_names);
+
+            // read records changed from the first commit (exclusive) to
+            // the latest (an insert overwrite table's replacecommit)
+            let records = hudi_table
+                .read_incremental_records("20240707001301554", None)
+                .await?;
+            assert_eq!(records.len(), 1);
+            assert_eq!(records[0].num_rows(), 1);
+
+            // verify the partition paths
+            let actual_partition_paths = StringArray::from(
+                records[0]
+                    .column_by_name("_hoodie_partition_path")
+                    .unwrap()
+                    .to_data(),
+            );
+            let expected_partition_paths = StringArray::from(vec!["30"]);
+            assert_eq!(actual_partition_paths, expected_partition_paths);
+
+            // verify the file names
+            let actual_file_names = StringArray::from(
+                records[0]
+                    .column_by_name("_hoodie_file_name")
+                    .unwrap()
+                    .to_data(),
+            );
+            let expected_file_names = StringArray::from(vec![
+                "ebcb261d-62d3-4895-90ec-5b3c9622dff4-0_0-111-154_20240707001303088.parquet",
+            ]);
+            assert_eq!(actual_file_names, expected_file_names);
+
+            Ok(())
+        }
     }
 }

--- a/crates/core/src/timeline/mod.rs
+++ b/crates/core/src/timeline/mod.rs
@@ -152,7 +152,7 @@ impl Timeline {
 
     pub async fn get_replaced_file_groups(&self) -> Result<HashSet<FileGroup>> {
         let mut file_groups: HashSet<FileGroup> = HashSet::new();
-        let selector = TimelineSelector::completed_replacecommits(self.hudi_configs.clone())?;
+        let selector = TimelineSelector::completed_replacecommits(self.hudi_configs.clone());
         for instant in selector.select(self)? {
             let commit_metadata = self.get_commit_metadata(&instant).await?;
             file_groups.extend(build_replaced_file_groups(&commit_metadata)?);

--- a/crates/core/src/timeline/mod.rs
+++ b/crates/core/src/timeline/mod.rs
@@ -122,11 +122,7 @@ impl Timeline {
         let bytes = self.storage.get_file_data(path.as_str()).await?;
 
         serde_json::from_slice(&bytes)
-            .and_then(|json: Value| {
-                json.as_object()
-                    .ok_or_else(|| serde::de::Error::custom("not a JSON object"))
-                    .map(Clone::clone)
-            }).map_err(|e| CoreError::Timeline(format!("Failed to get commit metadata: {}", e)))
+            .map_err(|e| CoreError::Timeline(format!("Failed to get commit metadata: {}", e)))
     }
 
     pub async fn get_latest_schema(&self) -> Result<Schema> {
@@ -280,6 +276,6 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(matches!(err, CoreError::Timeline(_)));
-        assert!(err.to_string().contains("not a JSON object"));
+        assert!(err.to_string().contains("Failed to get commit metadata"));
     }
 }

--- a/crates/core/src/timeline/mod.rs
+++ b/crates/core/src/timeline/mod.rs
@@ -165,15 +165,18 @@ impl Timeline {
 
     /// Get file groups in the timeline ranging from start (exclusive) to end (inclusive).
     /// File groups are as of the [end] timestamp or the latest if not given.
-    pub async fn get_file_groups_in_range(
+    pub async fn get_incremental_file_groups(
         &self,
-        start: Option<&str>,
-        end: Option<&str>,
+        start_timestamp: Option<&str>,
+        end_timestamp: Option<&str>,
     ) -> Result<HashSet<FileGroup>> {
         let mut file_groups: HashSet<FileGroup> = HashSet::new();
         let mut replaced_file_groups: HashSet<FileGroup> = HashSet::new();
-        let selector =
-            TimelineSelector::completed_commits_in_range(self.hudi_configs.clone(), start, end)?;
+        let selector = TimelineSelector::completed_commits_in_range(
+            self.hudi_configs.clone(),
+            start_timestamp,
+            end_timestamp,
+        )?;
         let commits = selector.select(self)?;
         for instant in commits {
             let commit_metadata = self.get_commit_metadata(&instant).await?;

--- a/crates/core/src/timeline/selector.rs
+++ b/crates/core/src/timeline/selector.rs
@@ -368,7 +368,12 @@ mod tests {
         let selected = selector.select(&timeline)?;
         assert_eq!(
             selected.iter().map(|i| &i.timestamp).collect::<Vec<_>>(),
-            &["20240103153000", "20240103153010999", "20240103153020999", "20240103153030999"]
+            &[
+                "20240103153000",
+                "20240103153010999",
+                "20240103153020999",
+                "20240103153030999"
+            ]
         );
 
         // start and end in the middle

--- a/crates/core/src/timeline/selector.rs
+++ b/crates/core/src/timeline/selector.rs
@@ -70,31 +70,15 @@ impl TimelineSelector {
         })
     }
 
-    pub fn completed_replacecommits(hudi_configs: Arc<HudiConfigs>) -> Result<Self> {
-        Self::completed_replacecommits_in_range(hudi_configs, None, None)
-    }
-
-    pub fn completed_replacecommits_in_range(
-        hudi_configs: Arc<HudiConfigs>,
-        start: Option<&str>,
-        end: Option<&str>,
-    ) -> Result<Self> {
-        let timezone = Self::get_timezone_from_configs(hudi_configs);
-        let start_datetime = start
-            .map(|s| Instant::parse_datetime(s, &timezone))
-            .transpose()?;
-        let end_datetime = end
-            .map(|e| Instant::parse_datetime(e, &timezone))
-            .transpose()?;
-
-        Ok(Self {
-            timezone,
-            start_datetime,
-            end_datetime,
+    pub fn completed_replacecommits(hudi_configs: Arc<HudiConfigs>) -> Self {
+        Self {
+            timezone: Self::get_timezone_from_configs(hudi_configs),
+            start_datetime: None,
+            end_datetime: None,
             states: Some(vec![State::Completed]),
             actions: Some(vec![Action::ReplaceCommit]),
             include_archived: false,
-        })
+        }
     }
 
     pub fn try_create_instant(&self, file_name: &str) -> Result<Instant> {

--- a/python/hudi/_internal.pyi
+++ b/python/hudi/_internal.pyi
@@ -189,6 +189,9 @@ class HudiTable:
             List[pyarrow.RecordBatch]: A list of record batches from the snapshot of the table.
         """
         ...
+    def read_incremental_records(
+        self, start_commit_time: str, end_commit_time: Optional[str]
+    ) -> List["pyarrow.RecordBatch"]: ...
 
 def build_hudi_table(
     base_uri: str,

--- a/python/hudi/_internal.pyi
+++ b/python/hudi/_internal.pyi
@@ -190,7 +190,7 @@ class HudiTable:
         """
         ...
     def read_incremental_records(
-        self, start_commit_time: str, end_commit_time: Optional[str]
+        self, start_timestamp: str, end_timestamp: Optional[str]
     ) -> List["pyarrow.RecordBatch"]: ...
 
 def build_hudi_table(

--- a/python/src/internal.rs
+++ b/python/src/internal.rs
@@ -241,6 +241,21 @@ impl HudiTable {
             .map_err(PythonError::from)?
             .to_pyarrow(py)
     }
+
+    #[pyo3(signature = (start_timestamp, end_timestamp=None))]
+    fn read_incremental_records(
+        &self,
+        start_timestamp: &str,
+        end_timestamp: Option<&str>,
+        py: Python,
+    ) -> PyResult<PyObject> {
+        rt().block_on(
+            self.inner
+                .read_incremental_records(start_timestamp, end_timestamp),
+        )
+        .map_err(PythonError::from)?
+        .to_pyarrow(py)
+    }
 }
 
 fn convert_filters(filters: Option<Vec<(String, String, String)>>) -> PyResult<Vec<Filter>> {

--- a/python/tests/test_table_incremental_read.py
+++ b/python/tests/test_table_incremental_read.py
@@ -1,0 +1,38 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+import pyarrow as pa
+
+from hudi import HudiTable
+
+
+def test_table_incremental_read_returns_correct_data(get_sample_table):
+    table_path = get_sample_table
+    table = HudiTable(table_path)
+
+    batches = table.read_incremental_records("20240402123035233", "20240402144910683")
+    t = pa.Table.from_batches(batches).select([0, 3, 4, 5, 6, 9]).sort_by("ts")
+    assert t.to_pylist() == [
+        {
+            "_hoodie_commit_time": "20240402144910683",
+            "_hoodie_partition_path": "san_francisco",
+            "_hoodie_file_name": "5a226868-2934-4f84-a16f-55124630c68d-0_0-7-24_20240402144910683.parquet",
+            "ts": 1695046462179,
+            "uuid": "9909a8b1-2d15-4d3d-8ec9-efc48c536a00",
+            "fare": 339.0,
+        },
+    ]


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

For performing incremental queries (latest-state mode), added table APIs

```
# rust
read_incremental_records(&self, start_timestamp: &str, end_timestamp: Option<&str>)

# python
read_incremental_records(self, start_timestamp: str, end_timestamp: Optional[str])
```


<!--- If it fixes an open issue, please link to the issue here. -->

Closes #9

<!--- Please link any related issues and PRs as well. -->

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
