### PR TITLE
build(deps): upgrade datafusion arrow, and restrict deps upgrade to patch-level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,50 +36,50 @@ repository = "https://github.com/apache/hudi-rs"
 
 [workspace.dependencies]
 # arrow
-arrow = { version = "~54.1.0", features = ["pyarrow"] }
-arrow-arith = { version = "~54.1.0" }
-arrow-array = { version = "~54.1.0" }
-arrow-buffer = { version = "~54.1.0" }
-arrow-cast = { version = "~54.1.0" }
-arrow-ipc = { version = "~54.1.0" }
-arrow-json = { version = "~54.1.0" }
-arrow-ord = { version = "~54.1.0" }
-arrow-row = { version = "~54.1.0" }
-arrow-schema = { version = "~54.1.0", features = ["serde"] }
-arrow-select = { version = "~54.1.0" }
+arrow = { version = "~54.2.0"}
+arrow-arith = { version = "~54.2.0" }
+arrow-array = { version = "~54.2.0" }
+arrow-buffer = { version = "~54.2.0" }
+arrow-cast = { version = "~54.2.0" }
+arrow-ipc = { version = "~54.2.0" }
+arrow-json = { version = "~54.2.0" }
+arrow-ord = { version = "~54.2.0" }
+arrow-row = { version = "~54.2.0" }
+arrow-schema = { version = "~54.2.0", features = ["serde"] }
+arrow-select = { version = "~54.2.0" }
 object_store = { version = "~0.11.2", features = ["aws", "azure", "gcp"] }
-parquet = { version = "~54.1.0", features = ["async", "object_store"] }
+parquet = { version = "~54.2.0", features = ["async", "object_store"] }
 
 # avro
-apache-avro = { version = "0.17.0" }
+apache-avro = { version = "~0.17.0" }
 
 # datafusion
-datafusion = { version = "~45.0.0" }
-datafusion-expr = { version = "~45.0.0" }
-datafusion-common = { version = "~45.0.0" }
-datafusion-physical-expr = { version = "~45.0.0" }
+datafusion = { version = "~46.0.0" }
+datafusion-expr = { version = "~46.0.0" }
+datafusion-common = { version = "~46.0.0" }
+datafusion-physical-expr = { version = "~46.0.0" }
 
 # serde
