### PR TITLE
fix: build up incremental file groups

### DIFF
--- a/crates/core/src/file_group/base_file.rs
+++ b/crates/core/src/file_group/base_file.rs
@@ -88,6 +88,14 @@ impl BaseFile {
     }
 }
 
+impl PartialEq for BaseFile {
+    fn eq(&self, other: &Self) -> bool {
+        self.file_name() == other.file_name()
+    }
+}
+
+impl Eq for BaseFile {}
+
 impl FromStr for BaseFile {
     type Err = CoreError;
 

--- a/crates/core/src/file_group/base_file.rs
+++ b/crates/core/src/file_group/base_file.rs
@@ -19,6 +19,7 @@
 use crate::error::CoreError;
 use crate::storage::file_metadata::FileMetadata;
 use crate::Result;
+use std::fmt::Display;
 use std::str::FromStr;
 
 /// Hudi Base file, part of a [FileSlice].
@@ -85,6 +86,12 @@ impl BaseFile {
             commit_timestamp = self.commit_timestamp,
             extension = self.extension,
         )
+    }
+}
+
+impl Display for BaseFile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "BaseFile: {}", self.file_name())
     }
 }
 

--- a/crates/core/src/file_group/file_slice.rs
+++ b/crates/core/src/file_group/file_slice.rs
@@ -33,6 +33,14 @@ pub struct FileSlice {
     pub partition_path: String,
 }
 
+impl PartialEq for FileSlice {
+    fn eq(&self, other: &Self) -> bool {
+        self.base_file == other.base_file && self.partition_path == other.partition_path
+    }
+}
+
+impl Eq for FileSlice {}
+
 impl FileSlice {
     pub fn new(base_file: BaseFile, partition_path: String) -> Self {
         Self {
@@ -45,6 +53,17 @@ impl FileSlice {
     #[inline]
     pub fn has_log_file(&self) -> bool {
         !self.log_files.is_empty()
+    }
+
+    pub fn merge(&mut self, other: &FileSlice) -> Result<()> {
+        if self != other {
+            return Err(CoreError::FileGroup(
+                "Cannot merge different file slices.".to_string(),
+            ));
+        }
+        self.log_files.extend(other.log_files.iter().cloned());
+
+        Ok(())
     }
 
     fn relative_path_for_file(&self, file_name: &str) -> Result<String> {

--- a/crates/core/src/file_group/file_slice.rs
+++ b/crates/core/src/file_group/file_slice.rs
@@ -38,8 +38,8 @@ impl Display for FileSlice {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "FileSlice {{ base_file: {}, partition_path: {} }}",
-            self.base_file, self.partition_path
+            "FileSlice {{ base_file: {}, log_files: {:?}, partition_path: {} }}",
+            self.base_file, self.log_files, self.partition_path
         )
     }
 }

--- a/crates/core/src/file_group/log_file/mod.rs
+++ b/crates/core/src/file_group/log_file/mod.rs
@@ -179,6 +179,13 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_log_file_name_in_formatted_str() {
+        let filename = ".54e9a5e9-ee5d-4ed2-acee-720b5810d380-0_20250109233025121.log.1_0-51-115";
+        let log_file = LogFile::from_str(filename).unwrap();
+        assert!(format!("{}", log_file).contains(filename));
+    }
+
+    #[test]
     fn test_valid_filename_parsing() {
         let filename = ".54e9a5e9-ee5d-4ed2-acee-720b5810d380-0_20250109233025121.log.1_0-51-115";
         let log_file = LogFile::from_str(filename).unwrap();

--- a/crates/core/src/file_group/log_file/mod.rs
+++ b/crates/core/src/file_group/log_file/mod.rs
@@ -20,6 +20,7 @@ use crate::error::CoreError;
 use crate::storage::file_metadata::FileMetadata;
 use crate::Result;
 use std::cmp::Ordering;
+use std::fmt::Display;
 use std::str::FromStr;
 
 mod log_block;
@@ -139,6 +140,12 @@ impl TryFrom<FileMetadata> for LogFile {
             write_token,
             file_metadata: Some(metadata),
         })
+    }
+}
+
+impl Display for LogFile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "LogFile: {}", self.file_name())
     }
 }
 

--- a/crates/core/src/file_group/mod.rs
+++ b/crates/core/src/file_group/mod.rs
@@ -97,6 +97,26 @@ impl FileGroup {
         Ok(file_group)
     }
 
