### PR TITLE
feat: iso8601 support in Time-travel & Incremental API

### DIFF
--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -241,8 +241,9 @@ impl Table {
         timestamp: &str,
         filters: &[(&str, &str, &str)],
     ) -> Result<Vec<Vec<FileSlice>>> {
+        let timestamp = format_timestamp(timestamp);
         let filters = from_str_tuples(filters)?;
-        self.get_file_slices_splits_internal(n, timestamp, &filters)
+        self.get_file_slices_splits_internal(n, &timestamp, &filters)
             .await
     }
 
@@ -295,8 +296,9 @@ impl Table {
         timestamp: &str,
         filters: &[(&str, &str, &str)],
     ) -> Result<Vec<FileSlice>> {
+        let timestamp = format_timestamp(timestamp);
         let filters = from_str_tuples(filters)?;
-        self.get_file_slices_internal(timestamp, &filters).await
+        self.get_file_slices_internal(&timestamp, &filters).await
     }
 
     async fn get_file_slices_internal(
@@ -406,8 +408,9 @@ impl Table {
         timestamp: &str,
         filters: &[(&str, &str, &str)],
     ) -> Result<Vec<RecordBatch>> {
+        let timestamp = format_timestamp(timestamp);
         let filters = from_str_tuples(filters)?;
-        self.read_snapshot_internal(timestamp, &filters).await
+        self.read_snapshot_internal(&timestamp, &filters).await
     }
 
     async fn read_snapshot_internal(
@@ -489,7 +492,6 @@ impl Table {
 ///
 /// # Returns
 /// A string formatted as `yyyyMMddHHmmSSSSS`. If the input cannot be parsed, the original string is returned.
-///
 fn format_timestamp(timestamp: &str) -> String {
     if let Ok(datetime) = DateTime::parse_from_rfc3339(timestamp) {
         return datetime.format("%Y%m%d%H%M%S%3f").to_string();

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -496,7 +496,7 @@ fn format_timestamp(timestamp: &str) -> String {
     if let Ok(datetime) = DateTime::parse_from_rfc3339(timestamp) {
         return datetime.format("%Y%m%d%H%M%S%3f").to_string();
     }
-    
+
     let formats = ["yyyyMMddHHmmSSSSS", "yyyyMMddHHmmSS"];
     for format in formats.iter() {
         if let Ok(datetime) = DateTime::parse_from_str(timestamp, format) {
@@ -507,7 +507,7 @@ fn format_timestamp(timestamp: &str) -> String {
     if timestamp.len() == 10 && timestamp.chars().all(|c| c.is_digit(10) || c == '-') {
         return format!("{}000000000", timestamp.replace("-", ""));
     }
-    
+
     timestamp.to_string()
 }
 


### PR DESCRIPTION
## Description

Added support for ISO8601 time format as described in issues, and overwrote other `*as_of()` methods in the same module.

closes #261

## How are the changes test-covered

- [ ] N/A
- [ ] Automated tests (unit and/or integration tests)
- [x] Manual tests
  - [ ] Details are described below
