### PR TITLE
feat: add `get_file_slices_splits_between` API

### DIFF
--- a/crates/core/src/util/collection.rs
+++ b/crates/core/src/util/collection.rs
@@ -28,3 +28,22 @@ where
         target.entry(key.clone()).or_insert_with(|| value.clone());
     }
 }
+
+/// Split a vector into approximately equal chunks based on the specified number of splits.
+///
+/// # Arguments
+/// * `items` - The vector to split
+/// * `num_splits` - The desired number of chunks (will be clamped to at least 1)
+pub fn split_into_chunks<T: Clone>(items: Vec<T>, num_splits: usize) -> Vec<Vec<T>> {
+    if items.is_empty() {
+        return Vec::new();
+    }
+
+    let n = std::cmp::max(1, num_splits);
+    let chunk_size = items.len().div_ceil(n);
+
+    items
+        .chunks(chunk_size)
+        .map(|chunk| chunk.to_vec())
+        .collect()
+}

--- a/crates/core/src/util/collection.rs
+++ b/crates/core/src/util/collection.rs
@@ -47,3 +47,42 @@ pub fn split_into_chunks<T: Clone>(items: Vec<T>, num_splits: usize) -> Vec<Vec<
         .map(|chunk| chunk.to_vec())
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_split_into_chunks_zero_splits() {
+        let items = vec![1, 2, 3, 4, 5];
+        let result = split_into_chunks(items.clone(), 0);
+        assert_eq!(result.len(), 1, "Zero splits should be clamped to 1");
+        assert_eq!(result[0], items, "All items should be in single chunk");
+    }
+
+    #[test]
+    fn test_split_into_chunks_empty_input() {
+        let items: Vec<i32> = vec![];
+        let result = split_into_chunks(items, 2);
+        assert!(result.is_empty(), "Empty input should return empty result");
+    }
+
+    #[test]
+    fn test_split_into_chunks_more_splits_than_items() {
+        let items = vec![1, 2, 3];
+        let result = split_into_chunks(items, 5);
+        assert_eq!(result.len(), 3, "Should return 3 chunks (one per item)");
+        assert_eq!(result[0], vec![1]);
+        assert_eq!(result[1], vec![2]);
+        assert_eq!(result[2], vec![3]);
+    }
+
+    #[test]
+    fn test_split_into_chunks_normal_case() {
+        let items = vec![1, 2, 3, 4, 5];
+        let result = split_into_chunks(items, 2);
+        assert_eq!(result.len(), 2, "Should return 2 chunks");
+        assert_eq!(result[0], vec![1, 2, 3], "First chunk should have 3 items");
+        assert_eq!(result[1], vec![4, 5], "Second chunk should have 2 items");
+    }
+}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Add `get_file_slices_splits_between()` API, enables parallel processing of incremental data changes between timestamps.
<!--- If it fixes an open issue, please link to the issue here. -->
closes #403
<!--- Please link any related issues and PRs as well. -->

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
