### PR TITLE
build(deps): update dep versions to only allow patch version upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,28 +36,28 @@ repository = "https://github.com/apache/hudi-rs"
 
 [workspace.dependencies]
 # arrow
-arrow = { version = "~54.1.0", features = ["pyarrow"] }
-arrow-arith = { version = "~54.1.0" }
-arrow-array = { version = "~54.1.0" }
-arrow-buffer = { version = "~54.1.0" }
-arrow-cast = { version = "~54.1.0" }
-arrow-ipc = { version = "~54.1.0" }
-arrow-json = { version = "~54.1.0" }
-arrow-ord = { version = "~54.1.0" }
-arrow-row = { version = "~54.1.0" }
-arrow-schema = { version = "~54.1.0", features = ["serde"] }
-arrow-select = { version = "~54.1.0" }
-object_store = { version = "~0.11.2", features = ["aws", "azure", "gcp"] }
-parquet = { version = "~54.1.0", features = ["async", "object_store"] }
+arrow = { version = "~54", features = ["pyarrow"] }
+arrow-arith = { version = "~54" }
+arrow-array = { version = "~54" }
+arrow-buffer = { version = "~54" }
+arrow-cast = { version = "~54" }
+arrow-ipc = { version = "~54" }
+arrow-json = { version = "~54" }
+arrow-ord = { version = "~54" }
+arrow-row = { version = "~54" }
+arrow-schema = { version = "~54", features = ["serde"] }
+arrow-select = { version = "~54" }
+object_store = { version = "~0.11", features = ["aws", "azure", "gcp"] }
+parquet = { version = "~54", features = ["async", "object_store"] }
 
 # avro
-apache-avro = { version = "0.17.0" }
+apache-avro = { version = "~0.17" }
 
 # datafusion
