### PR TITLE
feat: add query type enum for unified table query operations

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -64,3 +64,5 @@ pub mod timeline;
 pub mod util;
 
 use error::Result;
+
+pub use crate::table::query::QueryType;

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -92,6 +92,7 @@ pub mod file_pruner;
 pub(crate) mod fs_view;
 mod listing;
 pub mod partition;
+pub mod query;
 mod read_options;
 mod validation;
 

--- a/crates/core/src/table/query.rs
+++ b/crates/core/src/table/query.rs
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+//! Standardized query types for Hudi table read operations.
+
+use std::str::FromStr;
+use strum_macros::AsRefStr;
+
+use crate::config::error::ConfigError;
+use crate::config::error::ConfigError::InvalidValue;
+
+/// The kind of read query a caller intends to perform against a Hudi table.
+///
+/// Use this enum to communicate intent across API boundaries; the timestamps
+/// associated with time-travel or incremental reads are passed as separate
+/// parameters to the corresponding [`crate::table::Table`] read APIs.
+#[derive(Clone, Debug, PartialEq, AsRefStr)]
+pub enum QueryType {
+    /// Read the latest committed records, optionally as of a given timestamp
+    /// (time-travel) when supported by the caller's API.
+    #[strum(serialize = "snapshot")]
+    Snapshot,
+    /// Read only the base files, skipping unmerged log files. Applicable to
+    /// Merge-on-Read tables.
+    #[strum(serialize = "read_optimized")]
+    ReadOptimized,
+    /// Read only the records inserted or updated within a given time range.
+    #[strum(serialize = "incremental")]
+    Incremental,
+}
+
+impl FromStr for QueryType {
+    type Err = ConfigError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "snapshot" => Ok(Self::Snapshot),
+            "read_optimized" | "read-optimized" => Ok(Self::ReadOptimized),
+            "incremental" => Ok(Self::Incremental),
+            v => Err(InvalidValue(v.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn as_ref_returns_canonical_string() {
+        assert_eq!(QueryType::Snapshot.as_ref(), "snapshot");
+        assert_eq!(QueryType::ReadOptimized.as_ref(), "read_optimized");
+        assert_eq!(QueryType::Incremental.as_ref(), "incremental");
+    }
+
+    #[test]
+    fn from_str_accepts_aliases_case_insensitively() {
+        assert_eq!(
+            QueryType::from_str("snapshot").unwrap(),
+            QueryType::Snapshot
+        );
+        assert_eq!(
+            QueryType::from_str("SNAPSHOT").unwrap(),
+            QueryType::Snapshot
+        );
+        assert_eq!(
+            QueryType::from_str("read_optimized").unwrap(),
+            QueryType::ReadOptimized
+        );
+        assert_eq!(
+            QueryType::from_str("Read-Optimized").unwrap(),
+            QueryType::ReadOptimized
+        );
+        assert_eq!(
+            QueryType::from_str("Incremental").unwrap(),
+            QueryType::Incremental
+        );
+    }
+
+    #[test]
+    fn from_str_rejects_unknown_or_empty_value() {
+        assert!(matches!(
+            QueryType::from_str("").unwrap_err(),
+            InvalidValue(_)
+        ));
+        assert!(matches!(
+            QueryType::from_str("foo").unwrap_err(),
+            InvalidValue(_)
+        ));
+        assert!(matches!(
+            QueryType::from_str("snapshotx").unwrap_err(),
+            InvalidValue(_)
+        ));
+    }
+}

--- a/python/hudi/__init__.py
+++ b/python/hudi/__init__.py
@@ -21,6 +21,7 @@ from hudi._internal import (
     HudiFileGroupReader,
     HudiFileSlice,
     HudiInstant,
+    HudiQueryType,
     HudiTable,
     HudiTimeline,
 )
@@ -32,6 +33,7 @@ __all__ = [
     "HudiFileGroupReader",
     "HudiFileSlice",
     "HudiInstant",
+    "HudiQueryType",
     "HudiTable",
     "HudiTableBuilder",
     "HudiTimeline",

--- a/python/hudi/_internal.pyi
+++ b/python/hudi/_internal.pyi
@@ -133,6 +133,18 @@ class HudiInstant:
     @property
     def epoch_mills(self) -> int: ...
 
+class HudiQueryType:
+    """
+    Standardized query types for Hudi table read operations.
+
+    `str(query_type)` returns the canonical Hudi value: ``"snapshot"``,
+    ``"read_optimized"``, or ``"incremental"``.
+    """
+
+    Snapshot: "HudiQueryType"
+    ReadOptimized: "HudiQueryType"
+    Incremental: "HudiQueryType"
+
 @dataclass(init=False)
 class HudiTable:
     """

--- a/python/src/internal.rs
+++ b/python/src/internal.rs
@@ -26,6 +26,7 @@ use tokio::runtime::Runtime;
 
 #[cfg(feature = "datafusion")]
 use datafusion::error::DataFusionError;
+use hudi::QueryType;
 use hudi::error::CoreError;
 use hudi::file_group::FileGroup;
 use hudi::file_group::file_slice::FileSlice;
@@ -67,6 +68,50 @@ impl From<PythonError> for PyErr {
             #[cfg(feature = "datafusion")]
             PythonError::DataFusionCore(err) => convert_to_py_err(err),
         }
+    }
+}
+
+/// Standardized query types for Hudi table read operations.
+///
+/// Mirrors [`hudi::QueryType`] for use from Python.
+#[cfg(not(tarpaulin_include))]
+#[pyclass(eq, eq_int)]
+#[derive(Clone, Debug, PartialEq)]
+pub enum HudiQueryType {
+    Snapshot,
+    ReadOptimized,
+    Incremental,
+}
+
+impl From<HudiQueryType> for QueryType {
+    fn from(qt: HudiQueryType) -> Self {
+        match qt {
+            HudiQueryType::Snapshot => QueryType::Snapshot,
+            HudiQueryType::ReadOptimized => QueryType::ReadOptimized,
+            HudiQueryType::Incremental => QueryType::Incremental,
+        }
+    }
+}
+
+impl From<QueryType> for HudiQueryType {
+    fn from(qt: QueryType) -> Self {
+        match qt {
+            QueryType::Snapshot => HudiQueryType::Snapshot,
+            QueryType::ReadOptimized => HudiQueryType::ReadOptimized,
+            QueryType::Incremental => HudiQueryType::Incremental,
+        }
+    }
+}
+
+#[cfg(not(tarpaulin_include))]
+#[pymethods]
+impl HudiQueryType {
+    fn __str__(&self) -> String {
+        QueryType::from(self.clone()).as_ref().to_string()
+    }
+
+    fn __repr__(&self) -> String {
+        format!("HudiQueryType.{self:?}")
     }
 }
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -31,10 +31,13 @@ mod testing_internal;
 fn _internal(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
 
-    use internal::{HudiFileGroupReader, HudiFileSlice, HudiInstant, HudiTable, HudiTimeline};
+    use internal::{
+        HudiFileGroupReader, HudiFileSlice, HudiInstant, HudiQueryType, HudiTable, HudiTimeline,
+    };
     m.add_class::<HudiFileGroupReader>()?;
     m.add_class::<HudiFileSlice>()?;
     m.add_class::<HudiInstant>()?;
+    m.add_class::<HudiQueryType>()?;
     m.add_class::<HudiTable>()?;
     m.add_class::<HudiTimeline>()?;
 

--- a/python/tests/test_query_type.py
+++ b/python/tests/test_query_type.py
@@ -1,0 +1,39 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+from hudi import HudiQueryType
+
+
+def test_query_type_variants_are_distinct_and_comparable():
+    assert HudiQueryType.Snapshot == HudiQueryType.Snapshot
+    assert HudiQueryType.ReadOptimized == HudiQueryType.ReadOptimized
+    assert HudiQueryType.Incremental == HudiQueryType.Incremental
+    assert HudiQueryType.Snapshot != HudiQueryType.ReadOptimized
+    assert HudiQueryType.Snapshot != HudiQueryType.Incremental
+    assert HudiQueryType.ReadOptimized != HudiQueryType.Incremental
+
+
+def test_query_type_str_returns_canonical_hudi_value():
+    assert str(HudiQueryType.Snapshot) == "snapshot"
+    assert str(HudiQueryType.ReadOptimized) == "read_optimized"
+    assert str(HudiQueryType.Incremental) == "incremental"
+
+
+def test_query_type_repr_includes_variant_name():
+    assert repr(HudiQueryType.Snapshot) == "HudiQueryType.Snapshot"
+    assert repr(HudiQueryType.ReadOptimized) == "HudiQueryType.ReadOptimized"
+    assert repr(HudiQueryType.Incremental) == "HudiQueryType.Incremental"


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Add a standardized `QueryType` enum to provide a unified interface for all table query operations.
<!--- If it fixes an open issue, please link to the issue here. -->
closes #405 
<!--- Please link any related issues and PRs as well. -->

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
