### PR TITLE
chore(ci): add rust dependency caching with rust-cache action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,11 @@ jobs:
       options: --security-opt seccomp=unconfined
     steps:
       - uses: actions/checkout@v4
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
       - name: Rust unit tests with coverage report
         # https://github.com/xd009642/tarpaulin/issues/1092#issuecomment-1407739176
-        run: cargo tarpaulin --engine llvm --no-dead-code --no-fail-fast --all-features --workspace -o xml --output-dir ./cov-reports
+        run: cargo tarpaulin --engine llvm --no-dead-code --no-fail-fast --all-features --workspace -o xml --output-dir ./cov-reports --skip-clean
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Description

I made some changes to reduce the `ci.yml` time for Rust tests.

Closes https://github.com/apache/hudi-rs/issues/218

<!--- Describe your changes in detail -->

<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please link any related issues and PRs as well. -->

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [x] Manual tests
  - [x] Details are described below

The changes made are as follows:

1. Added the [Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) action.  
   This allows us to cache dependencies and build artifacts so repeated builds can skip redownloading or recompiling crates that are unchanged.

2. Added the `--skip-clean` argument to tarpaulin.  
   By default, tarpaulin behaves as if `--force-clean` is set, which deletes existing build artifacts and prevents reuse of cached builds.  
   With `--skip-clean`, the cached artifacts from `Swatinem/rust-cache` can be used before running tests.  
   (See [Tarpaulin documentation on recompilation](https://github.com/xd009642/tarpaulin?tab=readme-ov-file#recompilation) for details.)

Below are some CI logs from my fork that demonstrate how the caching works under different conditions:

- **First CI run**  
  Full build is required since there is no cache yet.  
  Once complete, a cache is stored.  
  [1. Link to the GitHub Actions log](https://github.com/K-dash/hudi-rs/actions/runs/12975643977/job/36186940166?pr=4)

- **Second CI run (minor code changes in `crates/core/src/config/error.rs` but no new dependencies)**  
  We only added a comment in the source code, so no dependencies were modified.  
  This means the cached artifacts are still valid and the test build is fast.  
  [2. Link to the GitHub Actions log](https://github.com/K-dash/hudi-rs/actions/runs/12975754396/job/36187193216?pr=4)

- **Third CI run (added a new dependency in `python/Cargo.toml`)**  
  The `python` crate is rebuilt, but other crates (`core`, `hudi`, etc.) remain cached.  
  [3. Link to the GitHub Actions log](https://github.com/K-dash/hudi-rs/actions/runs/12975802004/job/36187298925?pr=4)

Please review these changes and let me know if you have any questions.
