### PR TITLE
feat: support picking up storage options from `HOODIE_ENV_` env vars

### DIFF
--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -57,8 +57,7 @@ pub struct Storage {
 }
 
 impl Storage {
-    pub const CLOUD_STORAGE_PREFIXES: [&'static str; 4] =
-        ["AWS_", "AZURE_", "GOOGLE_", "HOODIE_ENV_"];
+    pub const CLOUD_STORAGE_PREFIXES: [&'static str; 3] = ["AWS_", "AZURE_", "GOOGLE_"];
 
     pub fn new(
         options: Arc<HashMap<String, String>>,


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Add support for Hudi-style AWS environment variables following the format documented in https://hudi.apache.org/docs/next/s3_hoodie.

<!--- If it fixes an open issue, please link to the issue here. -->
closes #374 
<!--- Please link any related issues and PRs as well. -->

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
