### PR TITLE
refactor: improve file system view's listing flow

### DIFF
--- a/crates/core/src/file_group/file_slice.rs
+++ b/crates/core/src/file_group/file_slice.rs
@@ -30,11 +30,11 @@ use std::path::PathBuf;
 pub struct FileSlice {
     pub base_file: BaseFile,
     pub log_files: BTreeSet<LogFile>,
-    pub partition_path: Option<String>,
+    pub partition_path: String,
 }
 
 impl FileSlice {
-    pub fn new(base_file: BaseFile, partition_path: Option<String>) -> Self {
+    pub fn new(base_file: BaseFile, partition_path: String) -> Self {
         Self {
             base_file,
             log_files: BTreeSet::new(),
@@ -43,7 +43,7 @@ impl FileSlice {
     }
 
     fn relative_path_for_file(&self, file_name: &str) -> Result<String> {
-        let path = PathBuf::from(self.partition_path()).join(file_name);
+        let path = PathBuf::from(self.partition_path.as_str()).join(file_name);
         path.to_str().map(|s| s.to_string()).ok_or_else(|| {
             CoreError::FileGroup(format!("Failed to get relative path for file: {file_name}",))
         })
@@ -65,12 +65,6 @@ impl FileSlice {
     #[inline]
     pub fn file_id(&self) -> &str {
         &self.base_file.file_id
-    }
-
-    /// Returns the partition path of the [FileSlice].
-    #[inline]
-    pub fn partition_path(&self) -> &str {
-        self.partition_path.as_deref().unwrap_or_default()
     }
 
     /// Returns the instant time that marks the [FileSlice] creation.

--- a/crates/core/src/metadata/mod.rs
+++ b/crates/core/src/metadata/mod.rs
@@ -17,3 +17,13 @@
  * under the License.
  */
 pub mod meta_field;
+
+pub const HUDI_METADATA_DIR: &str = ".hoodie";
+pub const DELTALAKE_METADATA_DIR: &str = "_delta_log";
+pub const ICEBERG_METADATA_DIR: &str = "metadata";
+
+pub const LAKE_FORMAT_METADATA_DIRS: &[&str; 3] = &[
+    HUDI_METADATA_DIR,
+    DELTALAKE_METADATA_DIR,
+    ICEBERG_METADATA_DIR,
+];

--- a/crates/core/src/table/fs_view.rs
+++ b/crates/core/src/table/fs_view.rs
@@ -21,26 +21,21 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use crate::config::HudiConfigs;
-use crate::file_group::base_file::BaseFile;
 use crate::file_group::FileGroup;
-use crate::storage::{get_leaf_dirs, Storage};
+use crate::storage::Storage;
 
-use crate::config::read::HudiReadConfig::ListingParallelism;
-use crate::config::table::HudiTableConfig::BaseFileFormat;
-use crate::error::CoreError;
 use crate::file_group::file_slice::FileSlice;
-use crate::file_group::log_file::LogFile;
-use crate::table::partition::{PartitionPruner, PARTITION_METAFIELD_PREFIX};
+use crate::table::listing::FileLister;
+use crate::table::partition::PartitionPruner;
 use crate::Result;
 use dashmap::DashMap;
-use futures::stream::{self, StreamExt, TryStreamExt};
 
 /// A view of the Hudi table's data files (files stored outside the `.hoodie/` directory) in the file system. It provides APIs to load and
 /// access the file groups and file slices.
 #[derive(Clone, Debug)]
 #[allow(dead_code)]
 pub struct FileSystemView {
-    hudi_configs: Arc<HudiConfigs>,
+    pub(crate) hudi_configs: Arc<HudiConfigs>,
     pub(crate) storage: Arc<Storage>,
     partition_to_file_groups: Arc<DashMap<String, Vec<FileGroup>>>,
 }
@@ -59,136 +54,18 @@ impl FileSystemView {
         })
     }
 
-    fn should_exclude_for_listing(file_name: &str) -> bool {
-        file_name.starts_with(PARTITION_METAFIELD_PREFIX) || file_name.ends_with(".crc")
-    }
-
-    async fn list_all_partition_paths(storage: &Storage) -> Result<Vec<String>> {
-        Self::list_partition_paths(storage, &PartitionPruner::empty()).await
-    }
-
-    async fn list_partition_paths(
-        storage: &Storage,
-        partition_pruner: &PartitionPruner,
-    ) -> Result<Vec<String>> {
-        let top_level_dirs: Vec<String> = storage
-            .list_dirs(None)
-            .await?
-            .into_iter()
-            .filter(|dir| dir != ".hoodie")
-            .collect();
-        let mut partition_paths = Vec::new();
-        for dir in top_level_dirs {
-            partition_paths.extend(get_leaf_dirs(storage, Some(&dir)).await?);
-        }
-        if partition_paths.is_empty() {
-            partition_paths.push("".to_string())
-        }
-        if partition_pruner.is_empty() {
-            return Ok(partition_paths);
-        }
-
-        Ok(partition_paths
-            .into_iter()
-            .filter(|path_str| partition_pruner.should_include(path_str))
-            .collect())
-    }
-
-    async fn list_file_groups_for_partition(
-        storage: &Storage,
-        partition_path: &str,
-        base_file_format: &str,
-    ) -> Result<Vec<FileGroup>> {
-        let listed_file_metadata = storage.list_files(Some(partition_path)).await?;
-
-        let mut file_id_to_base_files: HashMap<String, Vec<BaseFile>> = HashMap::new();
-        let mut file_id_to_log_files: HashMap<String, Vec<LogFile>> = HashMap::new();
-
-        for file_metadata in listed_file_metadata {
-            if Self::should_exclude_for_listing(&file_metadata.name) {
-                continue;
-            }
-
-            let base_file_extension = format!(".{}", base_file_format);
-            if file_metadata.name.ends_with(&base_file_extension) {
-                // After excluding the unintended files,
-                // we expect a file that has the base file extension to be a valid base file.
-                let base_file = BaseFile::try_from(file_metadata)?;
-                let file_id = &base_file.file_id;
-                file_id_to_base_files
-                    .entry(file_id.to_owned())
-                    .or_default()
-                    .push(base_file);
-            } else {
-                match LogFile::try_from(file_metadata) {
-                    Ok(log_file) => {
-                        let file_id = &log_file.file_id;
-                        file_id_to_log_files
-                            .entry(file_id.to_owned())
-                            .or_default()
-                            .push(log_file);
-                    }
-                    Err(e) => {
-                        // We don't support cdc log files yet, hence skipping error when parsing
-                        // fails. However, once we support all data files, we should return error
-                        // here because we expect all files to be either base files or log files,
-                        // after excluding the unintended files.
-                        log::warn!("Failed to create a log file: {}", e);
-                        continue;
-                    }
-                }
-            }
-        }
-
-        let mut file_groups: Vec<FileGroup> = Vec::new();
-        // TODO support creating file groups without base files
-        for (file_id, base_files) in file_id_to_base_files.into_iter() {
-            let mut file_group =
-                FileGroup::new(file_id.to_owned(), Some(partition_path.to_owned()));
-
-            file_group.add_base_files(base_files)?;
-
-            let log_files = file_id_to_log_files.remove(&file_id).unwrap_or_default();
-            file_group.add_log_files(log_files)?;
-
-            file_groups.push(file_group);
-        }
-        Ok(file_groups)
-    }
-
     async fn load_file_groups(&self, partition_pruner: &PartitionPruner) -> Result<()> {
-        let all_partition_paths = Self::list_all_partition_paths(&self.storage).await?;
-
-        let partition_paths_to_list = all_partition_paths
-            .into_iter()
-            .filter(|p| !self.partition_to_file_groups.contains_key(p))
-            .filter(|p| partition_pruner.should_include(p))
-            .collect::<HashSet<_>>();
-
-        let base_file_format = self
-            .hudi_configs
-            .get_or_default(BaseFileFormat)
-            .to::<String>();
-        let parallelism = self
-            .hudi_configs
-            .get_or_default(ListingParallelism)
-            .to::<usize>();
-        stream::iter(partition_paths_to_list)
-            .map(|path| {
-                let base_file_format = base_file_format.clone();
-                async move {
-                    let format = base_file_format.as_str();
-                    let file_groups =
-                        Self::list_file_groups_for_partition(&self.storage, &path, format).await?;
-                    Ok::<_, CoreError>((path, file_groups))
-                }
-            })
-            .buffer_unordered(parallelism)
-            .try_for_each(|(path, file_groups)| async move {
-                self.partition_to_file_groups.insert(path, file_groups);
-                Ok(())
-            })
-            .await
+        let lister = FileLister::new(
+            self.hudi_configs.clone(),
+            self.storage.clone(),
+            partition_pruner.to_owned(),
+        );
+        let file_groups_map = lister.list_file_groups_for_relevant_partitions().await?;
+        for (partition_path, file_groups) in file_groups_map {
+            self.partition_to_file_groups
+                .insert(partition_path, file_groups);
+        }
+        Ok(())
     }
 
     async fn collect_file_slices_as_of(
@@ -230,65 +107,18 @@ impl FileSystemView {
 
 #[cfg(test)]
 mod tests {
-    use crate::config::table::HudiTableConfig;
-    use crate::config::HudiConfigs;
+    use super::*;
     use crate::expr::filter::Filter;
-    use crate::storage::Storage;
-    use crate::table::fs_view::FileSystemView;
-    use crate::table::partition::PartitionPruner;
     use crate::table::Table;
 
     use hudi_tests::SampleTable;
-    use std::collections::{HashMap, HashSet};
-    use std::sync::Arc;
-    use url::Url;
-
-    async fn create_test_fs_view(base_url: Url) -> FileSystemView {
-        FileSystemView::new(
-            Arc::new(HudiConfigs::new([(HudiTableConfig::BasePath, base_url)])),
-            Arc::new(HashMap::new()),
-        )
-        .await
-        .unwrap()
-    }
-
-    #[tokio::test]
-    async fn get_partition_paths_for_nonpartitioned_table() {
-        let base_url = SampleTable::V6Nonpartitioned.url_to_cow();
-        let storage = Storage::new_with_base_url(base_url).unwrap();
-        let partition_pruner = PartitionPruner::empty();
-        let partition_paths = FileSystemView::list_partition_paths(&storage, &partition_pruner)
-            .await
-            .unwrap();
-        let partition_path_set: HashSet<&str> =
-            HashSet::from_iter(partition_paths.iter().map(|p| p.as_str()));
-        assert_eq!(partition_path_set, HashSet::from([""]))
-    }
-
-    #[tokio::test]
-    async fn get_partition_paths_for_complexkeygen_table() {
-        let base_url = SampleTable::V6ComplexkeygenHivestyle.url_to_cow();
-        let storage = Storage::new_with_base_url(base_url).unwrap();
-        let partition_pruner = PartitionPruner::empty();
-        let partition_paths = FileSystemView::list_partition_paths(&storage, &partition_pruner)
-            .await
-            .unwrap();
-        let partition_path_set: HashSet<&str> =
-            HashSet::from_iter(partition_paths.iter().map(|p| p.as_str()));
-        assert_eq!(
-            partition_path_set,
-            HashSet::from_iter(vec![
-                "byteField=10/shortField=300",
-                "byteField=20/shortField=100",
-                "byteField=30/shortField=100"
-            ])
-        )
-    }
+    use std::collections::HashSet;
 
     #[tokio::test]
     async fn fs_view_get_latest_file_slices() {
         let base_url = SampleTable::V6Nonpartitioned.url_to_cow();
-        let fs_view = create_test_fs_view(base_url).await;
+        let hudi_table = Table::new(base_url.path()).await.unwrap();
+        let fs_view = &hudi_table.file_system_view;
 
         assert!(fs_view.partition_to_file_groups.is_empty());
         let partition_pruner = PartitionPruner::empty();
@@ -313,7 +143,7 @@ mod tests {
     async fn fs_view_get_latest_file_slices_with_replace_commit() {
         let base_url = SampleTable::V6SimplekeygenNonhivestyleOverwritetable.url_to_cow();
         let hudi_table = Table::new(base_url.path()).await.unwrap();
-        let fs_view = create_test_fs_view(base_url).await;
+        let fs_view = &hudi_table.file_system_view;
 
         assert_eq!(fs_view.partition_to_file_groups.len(), 0);
         let partition_pruner = PartitionPruner::empty();
@@ -342,7 +172,7 @@ mod tests {
     async fn fs_view_get_latest_file_slices_with_partition_filters() {
         let base_url = SampleTable::V6ComplexkeygenHivestyle.url_to_cow();
         let hudi_table = Table::new(base_url.path()).await.unwrap();
-        let fs_view = create_test_fs_view(base_url).await;
+        let fs_view = &hudi_table.file_system_view;
 
         assert_eq!(fs_view.partition_to_file_groups.len(), 0);
 

--- a/crates/core/src/table/listing.rs
+++ b/crates/core/src/table/listing.rs
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+use crate::config::read::HudiReadConfig::ListingParallelism;
+use crate::config::table::HudiTableConfig::BaseFileFormat;
+use crate::config::HudiConfigs;
+use crate::error::CoreError;
+use crate::file_group::base_file::BaseFile;
+use crate::file_group::log_file::LogFile;
+use crate::file_group::FileGroup;
+use crate::metadata::LAKE_FORMAT_METADATA_DIRS;
+use crate::storage::{get_leaf_dirs, Storage};
+use crate::table::partition::{
+    is_table_partitioned, PartitionPruner, EMPTY_PARTITION_PATH, PARTITION_METAFIELD_PREFIX,
+};
+use crate::Result;
+use dashmap::DashMap;
+use futures::{stream, StreamExt, TryStreamExt};
+use std::collections::HashMap;
+use std::string::ToString;
+use std::sync::Arc;
+
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub struct FileLister {
+    hudi_configs: Arc<HudiConfigs>,
+    storage: Arc<Storage>,
+    partition_pruner: PartitionPruner,
+}
+
+impl FileLister {
+    pub fn new(
+        hudi_configs: Arc<HudiConfigs>,
+        storage: Arc<Storage>,
+        partition_pruner: PartitionPruner,
+    ) -> Self {
+        Self {
+            hudi_configs,
+            storage,
+            partition_pruner,
+        }
+    }
+
+    fn should_exclude_for_listing(file_name: &str) -> bool {
+        file_name.starts_with(PARTITION_METAFIELD_PREFIX) || file_name.ends_with(".crc")
+    }
+
+    async fn list_file_groups_for_partition(&self, partition_path: &str) -> Result<Vec<FileGroup>> {
+        let base_file_format = self
+            .hudi_configs
+            .get_or_default(BaseFileFormat)
+            .to::<String>();
+
+        let listed_file_metadata = self.storage.list_files(Some(partition_path)).await?;
+
+        let mut file_id_to_base_files: HashMap<String, Vec<BaseFile>> = HashMap::new();
+        let mut file_id_to_log_files: HashMap<String, Vec<LogFile>> = HashMap::new();
+
+        for file_metadata in listed_file_metadata {
+            if FileLister::should_exclude_for_listing(&file_metadata.name) {
+                continue;
+            }
+
+            let base_file_extension = format!(".{}", base_file_format);
+            if file_metadata.name.ends_with(&base_file_extension) {
+                // After excluding the unintended files,
+                // we expect a file that has the base file extension to be a valid base file.
+                let base_file = BaseFile::try_from(file_metadata)?;
+                let file_id = &base_file.file_id;
+                file_id_to_base_files
+                    .entry(file_id.to_owned())
+                    .or_default()
+                    .push(base_file);
+            } else {
+                match LogFile::try_from(file_metadata) {
+                    Ok(log_file) => {
+                        let file_id = &log_file.file_id;
+                        file_id_to_log_files
+                            .entry(file_id.to_owned())
+                            .or_default()
+                            .push(log_file);
+                    }
+                    Err(e) => {
+                        // We don't support cdc log files yet, hence skipping error when parsing
+                        // fails. However, once we support all data files, we should return error
+                        // here because we expect all files to be either base files or log files,
+                        // after excluding the unintended files.
+                        log::warn!("Failed to create a log file: {}", e);
+                        continue;
+                    }
+                }
+            }
+        }
+
+        let mut file_groups: Vec<FileGroup> = Vec::new();
+        // TODO support creating file groups without base files
+        for (file_id, base_files) in file_id_to_base_files.into_iter() {
+            let mut file_group = FileGroup::new(file_id.to_owned(), partition_path.to_string());
+
+            file_group.add_base_files(base_files)?;
+
+            let log_files = file_id_to_log_files.remove(&file_id).unwrap_or_default();
+            file_group.add_log_files(log_files)?;
+
+            file_groups.push(file_group);
+        }
+        Ok(file_groups)
+    }
+
+    async fn list_relevant_partition_paths(&self) -> Result<Vec<String>> {
+        if !is_table_partitioned(&self.hudi_configs) {
+            return Ok(vec![EMPTY_PARTITION_PATH.to_string()]);
+        }
+
+        let top_level_dirs: Vec<String> = self
+            .storage
+            .list_dirs(None)
+            .await?
+            .into_iter()
+            .filter(|dir| !LAKE_FORMAT_METADATA_DIRS.contains(&dir.as_str()))
+            .collect();
+
+        let mut partition_paths = Vec::new();
+        for dir in top_level_dirs {
+            partition_paths.extend(get_leaf_dirs(&self.storage, Some(&dir)).await?);
+        }
+
+        if partition_paths.is_empty() || self.partition_pruner.is_empty() {
+            return Ok(partition_paths);
+        }
+
+        Ok(partition_paths
+            .into_iter()
+            .filter(|path_str| self.partition_pruner.should_include(path_str))
+            .collect())
+    }
+
+    pub async fn list_file_groups_for_relevant_partitions(
+        &self,
+    ) -> Result<DashMap<String, Vec<FileGroup>>> {
+        if !is_table_partitioned(&self.hudi_configs) {
+            let file_groups = self
+                .list_file_groups_for_partition(EMPTY_PARTITION_PATH)
+                .await?;
+            let file_groups_map = DashMap::with_capacity(1);
+            file_groups_map.insert(EMPTY_PARTITION_PATH.to_string(), file_groups);
+            return Ok(file_groups_map);
+        }
+
+        let pruned_partition_paths = self.list_relevant_partition_paths().await?;
+        let file_groups_map = Arc::new(DashMap::with_capacity(pruned_partition_paths.len()));
+        let parallelism = self
+            .hudi_configs
+            .get_or_default(ListingParallelism)
+            .to::<usize>();
+        stream::iter(pruned_partition_paths)
+            .map(|p| async move {
+                let file_groups = self.list_file_groups_for_partition(&p).await?;
+                Ok::<_, CoreError>((p, file_groups))
+            })
+            .buffer_unordered(parallelism)
+            .try_for_each(|(p, file_groups)| {
+                let file_groups_map = file_groups_map.clone();
+                async move {
+                    file_groups_map.insert(p, file_groups);
+                    Ok(())
+                }
+            })
+            .await?;
+
+        Ok(file_groups_map.as_ref().to_owned())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::table::Table;
+    use hudi_tests::SampleTable;
+    use std::collections::HashSet;
+
+    #[tokio::test]
+    async fn list_partition_paths_for_nonpartitioned_table() {
+        let base_url = SampleTable::V6Nonpartitioned.url_to_cow();
+        let hudi_table = Table::new(base_url.path()).await.unwrap();
+        let lister = FileLister::new(
+            hudi_table.hudi_configs.clone(),
+            hudi_table.file_system_view.storage.clone(),
+            PartitionPruner::empty(),
+        );
+        let partition_paths = lister.list_relevant_partition_paths().await.unwrap();
+        let partition_path_set: HashSet<&str> =
+            HashSet::from_iter(partition_paths.iter().map(|p| p.as_str()));
+        assert_eq!(partition_path_set, HashSet::from([""]))
+    }
+
+    #[tokio::test]
+    async fn list_partition_paths_for_complexkeygen_table() {
+        let base_url = SampleTable::V6ComplexkeygenHivestyle.url_to_cow();
+        let hudi_table = Table::new(base_url.path()).await.unwrap();
+        let fs_view = &hudi_table.file_system_view;
+        let lister = FileLister::new(
+            fs_view.hudi_configs.clone(),
+            fs_view.storage.clone(),
+            PartitionPruner::empty(),
+        );
+        let partition_paths = lister.list_relevant_partition_paths().await.unwrap();
+        let partition_path_set: HashSet<&str> =
+            HashSet::from_iter(partition_paths.iter().map(|p| p.as_str()));
+        assert_eq!(
+            partition_path_set,
+            HashSet::from_iter(vec![
+                "byteField=10/shortField=300",
+                "byteField=20/shortField=100",
+                "byteField=30/shortField=100"
+            ])
+        )
+    }
+}

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -87,6 +87,7 @@
 
 pub mod builder;
 mod fs_view;
+mod listing;
 pub mod partition;
 
 use crate::config::read::HudiReadConfig::AsOfTimestamp;

--- a/python/src/internal.rs
+++ b/python/src/internal.rs
@@ -126,7 +126,7 @@ impl HudiFileSlice {
 #[cfg(not(tarpaulin))]
 fn convert_file_slice(f: &FileSlice) -> HudiFileSlice {
     let file_id = f.file_id().to_string();
-    let partition_path = f.partition_path().to_string();
+    let partition_path = f.partition_path.to_string();
     let creation_instant_time = f.creation_instant_time().to_string();
     let base_file_name = f.base_file.file_name();
     let file_metadata = f.base_file.file_metadata.clone().unwrap_or_default();


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

- Move file listing logic from `FileSystemView` to `FileLister`
- Change FileGroup and FileSlice partition_path to accept empty string for non-partitioned tables
- File system view will refresh relevant partitions for loading the latest file groups when a query needs to scan those
- Skip Iceberg's and Delta's metadata dirs when listing top level dirs

<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please link any related issues and PRs as well. -->

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
