### PR TITLE
feat: adopt stream pattern for file slices operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ url = { version = "~2.5.4" }
 
 # runtime / async
 async-recursion = { version = "~1.1.1" }
+async-stream = { version = "~0.3" }
 async-trait = { version = "~0.1" }
 dashmap = { version = "~6.1" }
 futures = { version = "~0.3" }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -65,6 +65,7 @@ url = { workspace = true }
 
 # runtime / async
 async-recursion = { workspace = true }
+async-stream = { workspace = true }
 dashmap = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
- Add non-cloning utility `split_into_chunks_by_moving()` for better memory efficiency
- Introduce streaming APIs for lazy FileSlice consumption
<!--- If it fixes an open issue, please link to the issue here. -->
fixes: #367 
<!--- Please link any related issues and PRs as well. -->

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
