### PR TITLE
feat: add APIs to support incremental query impl

### DIFF
--- a/crates/core/src/file_group/file_slice.rs
+++ b/crates/core/src/file_group/file_slice.rs
@@ -42,6 +42,11 @@ impl FileSlice {
         }
     }
 
+    #[inline]
+    pub fn has_log_file(&self) -> bool {
+        !self.log_files.is_empty()
+    }
+
     fn relative_path_for_file(&self, file_name: &str) -> Result<String> {
         let path = PathBuf::from(self.partition_path.as_str()).join(file_name);
         path.to_str().map(|s| s.to_string()).ok_or_else(|| {

--- a/crates/core/src/file_group/reader.rs
+++ b/crates/core/src/file_group/reader.rs
@@ -16,81 +16,122 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+use crate::config::read::HudiReadConfig;
 use crate::config::table::HudiTableConfig;
 use crate::config::util::split_hudi_options_from_others;
 use crate::config::HudiConfigs;
 use crate::error::CoreError::ReadFileSliceError;
 use crate::expr::filter::{Filter, SchemableFilter};
 use crate::file_group::file_slice::FileSlice;
-use crate::storage::Storage;
-use crate::Result;
-use arrow::compute::and;
-use arrow_array::{BooleanArray, RecordBatch};
-use arrow_schema::Schema;
-use futures::TryFutureExt;
-use std::sync::Arc;
-
 use crate::file_group::log_file::scanner::LogFileScanner;
 use crate::merge::record_merger::RecordMerger;
+use crate::metadata::meta_field::MetaField;
+use crate::storage::Storage;
 use crate::timeline::selector::InstantRange;
+use crate::Result;
+use arrow::compute::and;
 use arrow::compute::filter_record_batch;
+use arrow_array::{BooleanArray, RecordBatch};
+use futures::TryFutureExt;
+use std::convert::TryFrom;
+use std::sync::Arc;
 
-/// File group reader handles all read operations against a file group.
+/// The reader that handles all read operations against a file group.
 #[derive(Clone, Debug)]
 pub struct FileGroupReader {
     hudi_configs: Arc<HudiConfigs>,
     storage: Arc<Storage>,
-    and_filters: Vec<SchemableFilter>,
 }
 
 impl FileGroupReader {
-    pub(crate) fn new(hudi_configs: Arc<HudiConfigs>, storage: Arc<Storage>) -> Self {
-        Self {
-            storage,
-            hudi_configs,
-            and_filters: Vec::new(),
-        }
-    }
-
-    pub(crate) fn new_with_filters(
-        storage: Arc<Storage>,
+    pub(crate) fn new_with_configs_and_options<I, K, V>(
         hudi_configs: Arc<HudiConfigs>,
-        and_filters: &[Filter],
-        schema: &Schema,
-    ) -> Result<Self> {
-        let and_filters = and_filters
-            .iter()
-            .map(|filter| SchemableFilter::try_from((filter.clone(), schema)))
-            .collect::<Result<Vec<SchemableFilter>>>()?;
+        options: I,
+    ) -> Result<Self>
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<str>,
+        V: Into<String>,
+    {
+        let (hudi_opts, others) = split_hudi_options_from_others(options);
+
+        let mut final_opts = hudi_configs.as_options();
+        final_opts.extend(hudi_opts);
+        let hudi_configs = Arc::new(HudiConfigs::new(final_opts));
+        let storage = Storage::new(Arc::new(others), hudi_configs.clone())?;
 
         Ok(Self {
-            storage,
             hudi_configs,
-            and_filters,
+            storage,
         })
     }
 
+    /// Creates a new reader with the given base URI and options.
+    ///
+    /// # Arguments
+    ///     * `base_uri` - The base URI of the file group's residing table.
+    ///     * `options` - Additional options for the reader.
     pub fn new_with_options<I, K, V>(base_uri: &str, options: I) -> Result<Self>
     where
         I: IntoIterator<Item = (K, V)>,
         K: AsRef<str>,
         V: Into<String>,
     {
-        let (mut hudi_opts, others) = split_hudi_options_from_others(options);
-        hudi_opts.insert(
+        let hudi_configs = Arc::new(HudiConfigs::new([(
             HudiTableConfig::BasePath.as_ref().to_string(),
             base_uri.to_string(),
-        );
+        )]));
 
-        let hudi_configs = Arc::new(HudiConfigs::new(hudi_opts));
-
-        let storage = Storage::new(Arc::new(others), hudi_configs.clone())?;
-        Ok(Self::new(hudi_configs, storage))
+        Self::new_with_configs_and_options(hudi_configs, options)
     }
 
-    fn create_boolean_array_mask(&self, records: &RecordBatch) -> Result<BooleanArray> {
+    fn create_filtering_mask_for_base_file_records(
+        &self,
+        records: &RecordBatch,
+    ) -> Result<Option<BooleanArray>> {
+        let populates_meta_fields = self
+            .hudi_configs
+            .get_or_default(HudiTableConfig::PopulatesMetaFields)
+            .to::<bool>();
+        if !populates_meta_fields {
+            // If meta fields are not populated, commit time filtering is not applicable.
+            return Ok(None);
+        }
+
+        let mut and_filters: Vec<SchemableFilter> = Vec::new();
+        let schema = MetaField::schema();
+        if let Some(start) = self
+            .hudi_configs
+            .try_get(HudiReadConfig::FileGroupStartTimestamp)
+            .map(|v| v.to::<String>())
+        {
+            let filter: Filter =
+                Filter::try_from((MetaField::CommitTime.as_ref(), ">", start.as_str()))?;
+            let filter = SchemableFilter::try_from((filter, schema.as_ref()))?;
+            and_filters.push(filter);
+        } else {
+            // If start timestamp is not provided, the query is snapshot or time-travel, so
+            // commit time filtering is not needed as the base file being read is already
+            // filtered and selected by the timeline.
+            return Ok(None);
+        }
+
+        if let Some(end) = self
+            .hudi_configs
+            .try_get(HudiReadConfig::FileGroupEndTimestamp)
+            .map(|v| v.to::<String>())
+        {
+            let filter = Filter::try_from((MetaField::CommitTime.as_ref(), "<=", end.as_str()))?;
+            let filter = SchemableFilter::try_from((filter, schema.as_ref()))?;
+            and_filters.push(filter);
+        }
+
+        if and_filters.is_empty() {
+            return Ok(None);
+        }
+
         let mut mask = BooleanArray::from(vec![true; records.num_rows()]);
-        for filter in &self.and_filters {
+        for filter in &and_filters {
             let col_name = filter.field.name().as_str();
             let col_values = records
                 .column_by_name(col_name)
@@ -99,9 +140,16 @@ impl FileGroupReader {
             let comparison = filter.apply_comparsion(col_values)?;
             mask = and(&mask, &comparison)?;
         }
-        Ok(mask)
+        Ok(Some(mask))
     }
 
+    /// Reads the data from the base file at the given relative path.
+    ///
+    /// # Arguments
+    ///     * `relative_path` - The relative path to the base file.
+    ///
+    /// # Returns
+    /// A record batch read from the base file.
     pub async fn read_file_slice_by_base_file_path(
         &self,
         relative_path: &str,
@@ -112,22 +160,44 @@ impl FileGroupReader {
             .map_err(|e| ReadFileSliceError(format!("Failed to read path {relative_path}: {e:?}")))
             .await?;
 
-        if self.and_filters.is_empty() {
-            return Ok(records);
+        if let Some(mask) = self.create_filtering_mask_for_base_file_records(&records)? {
+            filter_record_batch(&records, &mask)
+                .map_err(|e| ReadFileSliceError(format!("Failed to filter records: {e:?}")))
+        } else {
+            Ok(records)
         }
-
-        let mask = self.create_boolean_array_mask(&records)?;
-        filter_record_batch(&records, &mask)
-            .map_err(|e| ReadFileSliceError(format!("Failed to filter records: {e:?}")))
     }
 
-    pub(crate) async fn read_file_slice(
-        &self,
-        file_slice: &FileSlice,
-        base_file_only: bool,
-        instant_range: InstantRange,
-    ) -> Result<RecordBatch> {
+    fn create_instant_range_for_log_file_scan(&self) -> InstantRange {
+        let timezone = self
+            .hudi_configs
+            .get_or_default(HudiTableConfig::TimelineTimezone)
+            .to::<String>();
+        let start_timestamp = self
+            .hudi_configs
+            .try_get(HudiReadConfig::FileGroupStartTimestamp)
+            .map(|v| v.to::<String>());
+        let end_timestamp = self
+            .hudi_configs
+            .try_get(HudiReadConfig::FileGroupEndTimestamp)
+            .map(|v| v.to::<String>());
+        InstantRange::new(timezone, start_timestamp, end_timestamp, false, true)
+    }
+
+    /// Reads the data from the given file slice.
+    ///
+    /// # Arguments
+    ///     * `file_slice` - The file slice to read.
+    ///
+    /// # Returns
+    /// A record batch read from the file slice.
+    pub async fn read_file_slice(&self, file_slice: &FileSlice) -> Result<RecordBatch> {
         let relative_path = file_slice.base_file_relative_path()?;
+        let base_file_only = !file_slice.has_log_file()
+            || self
+                .hudi_configs
+                .get_or_default(HudiReadConfig::UseReadOptimizedMode)
+                .to::<bool>();
         if base_file_only {
             self.read_file_slice_by_base_file_path(&relative_path).await
         } else {
@@ -142,6 +212,7 @@ impl FileGroupReader {
                 .iter()
                 .map(|log_file| file_slice.log_file_relative_path(log_file))
                 .collect::<Result<Vec<String>>>()?;
+            let instant_range = self.create_instant_range_for_log_file_scan();
             let log_record_batches =
                 LogFileScanner::new(self.hudi_configs.clone(), self.storage.clone())
                     .scan(log_file_paths, &instant_range)
@@ -159,71 +230,12 @@ impl FileGroupReader {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::util::empty_options;
     use crate::error::CoreError;
-    use crate::expr::filter::FilterField;
     use arrow::array::{ArrayRef, Int64Array, StringArray};
     use arrow::record_batch::RecordBatch;
     use arrow_schema::{DataType, Field, Schema};
     use std::sync::Arc;
-    use url::Url;
-
-    #[test]
-    fn test_new() {
-        let base_url = Url::parse("file:///tmp/hudi_data").unwrap();
-        let storage = Storage::new_with_base_url(base_url).unwrap();
-        let fg_reader = FileGroupReader::new(Arc::from(HudiConfigs::empty()), storage.clone());
-        assert!(Arc::ptr_eq(&fg_reader.storage, &storage));
-    }
-
-    fn create_test_schema() -> Schema {
-        Schema::new(vec![
-            Field::new("_hoodie_commit_time", DataType::Utf8, false),
-            Field::new("name", DataType::Utf8, false),
-            Field::new("age", DataType::Int64, false),
-        ])
-    }
-
-    #[tokio::test]
-    async fn test_new_with_filters() -> Result<()> {
-        let base_url = Url::parse("file:///tmp/hudi_data").unwrap();
-        let storage = Storage::new_with_base_url(base_url)?;
-        let schema = create_test_schema();
-        let empty_configs = Arc::new(HudiConfigs::empty());
-
-        // Test case 1: Empty filters
-        let reader = FileGroupReader::new_with_filters(
-            storage.clone(),
-            empty_configs.clone(),
-            &[],
-            &schema,
-        )?;
-        assert!(reader.and_filters.is_empty());
-
-        // Test case 2: Multiple filters
-        let filters = vec![
-            FilterField::new("_hoodie_commit_time").gt("0"),
-            FilterField::new("age").gte("18"),
-        ];
-        let reader = FileGroupReader::new_with_filters(
-            storage.clone(),
-            empty_configs.clone(),
-            &filters,
-            &schema,
-        )?;
-        assert_eq!(reader.and_filters.len(), 2);
-
-        // Test case 3: Invalid field name should error
-        let invalid_filters = vec![FilterField::new("non_existent_field").eq("value")];
-        assert!(FileGroupReader::new_with_filters(
-            storage.clone(),
-            empty_configs.clone(),
-            &invalid_filters,
-            &schema
-        )
-        .is_err());
-
-        Ok(())
-    }
 
     #[test]
     fn test_new_with_options() -> Result<()> {
@@ -239,11 +251,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_read_file_slice_returns_error() {
-        let storage =
-            Storage::new_with_base_url(Url::parse("file:///non-existent-path/table").unwrap())
+        let reader =
+            FileGroupReader::new_with_options("file:///non-existent-path/table", empty_options())
                 .unwrap();
-        let empty_configs = Arc::new(HudiConfigs::empty());
-        let reader = FileGroupReader::new(empty_configs.clone(), storage);
         let result = reader
             .read_file_slice_by_base_file_path("non_existent_file")
             .await;
@@ -251,7 +261,12 @@ mod tests {
     }
 
     fn create_test_record_batch() -> Result<RecordBatch> {
-        let schema = Arc::new(create_test_schema());
+        let schema = Schema::new(vec![
+            Field::new("_hoodie_commit_time", DataType::Utf8, false),
+            Field::new("name", DataType::Utf8, false),
+            Field::new("age", DataType::Int64, false),
+        ]);
+        let schema = Arc::new(schema);
 
         let commit_times: ArrayRef = Arc::new(StringArray::from(vec!["1", "2", "3", "4", "5"]));
         let names: ArrayRef = Arc::new(StringArray::from(vec![
@@ -263,66 +278,59 @@ mod tests {
     }
 
     #[test]
-    fn test_create_boolean_array_mask() -> Result<()> {
-        let storage =
-            Storage::new_with_base_url(Url::parse("file:///non-existent-path/table").unwrap())?;
-        let empty_configs = Arc::new(HudiConfigs::empty());
-        let schema = create_test_schema();
+    fn test_create_filtering_mask_for_base_file_records() -> Result<()> {
+        let base_uri = "file:///non-existent-path/table";
         let records = create_test_record_batch()?;
-
-        // Test case 1: No filters
-        let reader = FileGroupReader::new_with_filters(
-            storage.clone(),
-            empty_configs.clone(),
-            &[],
-            &schema,
+        // Test case 1: No meta fields populated
+        let reader = FileGroupReader::new_with_options(
+            base_uri,
+            [
+                (HudiTableConfig::PopulatesMetaFields.as_ref(), "false"),
+                (HudiReadConfig::FileGroupStartTimestamp.as_ref(), "2"),
+            ],
         )?;
-        let mask = reader.create_boolean_array_mask(&records)?;
-        assert_eq!(mask, BooleanArray::from(vec![true; 5]));
+        let mask = reader.create_filtering_mask_for_base_file_records(&records)?;
+        assert_eq!(mask, None, "Commit time filtering should not be needed");
 
-        // Test case 2: Single filter on commit time
-        let filters = vec![FilterField::new("_hoodie_commit_time").gt("2")];
-        let reader = FileGroupReader::new_with_filters(
-            storage.clone(),
-            empty_configs.clone(),
-            &filters,
-            &schema,
+        // Test case 2: No commit time filtering options
+        let reader = FileGroupReader::new_with_options(base_uri, empty_options())?;
+        let mask = reader.create_filtering_mask_for_base_file_records(&records)?;
+        assert_eq!(mask, None);
+
+        // Test case 3: Filtering commit time > '2'
+        let reader = FileGroupReader::new_with_options(
+            base_uri,
+            [(HudiReadConfig::FileGroupStartTimestamp, "2")],
         )?;
-        let mask = reader.create_boolean_array_mask(&records)?;
+        let mask = reader.create_filtering_mask_for_base_file_records(&records)?;
         assert_eq!(
             mask,
-            BooleanArray::from(vec![false, false, true, true, true]),
+            Some(BooleanArray::from(vec![false, false, true, true, true])),
             "Expected only records with commit_time > '2'"
         );
 
-        // Test case 3: Multiple AND filters
-        let filters = vec![
-            FilterField::new("_hoodie_commit_time").gt("2"),
-            FilterField::new("age").lt("40"),
-        ];
-        let reader = FileGroupReader::new_with_filters(
-            storage.clone(),
-            empty_configs.clone(),
-            &filters,
-            &schema,
+        // Test case 4: Filtering commit time <= '4'
+        let reader = FileGroupReader::new_with_options(
+            base_uri,
+            [(HudiReadConfig::FileGroupEndTimestamp, "4")],
         )?;
-        let mask = reader.create_boolean_array_mask(&records)?;
+        let mask = reader.create_filtering_mask_for_base_file_records(&records)?;
+        assert_eq!(mask, None, "Commit time filtering should not be needed");
+
+        // Test case 5: Filtering commit time > '2' and <= '4'
+        let reader = FileGroupReader::new_with_options(
+            base_uri,
+            [
+                (HudiReadConfig::FileGroupStartTimestamp, "2"),
+                (HudiReadConfig::FileGroupEndTimestamp, "4"),
+            ],
+        )?;
+        let mask = reader.create_filtering_mask_for_base_file_records(&records)?;
         assert_eq!(
             mask,
-            BooleanArray::from(vec![false, false, true, false, false]),
-            "Expected only record with commit_time > '2' AND age < 40"
+            Some(BooleanArray::from(vec![false, false, true, true, false])),
+            "Expected only records with commit_time > '2' and <= '4'"
         );
-
-        // Test case 4: Filter resulting in all false
-        let filters = vec![FilterField::new("age").gt("100")];
-        let reader = FileGroupReader::new_with_filters(
-            storage.clone(),
-            empty_configs.clone(),
-            &filters,
-            &schema,
-        )?;
-        let mask = reader.create_boolean_array_mask(&records)?;
-        assert_eq!(mask, BooleanArray::from(vec![false; 5]));
 
         Ok(())
     }

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -844,7 +844,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn hudi_table_get_file_slices_splits_as_of() {
+    async fn hudi_table_get_file_slices_splits_as_of_timestamps() {
         let base_url = SampleTable::V6SimplekeygenNonhivestyleOverwritetable.url_to_mor();
         let hudi_table = Table::new(base_url.path()).await.unwrap();
 
@@ -951,6 +951,29 @@ mod tests {
                 .collect::<Vec<_>>(),
             Vec::<String>::new()
         );
+    }
+
+    #[tokio::test]
+    async fn empty_hudi_table_get_file_slices_between_timestamps() {
+        let base_url = SampleTable::V6Empty.url_to_cow();
+        let hudi_table = Table::new(base_url.path()).await.unwrap();
+        let file_slices = hudi_table
+            .get_file_slices_between(Some(EARLIEST_START_TIMESTAMP), None)
+            .await
+            .unwrap();
+        assert!(file_slices.is_empty())
+    }
+
+    #[tokio::test]
+    async fn hudi_table_get_file_slices_between_timestamps() {
+        let base_url = SampleTable::V6SimplekeygenNonhivestyleOverwritetable.url_to_mor();
+        let hudi_table = Table::new(base_url.path()).await.unwrap();
+        let file_slices = hudi_table
+            .get_file_slices_between(None, Some("20250121000656060"))
+            .await
+            .unwrap();
+        assert_eq!(file_slices.len(), 3);
+        // TODO: Add more assertions
     }
 
     #[tokio::test]

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -369,7 +369,17 @@ impl Table {
         K: AsRef<str>,
         V: Into<String>,
     {
-        FileGroupReader::new_with_configs_and_options(self.hudi_configs.clone(), options)
+        let mut overwriting_options = HashMap::with_capacity(self.storage_options.len());
+        for (k, v) in self.storage_options.iter() {
+            overwriting_options.insert(k.clone(), v.clone());
+        }
+        for (k, v) in options {
+            overwriting_options.insert(k.as_ref().to_string(), v.into());
+        }
+        FileGroupReader::new_with_configs_and_options(
+            self.hudi_configs.clone(),
+            overwriting_options,
+        )
     }
 
     /// Get all the latest records in the table.

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -99,7 +99,7 @@ use crate::file_group::reader::FileGroupReader;
 use crate::table::builder::TableBuilder;
 use crate::table::fs_view::FileSystemView;
 use crate::table::partition::PartitionPruner;
-use crate::timeline::{Timeline, DEFAULT_START_TIMESTAMP};
+use crate::timeline::{Timeline, EARLIEST_START_TIMESTAMP};
 use crate::Result;
 
 use crate::config::read::HudiReadConfig;
@@ -335,7 +335,7 @@ impl Table {
             return Ok(Vec::new());
         };
 
-        let start = start_timestamp.unwrap_or(DEFAULT_START_TIMESTAMP);
+        let start = start_timestamp.unwrap_or(EARLIEST_START_TIMESTAMP);
 
         self.get_file_slices_between_internal(start, end).await
     }

--- a/crates/core/src/timeline/mod.rs
+++ b/crates/core/src/timeline/mod.rs
@@ -45,9 +45,11 @@ pub struct Timeline {
     pub completed_commits: Vec<Instant>,
 }
 
+pub const DEFAULT_START_TIMESTAMP: &str = "19700101000000000";
+
 impl Timeline {
     #[cfg(test)]
-    pub async fn new_from_completed_commits(
+    pub(crate) async fn new_from_completed_commits(
         hudi_configs: Arc<HudiConfigs>,
         storage_options: Arc<HashMap<String, String>>,
         completed_commits: Vec<Instant>,
@@ -60,7 +62,7 @@ impl Timeline {
         })
     }
 
-    pub async fn new_from_storage(
+    pub(crate) async fn new_from_storage(
         hudi_configs: Arc<HudiConfigs>,
         storage_options: Arc<HashMap<String, String>>,
     ) -> Result<Self> {
@@ -104,7 +106,7 @@ impl Timeline {
         Ok(instants)
     }
 
-    pub fn get_latest_commit_timestamp(&self) -> Option<&str> {
+    pub(crate) fn get_latest_commit_timestamp(&self) -> Option<&str> {
         self.completed_commits
             .iter()
             .next_back()
@@ -126,7 +128,7 @@ impl Timeline {
             .map_err(|e| CoreError::Timeline(format!("Failed to get commit metadata: {}", e)))
     }
 
-    pub async fn get_latest_schema(&self) -> Result<Schema> {
+    pub(crate) async fn get_latest_schema(&self) -> Result<Schema> {
         let commit_metadata = self.get_latest_commit_metadata().await?;
 
         let first_partition = commit_metadata
@@ -181,7 +183,7 @@ impl Timeline {
         }
     }
 
-    pub async fn get_replaced_file_groups_as_of(
+    pub(crate) async fn get_replaced_file_groups_as_of(
         &self,
         timestamp: &str,
     ) -> Result<HashSet<FileGroup>> {
@@ -203,7 +205,7 @@ impl Timeline {
 
     /// Get file groups in the timeline ranging from start (exclusive) to end (inclusive).
     /// File groups are as of the [end] timestamp or the latest if not given.
-    pub async fn get_incremental_file_groups(
+    pub(crate) async fn get_file_groups_between(
         &self,
         start_timestamp: Option<&str>,
         end_timestamp: Option<&str>,

--- a/crates/core/src/timeline/mod.rs
+++ b/crates/core/src/timeline/mod.rs
@@ -45,7 +45,7 @@ pub struct Timeline {
     pub completed_commits: Vec<Instant>,
 }
 
-pub const DEFAULT_START_TIMESTAMP: &str = "19700101000000000";
+pub const EARLIEST_START_TIMESTAMP: &str = "19700101000000000";
 
 impl Timeline {
     #[cfg(test)]

--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -67,7 +67,7 @@ use hudi_core::util::StrTupleRef;
 /// // Create a new HudiDataSource with specific read options
 /// let hudi = HudiDataSource::new_with_options(
 ///     "/tmp/trips_table",
-///     [("hoodie.read.as.of.timestamp", "20241122010827898")]).await?;
+///     [("hoodie.read.input.partitions", 5)]).await?;
 ///
 /// // Register the Hudi table with the session context
 /// ctx.register_table("trips_table", Arc::new(hudi))?;

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -75,8 +75,10 @@ def test_read_table_can_read_from_batches(get_sample_table):
 
     file_slices = table.get_file_slices()
     file_slice_paths = [f.base_file_relative_path() for f in file_slices]
-    batch = table.create_file_group_reader().read_file_slice_by_base_file_path(
-        file_slice_paths[0]
+    batch = (
+        table.create_file_group_reader_with_options().read_file_slice_by_base_file_path(
+            file_slice_paths[0]
+        )
     )
     t = pa.Table.from_batches([batch])
     assert t.num_rows == 1


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

- Add new table API `get_file_slices_between()` to support reading incremental file slices for engine integration
- Add time range configs for file group reader to support filtering records and log file scanning
  - `hoodie.read.file_group.start_timestamp`
  - `hoodie.read.file_group.end_timestamp` 
- Remove `hoodie.read.as.of.timestamp` from configs in favor of passing time travel timestamp via API
- Refactor the table APIs impl to provide clearer flow of reading file slices
  - Push down the logic of checking base file only and composing instant range to file group reader
- Add the corresponding Python APIs

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #271

<!--- Please link any related issues and PRs as well. -->

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