+    pub fn merge(&mut self, other: &FileGroup) -> Result<()> {
+        if self != other {
+            return Err(CoreError::FileGroup(format!(
+                "Cannot merge FileGroup with different file groups. Existing: {}, New: {}",
+                self, other
+            )));
+        }
+
+        for (commit_timestamp, other_file_slice) in other.file_slices.iter() {
+            if let Some(existing_file_slice) = self.file_slices.get_mut(commit_timestamp) {
+                existing_file_slice.merge(other_file_slice)?;
+            } else {
+                self.file_slices
+                    .insert(commit_timestamp.clone(), other_file_slice.clone());
+            }
+        }
+
+        Ok(())
+    }
+
     /// Add a [BaseFile] based on the file name to the corresponding [FileSlice] in the [FileGroup].
     pub fn add_base_file_from_name(&mut self, file_name: &str) -> Result<&Self> {
         let base_file = BaseFile::from_str(file_name)?;

--- a/crates/core/src/file_group/mod.rs
+++ b/crates/core/src/file_group/mod.rs
@@ -100,8 +100,7 @@ impl FileGroup {
     pub fn merge(&mut self, other: &FileGroup) -> Result<()> {
         if self != other {
             return Err(CoreError::FileGroup(format!(
-                "Cannot merge FileGroup with different file groups. Existing: {}, New: {}",
-                self, other
+                "Cannot merge different file groups: {self} and {other}",
             )));
         }
 

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -978,12 +978,37 @@ mod tests {
     async fn hudi_table_get_file_slices_between_timestamps() {
         let base_url = SampleTable::V6SimplekeygenNonhivestyleOverwritetable.url_to_mor();
         let hudi_table = Table::new(base_url.path()).await.unwrap();
-        let file_slices = hudi_table
+        let mut file_slices = hudi_table
             .get_file_slices_between(None, Some("20250121000656060"))
             .await
             .unwrap();
         assert_eq!(file_slices.len(), 3);
-        // TODO: Add more assertions
+
+        file_slices.sort_unstable_by_key(|f| f.partition_path.clone());
+
+        let file_slice_0 = &file_slices[0];
+        assert_eq!(file_slice_0.partition_path, "10");
+        assert_eq!(
+            file_slice_0.file_id(),
+            "92e64357-e4d1-4639-a9d3-c3535829d0aa-0"
+        );
+        assert_eq!(file_slice_0.log_files.len(), 1);
+
+        let file_slice_1 = &file_slices[1];
+        assert_eq!(file_slice_1.partition_path, "20");
+        assert_eq!(
+            file_slice_1.file_id(),
+            "d49ae379-4f20-4549-8e23-a5f9604412c0-0"
+        );
+        assert!(file_slice_1.log_files.is_empty());
+
+        let file_slice_2 = &file_slices[2];
+        assert_eq!(file_slice_2.partition_path, "30");
+        assert_eq!(
+            file_slice_2.file_id(),
+            "de3550df-e12c-4591-9335-92ff992258a2-0"
+        );
+        assert!(file_slice_2.log_files.is_empty());
     }
 
     #[tokio::test]

--- a/crates/core/src/timeline/mod.rs
+++ b/crates/core/src/timeline/mod.rs
@@ -21,7 +21,7 @@ pub(crate) mod selector;
 
 use crate::config::HudiConfigs;
 use crate::error::CoreError;
-use crate::file_group::builder::{build_file_groups, build_replaced_file_groups};
+use crate::file_group::builder::{build_file_groups, build_replaced_file_groups, FileGroupMerger};
 use crate::file_group::FileGroup;
 use crate::storage::Storage;
 use crate::timeline::selector::TimelineSelector;
@@ -220,7 +220,7 @@ impl Timeline {
         let commits = selector.select(self)?;
         for commit in commits {
             let commit_metadata = self.get_commit_metadata(&commit).await?;
-            file_groups.extend(build_file_groups(&commit_metadata)?);
+            file_groups.merge(build_file_groups(&commit_metadata)?)?;
 
             if commit.is_replacecommit() {
                 replaced_file_groups.extend(build_replaced_file_groups(&commit_metadata)?);


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

When incrementally fetch changed file groups from commit metadata, the same file groups should be merged such that all relevant log files are included.

<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please link any related issues and PRs as well. -->

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
