### PR TITLE
feat: expose datafusion custom table provider to python

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ datafusion = { version = "~46.0.0" }
 datafusion-expr = { version = "~46.0.0" }
 datafusion-common = { version = "~46.0.0" }
 datafusion-physical-expr = { version = "~46.0.0" }
+datafusion-ffi = { version = "~46.0.0" }
 
 # serde
 percent-encoding = { version = "~2.3.1" }

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Update `src/main.rs` with the code snippet below then `cargo run`.
 
 </details>
 
+#### Rust
 ```rust
 use std::sync::Arc;
 
@@ -293,6 +294,19 @@ async fn main() -> Result<()> {
     df.show().await?;
     Ok(())
 }
+```
+
+#### Python
+```python
+    from datafusion import SessionContext
+    from hudi import HudiDataSource
+
+    table = HudiDataSource(
+        "/tmp/trips_table", [("hoodie.read.use.read_optimized.mode", "true")]
+    )
+    ctx = SessionContext()
+    ctx.register_table_provider("trips", table)
+    ctx.sql("SELECT  max(fare), city from trips group by city order by 1 desc").show()
 ```
 
 ### Other Integrations

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -33,9 +33,12 @@ crate-type = ["cdylib"]
 doc = false
 
 [dependencies]
-hudi = { path = "../crates/hudi" }
+hudi = { path = "../crates/hudi", features = ["datafusion"]}
 # arrow
 arrow = { workspace = true, features = ["pyarrow"] }
+
+datafusion = { workspace = true }
+datafusion-ffi = { workspace = true }
 
 # "stdlib"
 thiserror = { workspace = true }

--- a/python/hudi/__init__.py
+++ b/python/hudi/__init__.py
@@ -17,6 +17,7 @@
 
 
 from hudi._internal import (
+    HudiDataSource,
     HudiFileGroupReader,
     HudiFileSlice,
     HudiInstant,
@@ -27,6 +28,7 @@ from hudi._internal import __version__ as __version__
 from hudi.table.builder import HudiTableBuilder
 
 __all__ = [
+    "HudiDataSource",
     "HudiFileGroupReader",
     "HudiFileSlice",
     "HudiInstant",

--- a/python/hudi/_internal.pyi
+++ b/python/hudi/_internal.pyi
@@ -349,3 +349,18 @@ def build_hudi_table(
         HudiTable: An instance of hudi table.
     """
     ...
+@dataclass(init=False)
+class HudiDataSource:
+    def __init__(
+        self,
+        base_uri: str,
+        options: Optional[List[Tuple[str, str]]] = None,
+    ):
+        """
+        Initializes the HudiDataSource.
+
+        Parameters:
+            base_uri (str): The base URI of the Hudi table.
+            options (Optional[List[Tuple[str, str]]]): Additional configuration options (optional).
+        """
+        ...

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
 dependencies = [
     "pyarrow>=11.0.0",
     "pyarrow-hotfix",
+    "datafusion==46.0.0",
 ]
 
 dynamic = ["version"]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -25,12 +25,15 @@ mod internal;
 fn _internal(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
 
-    use internal::{HudiFileGroupReader, HudiFileSlice, HudiInstant, HudiTable, HudiTimeline};
+    use internal::{
+        HudiDataSource, HudiFileGroupReader, HudiFileSlice, HudiInstant, HudiTable, HudiTimeline,
+    };
     m.add_class::<HudiFileGroupReader>()?;
     m.add_class::<HudiFileSlice>()?;
     m.add_class::<HudiInstant>()?;
     m.add_class::<HudiTable>()?;
     m.add_class::<HudiTimeline>()?;
+    m.add_class::<HudiDataSource>()?;
 
     use internal::build_hudi_table;
     m.add_function(wrap_pyfunction!(build_hudi_table, m)?)?;

--- a/python/tests/test_datafusion_read.py
+++ b/python/tests/test_datafusion_read.py
@@ -1,0 +1,15 @@
+from datafusion import SessionContext
+
+from hudi import HudiDataSource
+
+
+def test_datafusion_table_registry(get_sample_table):
+    table_path = get_sample_table
+
+    table = HudiDataSource(
+        table_path, [("hoodie.read.use.read_optimized.mode", "true")]
+    )
+    ctx = SessionContext()
+    ctx.register_table_provider("trips", table)
+    df = ctx.sql("SELECT  city from trips order by city desc limit 1").to_arrow_table()
+    assert df.to_pylist() == [{"city": "sao_paulo"}]


### PR DESCRIPTION
## Description

This work seeks to expose the existing datafusion datasource to the python api, with the goal of being able to use dafusion in python hudi-rs. To implement this we leverage datafusion FFI custom table provider as mentioned in this [doc](https://github.com/apache/datafusion-python/blob/main/docs/source/user-guide/io/table_provider.rst). 

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
