### PR TITLE
refactor: rename variable names in splitting table APIs

### DIFF
--- a/crates/core/src/util/collection.rs
+++ b/crates/core/src/util/collection.rs
@@ -40,7 +40,7 @@ pub fn split_into_chunks<T: Clone>(items: Vec<T>, num_splits: usize) -> Vec<Vec<
     }
 
     let num_splits = std::cmp::max(1, num_splits);
-    let chunk_size = items.len().div_ceil(splits);
+    let chunk_size = items.len().div_ceil(num_splits);
 
     items
         .chunks(chunk_size)

--- a/crates/core/src/util/collection.rs
+++ b/crates/core/src/util/collection.rs
@@ -39,8 +39,8 @@ pub fn split_into_chunks<T: Clone>(items: Vec<T>, num_splits: usize) -> Vec<Vec<
         return Vec::new();
     }
 
-    let n = std::cmp::max(1, num_splits);
-    let chunk_size = items.len().div_ceil(n);
+    let splits = std::cmp::max(1, num_splits);
+    let chunk_size = items.len().div_ceil(splits);
 
     items
         .chunks(chunk_size)

--- a/crates/core/src/util/collection.rs
+++ b/crates/core/src/util/collection.rs
@@ -39,7 +39,7 @@ pub fn split_into_chunks<T: Clone>(items: Vec<T>, num_splits: usize) -> Vec<Vec<
         return Vec::new();
     }
 
-    let splits = std::cmp::max(1, num_splits);
+    let num_splits = std::cmp::max(1, num_splits);
     let chunk_size = items.len().div_ceil(splits);
 
     items

--- a/python/hudi/_internal.pyi
+++ b/python/hudi/_internal.pyi
@@ -237,7 +237,10 @@ class HudiTable:
         """
         ...
     def get_file_slices_splits_as_of(
-        self, num_splits: int, timestamp: str, filters: Optional[List[Tuple[str, str, str]]]
+        self,
+        num_splits: int,
+        timestamp: str,
+        filters: Optional[List[Tuple[str, str, str]]],
     ) -> List[List[HudiFileSlice]]:
         """
         Retrieves all file slices in the Hudi table as of a timestamp in 'num_splits' splits, optionally filtered by given filters.

--- a/python/hudi/_internal.pyi
+++ b/python/hudi/_internal.pyi
@@ -223,13 +223,13 @@ class HudiTable:
         """
         ...
     def get_file_slices_splits(
-        self, n: int, filters: Optional[List[Tuple[str, str, str]]]
+        self, num_splits: int, filters: Optional[List[Tuple[str, str, str]]]
     ) -> List[List[HudiFileSlice]]:
         """
-        Retrieves all file slices in the Hudi table in 'n' splits, optionally filtered by given filters.
+        Retrieves all file slices in the Hudi table in 'num_splits' splits, optionally filtered by given filters.
 
         Parameters:
-            n (int): The number of parts to split the file slices into.
+            num_splits (int): The number of parts to split the file slices into.
             filters (Optional[List[Tuple[str, str, str]]]): Optional filters for selecting file slices.
 
         Returns:
@@ -237,10 +237,10 @@ class HudiTable:
         """
         ...
     def get_file_slices_splits_as_of(
-        self, n: int, timestamp: str, filters: Optional[List[Tuple[str, str, str]]]
+        self, num_splits: int, timestamp: str, filters: Optional[List[Tuple[str, str, str]]]
     ) -> List[List[HudiFileSlice]]:
         """
-        Retrieves all file slices in the Hudi table as of a timestamp in 'n' splits, optionally filtered by given filters.
+        Retrieves all file slices in the Hudi table as of a timestamp in 'num_splits' splits, optionally filtered by given filters.
         """
         ...
     def get_file_slices(

--- a/python/src/internal.rs
+++ b/python/src/internal.rs
@@ -330,10 +330,10 @@ impl HudiTable {
         })
     }
 
-    #[pyo3(signature = (n, filters=None))]
+    #[pyo3(signature = (num_splits, filters=None))]
     fn get_file_slices_splits(
         &self,
-        n: usize,
+        num_splits: usize,
         filters: Option<Vec<(String, String, String)>>,
         py: Python,
     ) -> PyResult<Vec<Vec<HudiFileSlice>>> {
@@ -341,7 +341,7 @@ impl HudiTable {
             let file_slices = rt()
                 .block_on(
                     self.inner
-                        .get_file_slices_splits(n, filters.unwrap_or_default()),
+                        .get_file_slices_splits(num_splits, filters.unwrap_or_default()),
                 )
                 .map_err(PythonError::from)?;
             Ok(file_slices
@@ -351,10 +351,10 @@ impl HudiTable {
         })
     }
 
-    #[pyo3(signature = (n, timestamp, filters=None))]
+    #[pyo3(signature = (num_splits, timestamp, filters=None))]
     fn get_file_slices_splits_as_of(
         &self,
-        n: usize,
+        num_splits: usize,
         timestamp: &str,
         filters: Option<Vec<(String, String, String)>>,
         py: Python,
@@ -362,7 +362,7 @@ impl HudiTable {
         py.allow_threads(|| {
             let file_slices = rt()
                 .block_on(self.inner.get_file_slices_splits_as_of(
-                    n,
+                    num_splits,
                     timestamp,
                     filters.unwrap_or_default(),
                 ))


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Rename parameter `n` to `num_splits` in all file slice splitting APIs for better readability.
<!--- If it fixes an open issue, please link to the issue here. -->
fixes: #423 
<!--- Please link any related issues and PRs as well. -->

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