-percent-encoding = { version = "2.3.1" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0" }
+percent-encoding = { version = "~2.3.1" }
+serde = { version = "~1.0", features = ["derive"] }
+serde_json = { version = "~1.0" }
 
 # "stdlib"
-thiserror = { version = "2.0.11" }
-bytes = { version = "1" }
+thiserror = { version = "~2.0.11" }
+bytes = { version = "~1.10" }
 chrono = { version = "=0.4.39" }
-lazy_static = { version = "1.5.0" }
-log = { version = "0.4" }
-num-traits = { version = "0.2" }
-once_cell = { version = "1.21.3" }
-paste = { version = "1.0.15" }
-strum = { version = "0.27.0", features = ["derive"] }
-strum_macros = "0.27.0"
-url = { version = "2.5" }
+lazy_static = { version = "~1.5.0" }
+log = { version = "~0.4" }
+num-traits = { version = "~0.2" }
+once_cell = { version = "~1.21.3" }
+paste = { version = "~1.0.15" }
+strum = { version = "~0.27.0", features = ["derive"] }
+strum_macros = "~0.27.0"
+url = { version = "~2.5.4" }
 
 # runtime / async
-async-recursion = { version = "1.1.1" }
-async-trait = { version = "0.1" }
-dashmap = { version = "6.1" }
-futures = { version = "0.3" }
-tokio = { version = "1", features = ["rt-multi-thread"] }
+async-recursion = { version = "~1.1.1" }
+async-trait = { version = "~0.1" }
+dashmap = { version = "~6.1" }
+futures = { version = "~0.3" }
+tokio = { version = "~1.45", features = ["rt-multi-thread"] }

--- a/crates/core/src/avro_to_arrow/README.md
+++ b/crates/core/src/avro_to_arrow/README.md
@@ -19,7 +19,7 @@
 
 > [!NOTE]
 > This module is taken
-> from [Apache DataFusion](https://github.com/apache/datafusion/tree/45.0.0/datafusion/core/src/datasource/avro_to_arrow)
+> from [Apache DataFusion](https://github.com/apache/datafusion/tree/46.0.1/datafusion/core/src/datasource/avro_to_arrow)
 > and modified to work with Hudi Avro log block. The original code is licensed under the Apache License, Version 2.0.
 
 ## Notable Changes

--- a/crates/core/src/table/partition.rs
+++ b/crates/core/src/table/partition.rs
@@ -63,10 +63,10 @@ impl PartitionPruner {
         partition_schema: &Schema,
         hudi_configs: &HudiConfigs,
     ) -> Result<Self> {
-        let and_filters = and_filters
+        let and_filters: Vec<SchemableFilter> = and_filters
             .iter()
-            .map(|filter| SchemableFilter::try_from((filter.clone(), partition_schema)))
-            .collect::<Result<Vec<SchemableFilter>>>()?;
+            .filter_map(|filter| SchemableFilter::try_from((filter.clone(), partition_schema)).ok())
+            .collect();
 
         let schema = Arc::new(partition_schema.clone());
         let is_hive_style: bool = hudi_configs

--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -471,7 +471,7 @@ mod tests {
             table_name
         )));
         assert!(plan_lines[4].starts_with(
-            "FilterExec: CAST(id@0 AS Int64) % 2 = 0 AND get_field(structField@3, field2) > 30"
+            "FilterExec: CAST(id@0 AS Int64) % 2 = 0 AND name@1 != Alice AND get_field(structField@3, field2) > 30"
         ));
         assert!(plan_lines[5].contains(&format!("input_partitions={}", planned_input_partitioned)));
     }
@@ -490,7 +490,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_datafusion_read_hudi_table() {
+    async fn test_datafusion_read_hudi_table_with_partition_filter_pushdown() {
         for (test_table, use_sql, planned_input_partitions) in &[
             (V6ComplexkeygenHivestyle, true, 2),
             (V6Nonpartitioned, true, 1),
@@ -507,7 +507,7 @@ mod tests {
             let sql = format!(
                 r#"
             SELECT id, name, isActive, structField.field2
-            FROM {} WHERE id % 2 = 0
+            FROM {} WHERE id % 2 = 0 AND name != 'Alice'
             AND structField.field2 > 30 ORDER BY name LIMIT 10"#,
                 test_table.as_ref()
             );
@@ -531,7 +531,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_datafusion_read_hudi_table_with_replacecommits() {
+    async fn test_datafusion_read_hudi_table_with_replacecommits_with_partition_filter_pushdown() {
         for (test_table, use_sql, planned_input_partitions) in
             &[(V6SimplekeygenNonhivestyleOverwritetable, true, 1)]
         {
@@ -544,7 +544,7 @@ mod tests {
             let sql = format!(
                 r#"
             SELECT id, name, isActive, structField.field2
-            FROM {} WHERE id % 2 = 0
+            FROM {} WHERE id % 2 = 0 AND name != 'Alice'
             AND structField.field2 > 30 ORDER BY name LIMIT 10"#,
                 test_table.as_ref()
             );

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -38,5 +38,5 @@ strum_macros = { workspace = true }
 url = { workspace = true }
 
 # testing
-tempfile = "3"
-zip-extract = "0.3"
+tempfile = "3.20.0"
+zip-extract = "0.3.0"

--- a/demo/apps/datafusion/Cargo.toml
+++ b/demo/apps/datafusion/Cargo.toml
@@ -24,6 +24,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tokio = "^1"
-datafusion = "~45.0.0"
+tokio = "~1.45"
+datafusion = "~46.0.0"
 hudi = { path = "../../../crates/hudi", features = ["datafusion"] }

--- a/demo/apps/hudi-table-api/rust/Cargo.toml
+++ b/demo/apps/hudi-table-api/rust/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tokio = "^1"
-arrow = { version = "~54.1.0", features = ["pyarrow"] }
+tokio = "~1.45"
+arrow = { version = "~54.2.0" }
 
 hudi = { path = "../../../../crates/hudi" }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -35,7 +35,7 @@ doc = false
 [dependencies]
 hudi = { path = "../crates/hudi" }
 # arrow
-arrow = { workspace = true }
+arrow = { workspace = true, features = ["pyarrow"] }
 
 # "stdlib"
 thiserror = { workspace = true }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

DataFusion 45.0 -> 46.0
Arrow 54.1 -> 54.2

Fix DataFusion API usage based on the new version. Update test cases to cover filter pushdown.


<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please link any related issues and PRs as well. -->

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
