### PR TITLE
fix: include commit_seqno for merge order

### DIFF
--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -54,6 +54,9 @@ pub enum CoreError {
     #[error("{0}")]
     InvalidPartitionPath(String),
 
+    #[error("{0}")]
+    InvalidValue(String),
+
     #[error(transparent)]
     ParquetError(#[from] parquet::errors::ParquetError),
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -48,6 +48,7 @@ pub mod error;
 pub mod expr;
 pub mod file_group;
 pub mod merge;
+pub mod metadata;
 pub mod storage;
 pub mod table;
 pub mod timeline;

--- a/crates/core/src/merge/mod.rs
+++ b/crates/core/src/merge/mod.rs
@@ -17,7 +17,6 @@
  * under the License.
  */
 pub mod record_merger;
-
 use crate::config::error;
 use crate::config::error::ConfigError;
 use crate::config::error::ConfigError::InvalidValue;

--- a/crates/core/src/merge/mod.rs
+++ b/crates/core/src/merge/mod.rs
@@ -17,6 +17,7 @@
  * under the License.
  */
 pub mod record_merger;
+
 use crate::config::error;
 use crate::config::error::ConfigError;
 use crate::config::error::ConfigError::InvalidValue;

--- a/crates/core/src/metadata/meta_field.rs
+++ b/crates/core/src/metadata/meta_field.rs
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+use crate::error::CoreError;
+use crate::Result;
+use std::fmt::Display;
+use std::str::FromStr;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MetaField {
+    CommitTime = 0,
+    CommitSeqno = 1,
+    RecordKey = 2,
+    PartitionPath = 3,
+    FileName = 4,
+    Operation = 5,
+}
+
+impl AsRef<str> for MetaField {
+    fn as_ref(&self) -> &str {
+        match self {
+            MetaField::CommitTime => "_hoodie_commit_time",
+            MetaField::CommitSeqno => "_hoodie_commit_seqno",
+            MetaField::RecordKey => "_hoodie_record_key",
+            MetaField::PartitionPath => "_hoodie_partition_path",
+            MetaField::FileName => "_hoodie_file_name",
+            MetaField::Operation => "_hoodie_operation",
+        }
+    }
+}
+
+impl Display for MetaField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_ref())
+    }
+}
+
+impl FromStr for MetaField {
+    type Err = CoreError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "_hoodie_commit_time" => Ok(MetaField::CommitTime),
+            "_hoodie_commit_seqno" => Ok(MetaField::CommitSeqno),
+            "_hoodie_record_key" => Ok(MetaField::RecordKey),
+            "_hoodie_partition_path" => Ok(MetaField::PartitionPath),
+            "_hoodie_file_name" => Ok(MetaField::FileName),
+            "_hoodie_operation" => Ok(MetaField::Operation),
+            _ => Err(CoreError::InvalidValue(s.to_string())),
+        }
+    }
+}
+
+impl MetaField {
+    #[inline]
+    pub fn field_index(&self) -> usize {
+        self.clone() as usize
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_field_index() {
+        assert_eq!(MetaField::CommitTime.field_index(), 0);
+        assert_eq!(MetaField::CommitSeqno.field_index(), 1);
+        assert_eq!(MetaField::RecordKey.field_index(), 2);
+        assert_eq!(MetaField::PartitionPath.field_index(), 3);
+        assert_eq!(MetaField::FileName.field_index(), 4);
+        assert_eq!(MetaField::Operation.field_index(), 5);
+    }
+
+    #[test]
+    fn test_as_ref() {
+        assert_eq!(MetaField::CommitTime.as_ref(), "_hoodie_commit_time");
+        assert_eq!(MetaField::CommitSeqno.as_ref(), "_hoodie_commit_seqno");
+        assert_eq!(MetaField::RecordKey.as_ref(), "_hoodie_record_key");
+        assert_eq!(MetaField::PartitionPath.as_ref(), "_hoodie_partition_path");
+        assert_eq!(MetaField::FileName.as_ref(), "_hoodie_file_name");
+        assert_eq!(MetaField::Operation.as_ref(), "_hoodie_operation");
+    }
+
+    #[test]
+    fn test_display() {
+        assert_eq!(MetaField::CommitTime.to_string(), "_hoodie_commit_time");
+        assert_eq!(
+            format!("{}", MetaField::CommitSeqno),
+            "_hoodie_commit_seqno"
+        );
+        assert_eq!(MetaField::RecordKey.to_string(), "_hoodie_record_key");
+    }
+
+    #[test]
+    fn test_from_str_valid() -> Result<(), CoreError> {
+        assert_eq!(
+            MetaField::from_str("_hoodie_commit_time")?,
+            MetaField::CommitTime
+        );
+        assert_eq!(
+            MetaField::from_str("_hoodie_commit_seqno")?,
+            MetaField::CommitSeqno
+        );
+        assert_eq!(
+            MetaField::from_str("_hoodie_record_key")?,
+            MetaField::RecordKey
+        );
+        assert_eq!(
+            MetaField::from_str("_hoodie_partition_path")?,
+            MetaField::PartitionPath
+        );
+        assert_eq!(
+            MetaField::from_str("_hoodie_file_name")?,
+            MetaField::FileName
+        );
+        assert_eq!(
+            MetaField::from_str("_hoodie_operation")?,
+            MetaField::Operation
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_str_invalid() {
+        assert!(matches!(
+            MetaField::from_str(""),
+            Err(CoreError::InvalidValue(_))
+        ));
+        assert!(matches!(
+            MetaField::from_str("_hoodie_invalid"),
+            Err(CoreError::InvalidValue(_))
+        ));
+        assert!(matches!(
+            MetaField::from_str("invalid"),
+            Err(CoreError::InvalidValue(_))
+        ));
+    }
+
+    #[test]
+    fn test_roundtrip() -> Result<(), CoreError> {
+        // Test conversion from enum -> string -> enum
+        let fields = [
+            MetaField::CommitTime,
+            MetaField::CommitSeqno,
+            MetaField::RecordKey,
+            MetaField::PartitionPath,
+            MetaField::FileName,
+            MetaField::Operation,
+        ];
+
+        for field in fields {
+            let s = field.to_string();
+            let parsed = MetaField::from_str(&s)?;
+            assert_eq!(field, parsed);
+        }
+        Ok(())
+    }
+}

--- a/crates/core/src/metadata/mod.rs
+++ b/crates/core/src/metadata/mod.rs
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+pub mod meta_field;

--- a/crates/core/src/util/arrow.rs
+++ b/crates/core/src/util/arrow.rs
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use crate::Result;
+use arrow::array::ArrayRef;
+use arrow::array::RecordBatch;
+use arrow::array::StringArray;
+use arrow_array::{Array, UInt32Array};
+use arrow_row::{RowConverter, SortField};
+use arrow_schema::ArrowError;
+
+pub trait ColumnAsArray {
+    fn get_array(&self, column_name: &str) -> Result<ArrayRef>;
+
+    fn get_string_array(&self, column_name: &str) -> Result<StringArray>;
+}
+
+impl ColumnAsArray for RecordBatch {
+    fn get_array(&self, column_name: &str) -> Result<ArrayRef> {
+        let index = self.schema().index_of(column_name)?;
+        let array = self.column(index);
+        Ok(array.clone())
+    }
+
+    fn get_string_array(&self, column_name: &str) -> Result<StringArray> {
+        let array = self.get_array(column_name)?;
+        let array = array
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| {
+                ArrowError::CastError(format!(
+                    "Column {column_name} cannot be cast to StringArray."
+                ))
+            })?;
+        Ok(array.clone())
+    }
+}
+
+pub fn lexsort_to_indices(arrays: &[ArrayRef], desc: bool) -> UInt32Array {
+    let fields = arrays
+        .iter()
+        .map(|a| SortField::new(a.data_type().clone()))
+        .collect();
+    let converter = RowConverter::new(fields).unwrap();
+    let rows = converter.convert_columns(arrays).unwrap();
+    let mut sort: Vec<_> = rows.iter().enumerate().collect();
+    if desc {
+        sort.sort_unstable_by(|(_, a), (_, b)| b.cmp(a));
+    } else {
+        sort.sort_unstable_by(|(_, a), (_, b)| a.cmp(b));
+    }
+    UInt32Array::from_iter_values(sort.iter().map(|(i, _)| *i as u32))
+}

--- a/crates/core/src/util/mod.rs
+++ b/crates/core/src/util/mod.rs
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+pub mod arrow;
 
 pub fn convert_vec_to_slice(vec: &[(String, String, String)]) -> Vec<(&str, &str, &str)> {
     vec.iter()


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

- Add `MetaField` enum for Hudi meta fields.
- Consider `_hoodie_commit_seqno` for merging when precombine values are equal

<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please link any related issues and PRs as well. -->

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
