### PR TITLE
fix: handle as-of timestamp for excluding file groups

### DIFF
--- a/crates/core/src/timeline/mod.rs
+++ b/crates/core/src/timeline/mod.rs
@@ -181,9 +181,16 @@ impl Timeline {
         }
     }
 
-    pub async fn get_replaced_file_groups(&self) -> Result<HashSet<FileGroup>> {
+    pub async fn get_replaced_file_groups_as_of(
+        &self,
+        timestamp: &str,
+    ) -> Result<HashSet<FileGroup>> {
         let mut file_groups: HashSet<FileGroup> = HashSet::new();
-        let selector = TimelineSelector::completed_replacecommits(self.hudi_configs.clone());
+        let selector = TimelineSelector::completed_replacecommits_in_range(
+            self.hudi_configs.clone(),
+            None,
+            Some(timestamp),
+        )?;
         for instant in selector.select(self)? {
             let commit_metadata = self.get_commit_metadata(&instant).await?;
             file_groups.extend(build_replaced_file_groups(&commit_metadata)?);


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

When getting excluding file groups, it should consider the as-of timestamp if provided.

<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please link any related issues and PRs as well. -->

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