-datafusion = { version = "~45.0.0" }
-datafusion-expr = { version = "~45.0.0" }
-datafusion-common = { version = "~45.0.0" }
-datafusion-physical-expr = { version = "~45.0.0" }
+datafusion = { version = "~45.0" }
+datafusion-expr = { version = "~45.0" }
+datafusion-common = { version = "~45.0" }
+datafusion-physical-expr = { version = "~45.0" }
 
 # serde
 percent-encoding = { version = "2.3.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ repository = "https://github.com/apache/hudi-rs"
 
 [workspace.dependencies]
 # arrow
-arrow = { version = "~54", features = ["pyarrow"] }
+arrow = { version = "~54" }
 arrow-arith = { version = "~54" }
 arrow-array = { version = "~54" }
 arrow-buffer = { version = "~54" }
@@ -60,26 +60,26 @@ datafusion-common = { version = "~45.0" }
 datafusion-physical-expr = { version = "~45.0" }
 
 # serde
-percent-encoding = { version = "2.3.1" }
+percent-encoding = { version = "2.3" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 
 # "stdlib"
-thiserror = { version = "2.0.11" }
+thiserror = { version = "2.0" }
 bytes = { version = "1" }
-chrono = { version = "=0.4.39" }
-lazy_static = { version = "1.5.0" }
+chrono = { version = "0.4" }
+lazy_static = { version = "1.5" }
 log = { version = "0.4" }
 num-traits = { version = "0.2" }
-once_cell = { version = "1.21.3" }
-paste = { version = "1.0.15" }
-strum = { version = "0.27.0", features = ["derive"] }
-strum_macros = "0.27.0"
+once_cell = { version = "1.21" }
+paste = { version = "1.0" }
+strum = { version = "0.27", features = ["derive"] }
+strum_macros = "0.27"
 url = { version = "2.5" }
 
 # runtime / async
-async-recursion = { version = "1.1.1" }
+async-recursion = { version = "1.1" }
 async-trait = { version = "0.1" }
 dashmap = { version = "6.1" }
 futures = { version = "0.3" }
-tokio = { version = "1", features = ["rt-multi-thread"] }
+tokio = { version = "1.45", features = ["rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,19 +36,19 @@ repository = "https://github.com/apache/hudi-rs"
 
 [workspace.dependencies]
 # arrow
-arrow = { version = "~54" }
-arrow-arith = { version = "~54" }
-arrow-array = { version = "~54" }
-arrow-buffer = { version = "~54" }
-arrow-cast = { version = "~54" }
-arrow-ipc = { version = "~54" }
-arrow-json = { version = "~54" }
-arrow-ord = { version = "~54" }
-arrow-row = { version = "~54" }
-arrow-schema = { version = "~54", features = ["serde"] }
-arrow-select = { version = "~54" }
+arrow = { version = "~54.3" }
+arrow-arith = { version = "~54.3" }
+arrow-array = { version = "~54.3" }
+arrow-buffer = { version = "~54.3" }
+arrow-cast = { version = "~54.3" }
+arrow-ipc = { version = "~54.3" }
+arrow-json = { version = "~54.3" }
+arrow-ord = { version = "~54.3" }
+arrow-row = { version = "~54.3" }
+arrow-schema = { version = "~54.3", features = ["serde"] }
+arrow-select = { version = "~54.3" }
 object_store = { version = "~0.11", features = ["aws", "azure", "gcp"] }
-parquet = { version = "~54", features = ["async", "object_store"] }
+parquet = { version = "~54.3", features = ["async", "object_store"] }
 
 # avro
 apache-avro = { version = "~0.17" }
@@ -60,26 +60,26 @@ datafusion-common = { version = "~45.0" }
 datafusion-physical-expr = { version = "~45.0" }
 
 # serde
-percent-encoding = { version = "2.3" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0" }
+percent-encoding = { version = "~2.3" }
+serde = { version = "~1.0", features = ["derive"] }
+serde_json = { version = "~1.0" }
 
 # "stdlib"
-thiserror = { version = "2.0" }
-bytes = { version = "1" }
-chrono = { version = "0.4" }
-lazy_static = { version = "1.5" }
-log = { version = "0.4" }
-num-traits = { version = "0.2" }
-once_cell = { version = "1.21" }
-paste = { version = "1.0" }
-strum = { version = "0.27", features = ["derive"] }
-strum_macros = "0.27"
-url = { version = "2.5" }
+thiserror = { version = "~2.0" }
+bytes = { version = "~1.10" }
+chrono = { version = "~0.4" }
+lazy_static = { version = "~1.5" }
+log = { version = "~0.4" }
+num-traits = { version = "~0.2" }
+once_cell = { version = "~1.21" }
+paste = { version = "~1.0" }
+strum = { version = "~0.27", features = ["derive"] }
+strum_macros = "~0.27"
+url = { version = "~2.5" }
 
 # runtime / async
-async-recursion = { version = "1.1" }
-async-trait = { version = "0.1" }
-dashmap = { version = "6.1" }
-futures = { version = "0.3" }
-tokio = { version = "1.45", features = ["rt-multi-thread"] }
+async-recursion = { version = "~1.1" }
+async-trait = { version = "~0.1" }
+dashmap = { version = "~6.1" }
+futures = { version = "~0.3" }
+tokio = { version = "~1.45", features = ["rt-multi-thread"] }

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -38,5 +38,5 @@ strum_macros = { workspace = true }
 url = { workspace = true }
 
 # testing
-tempfile = "3"
-zip-extract = "0.3"
+tempfile = "~3.20"
+zip-extract = "~0.3"

--- a/demo/apps/datafusion/Cargo.toml
+++ b/demo/apps/datafusion/Cargo.toml
@@ -25,5 +25,5 @@ edition = "2021"
 
 [dependencies]
 tokio = "^1"
-datafusion = "~45.0.0"
+datafusion = "~45.0"
 hudi = { path = "../../../crates/hudi", features = ["datafusion"] }

--- a/demo/apps/hudi-table-api/rust/Cargo.toml
+++ b/demo/apps/hudi-table-api/rust/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tokio = "^1"
-arrow = { version = "~54.1.0", features = ["pyarrow"] }
+tokio = "~1.45"
+arrow = { version = "~54.3" }
 
 hudi = { path = "../../../../crates/hudi" }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -35,7 +35,7 @@ doc = false
 [dependencies]
 hudi = { path = "../crates/hudi" }
 # arrow
-arrow = { workspace = true }
+arrow = { workspace = true, features = ["pyarrow"] }
 
 # "stdlib"
 thiserror = { workspace = true }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Only patch versions (the z in x.y.z) can be automatically upgraded.

<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please link any related issues and PRs as well. -->

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
