### PR TITLE
fix: make local timezone test more robust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         os: [ ubuntu-22.04 ]
     runs-on: ${{ matrix.os }}
     container:
-      image: xd009642/tarpaulin:0.32.3
+      image: xd009642/tarpaulin:0.32.3-slim
       options: --security-opt seccomp=unconfined
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         os: [ ubuntu-22.04 ]
     runs-on: ${{ matrix.os }}
     container:
-      image: xd009642/tarpaulin:0.32.3
+      image: xd009642/tarpaulin:0.31.5
       options: --security-opt seccomp=unconfined
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         os: [ ubuntu-22.04 ]
     runs-on: ${{ matrix.os }}
     container:
-      image: xd009642/tarpaulin:0.32.3-slim
+      image: xd009642/tarpaulin:0.32.3
       options: --security-opt seccomp=unconfined
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         os: [ ubuntu-22.04 ]
     runs-on: ${{ matrix.os }}
     container:
-      image: xd009642/tarpaulin:0.31.5
+      image: xd009642/tarpaulin:0.32.3
       options: --security-opt seccomp=unconfined
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ serde_json = { version = "1.0" }
 # "stdlib"
 thiserror = { version = "2.0.11" }
 bytes = { version = "1" }
-chrono = { version = "0.4" }
+chrono = { version = "0.4.39" }
 lazy_static = { version = "1.5.0" }
 log = { version = "0.4" }
 paste = { version = "1.0.15" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ serde_json = { version = "1.0" }
 # "stdlib"
 thiserror = { version = "2.0.11" }
 bytes = { version = "1" }
-chrono = { version = "0.4.39" }
+chrono = { version = "0.4.38" }
 lazy_static = { version = "1.5.0" }
 log = { version = "0.4" }
 paste = { version = "1.0.15" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ serde_json = { version = "1.0" }
 # "stdlib"
 thiserror = { version = "2.0.11" }
 bytes = { version = "1" }
-chrono = { version = "0.4.38" }
+chrono = { version = "=0.4.39" }
 lazy_static = { version = "1.5.0" }
 log = { version = "0.4" }
 paste = { version = "1.0.15" }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

When DST changes, the test case is affected due to using `Local::now()`. Fixed the timezone to ensure consistent test expectation.

Also fixed the patch version for chrono due to https://www.reddit.com/r/rust/comments/1iz0py1/crate_build_is_broken_by_chrono_and_arrowarinth/

<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please link any related issues and PRs as well. -->

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
