### PR TITLE
chore(ci): replace archived actions-rs actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,19 +51,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - run: |
+           rustup toolchain add --profile=minimal stable
+           rustup override set stable
 
       - name: cargo publish
-        uses: actions-rs/cargo@v1
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        with:
-          command: publish
-          args: -p ${{ matrix.package }} --all-features
+        run: |
+          cargo publish -p ${{ matrix.package }} --all-features
 
   release-pypi-mac:
     name: PyPI release on Mac


### PR DESCRIPTION
The actions-rs org has been archived for years at this point and it doesn't look like it's coming back. For security reasons we are going to remove it from the list of allowed actions in the org soon. (See https://github.com/apache/infrastructure-actions)
