### PR TITLE
refactor: use `OptionResolver` to handle options

### DIFF
--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -91,6 +91,7 @@ pub mod builder;
 mod fs_view;
 mod listing;
 pub mod partition;
+mod validation;
 
 use crate::config::read::HudiReadConfig;
 use crate::config::table::HudiTableConfig::PartitionFields;

--- a/crates/core/src/table/validation.rs
+++ b/crates/core/src/table/validation.rs
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+use crate::config::internal::HudiInternalConfig::SkipConfigValidation;
+use crate::config::read::HudiReadConfig;
+use crate::config::table::HudiTableConfig;
+use crate::config::table::HudiTableConfig::{
+    DropsPartitionFields, TableVersion, TimelineLayoutVersion,
+};
+use crate::config::HudiConfigs;
+use crate::error::CoreError;
+use crate::merge::record_merger::RecordMerger;
+use strum::IntoEnumIterator;
+
+pub fn validate_configs(hudi_configs: &HudiConfigs) -> crate::error::Result<()> {
+    if hudi_configs
+        .get_or_default(SkipConfigValidation)
+        .to::<bool>()
+    {
+        return Ok(());
+    }
+
+    for conf in HudiTableConfig::iter() {
+        hudi_configs.validate(conf)?
+    }
+
+    for conf in HudiReadConfig::iter() {
+        hudi_configs.validate(conf)?
+    }
+
+    // additional validation
+    let table_version = hudi_configs.get(TableVersion)?.to::<isize>();
+    if !(5..=6).contains(&table_version) {
+        return Err(CoreError::Unsupported(
+            "Only support table version 5 and 6.".to_string(),
+        ));
+    }
+
+    let timeline_layout_version = hudi_configs.get(TimelineLayoutVersion)?.to::<isize>();
+    if timeline_layout_version != 1 {
+        return Err(CoreError::Unsupported(
+            "Only support timeline layout version 1.".to_string(),
+        ));
+    }
+
+    let drops_partition_cols = hudi_configs
+        .get_or_default(DropsPartitionFields)
+        .to::<bool>();
+    if drops_partition_cols {
+        return Err(CoreError::Unsupported(format!(
+            "Only support when `{}` is disabled",
+            DropsPartitionFields.as_ref()
+        )));
+    }
+
+    RecordMerger::validate_configs(hudi_configs)?;
+
+    Ok(())
+}

--- a/crates/core/src/util/collection.rs
+++ b/crates/core/src/util/collection.rs
@@ -16,5 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-pub mod arrow;
-pub mod collection;
+use std::collections::HashMap;
+use std::hash::Hash;
+
+pub fn extend_if_absent<K, V>(target: &mut HashMap<K, V>, source: &HashMap<K, V>)
+where
+    K: Eq + Hash + Clone,
+    V: Clone,
+{
+    for (key, value) in source {
+        target.entry(key.clone()).or_insert_with(|| value.clone());
+    }
+}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Add `OptionResolver` to handle resolving options during table instance creation. The logic can be re-used for creating file group reader.

<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please link any related issues and PRs as well. -->

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
