### PR TITLE
refactor: replace custom `.to::()` with `into()` for `HudiConfig` conversions

### DIFF
--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -92,7 +92,6 @@ pub enum HudiConfigValue {
 }
 
 impl HudiConfigValue {
-
     /// A convenience method to convert [HudiConfigValue] to [Url] when the value is a [String] and is intended to be a URL.
     /// Panic if the value is not a [String].
     pub fn to_url(self) -> StorageResult<Url> {

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -92,16 +92,6 @@ pub enum HudiConfigValue {
 }
 
 impl HudiConfigValue {
-    /// Covert [HudiConfigValue] logical type to the representing data type in Rust.
-    ///
-    /// - [`HudiConfigValue::Boolean`] -> [bool]
-    /// - [`HudiConfigValue::Integer`] -> [isize]
-    /// - [`HudiConfigValue::UInteger`] -> [usize]
-    /// - [`HudiConfigValue::String`] -> [String]
-    /// - [`HudiConfigValue::List`] -> [`Vec<String>`]
-    pub fn to<T: 'static + std::fmt::Debug + From<HudiConfigValue>>(self) -> T {
-        T::from(self)
-    }
 
     /// A convenience method to convert [HudiConfigValue] to [Url] when the value is a [String] and is intended to be a URL.
     /// Panic if the value is not a [String].

--- a/crates/core/src/config/read.rs
+++ b/crates/core/src/config/read.rs
@@ -142,20 +142,26 @@ mod tests {
             ),
         ]);
         assert_eq!(
-            InputPartitions.parse_value(&options).unwrap().to::<usize>(),
+            { let value: usize = InputPartitions.parse_value(&options).unwrap().into(); value },
             100
         );
         assert_eq!(
-            ListingParallelism
-                .parse_value(&options)
-                .unwrap()
-                .to::<usize>(),
+            {
+                let value: usize = ListingParallelism
+                    .parse_value(&options)
+                    .unwrap()
+                    .into();
+                value
+            },
             100
         );
-        assert!(UseReadOptimizedMode
-            .parse_value(&options)
-            .unwrap()
-            .to::<bool>());
+        assert!({
+            let value: bool = UseReadOptimizedMode
+                .parse_value(&options)
+                .unwrap()
+                .into();
+            value
+        });
     }
 
     #[test]
@@ -170,9 +176,12 @@ mod tests {
             ParseInt(_, _, _)
         ));
         assert_eq!(
-            InputPartitions
-                .parse_value_or_default(&options)
-                .to::<usize>(),
+            {
+                let value: usize = InputPartitions
+                    .parse_value_or_default(&options)
+                    .into();
+                value
+            },
             0
         );
         assert!(matches!(
@@ -180,17 +189,23 @@ mod tests {
             ParseInt(_, _, _)
         ));
         assert_eq!(
-            ListingParallelism
-                .parse_value_or_default(&options)
-                .to::<usize>(),
+            {
+                let value: usize = ListingParallelism
+                    .parse_value_or_default(&options)
+                    .into();
+                value
+            },
             10
         );
         assert!(matches!(
             UseReadOptimizedMode.parse_value(&options).unwrap_err(),
             ParseBool(_, _, _)
         ));
-        assert!(!UseReadOptimizedMode
-            .parse_value_or_default(&options)
-            .to::<bool>())
+        assert!({
+            let value: bool = UseReadOptimizedMode
+                .parse_value_or_default(&options)
+                .into();
+            !value
+        })
     }
 }

--- a/crates/core/src/config/read.rs
+++ b/crates/core/src/config/read.rs
@@ -141,27 +141,12 @@ mod tests {
                 "true".to_string(),
             ),
         ]);
-        assert_eq!(
-            { let value: usize = InputPartitions.parse_value(&options).unwrap().into(); value },
-            100
-        );
-        assert_eq!(
-            {
-                let value: usize = ListingParallelism
-                    .parse_value(&options)
-                    .unwrap()
-                    .into();
-                value
-            },
-            100
-        );
-        assert!({
-            let value: bool = UseReadOptimizedMode
-                .parse_value(&options)
-                .unwrap()
-                .into();
-            value
-        });
+        let actual: usize = InputPartitions.parse_value(&options).unwrap().into();
+        assert_eq!(actual, 100);
+        let actual: usize = ListingParallelism.parse_value(&options).unwrap().into();
+        assert_eq!(actual, 100);
+        let actual: bool = UseReadOptimizedMode.parse_value(&options).unwrap().into();
+        assert!(actual);
     }
 
     #[test]
@@ -175,37 +160,19 @@ mod tests {
             InputPartitions.parse_value(&options).unwrap_err(),
             ParseInt(_, _, _)
         ));
-        assert_eq!(
-            {
-                let value: usize = InputPartitions
-                    .parse_value_or_default(&options)
-                    .into();
-                value
-            },
-            0
-        );
+        let actual: usize = InputPartitions.parse_value_or_default(&options).into();
+        assert_eq!(actual, 0);
         assert!(matches!(
             ListingParallelism.parse_value(&options).unwrap_err(),
             ParseInt(_, _, _)
         ));
-        assert_eq!(
-            {
-                let value: usize = ListingParallelism
-                    .parse_value_or_default(&options)
-                    .into();
-                value
-            },
-            10
-        );
+        let actual: usize = ListingParallelism.parse_value_or_default(&options).into();
+        assert_eq!(actual, 10);
         assert!(matches!(
             UseReadOptimizedMode.parse_value(&options).unwrap_err(),
             ParseBool(_, _, _)
         ));
-        assert!({
-            let value: bool = UseReadOptimizedMode
-                .parse_value_or_default(&options)
-                .into();
-            !value
-        })
+        let actual: bool = UseReadOptimizedMode.parse_value_or_default(&options).into();
+        assert!(!actual)
     }
 }

--- a/crates/core/src/config/table.rs
+++ b/crates/core/src/config/table.rs
@@ -483,25 +483,21 @@ mod tests {
             (HudiTableConfig::PopulatesMetaFields, "false"),
             (HudiTableConfig::PrecombineField, "ts"),
         ]);
+        let actual: String = hudi_configs
+            .get_or_default(HudiTableConfig::RecordMergeStrategy)
+            .into();
         assert_eq!(
-            {
-                let value: String = hudi_configs
-                    .get_or_default(HudiTableConfig::RecordMergeStrategy)
-                    .into();
-                value
-            },
+            actual,
             RecordMergeStrategyValue::AppendOnly.as_ref(),
             "Should derive as append-only due to populatesMetaFields=false"
         );
 
         let hudi_configs = HudiConfigs::new(vec![(HudiTableConfig::PopulatesMetaFields, "true")]);
+        let actual: String = hudi_configs
+            .get_or_default(HudiTableConfig::RecordMergeStrategy)
+            .into();
         assert_eq!(
-            {
-                let value: String = hudi_configs
-                    .get_or_default(HudiTableConfig::RecordMergeStrategy)
-                    .into();
-                value
-            },
+            actual,
             RecordMergeStrategyValue::AppendOnly.as_ref(),
             "Should derive as append-only due to missing precombine field"
         );
@@ -510,14 +506,12 @@ mod tests {
             (HudiTableConfig::PopulatesMetaFields, "true"),
             (HudiTableConfig::PrecombineField, "ts"),
         ]);
+        let actual: String = hudi_configs
+            .get_or_default(HudiTableConfig::RecordMergeStrategy)
+            .into();
         assert_eq!(
-            {
-                let value: String = hudi_configs
-                    .get_or_default(HudiTableConfig::RecordMergeStrategy)
-                    .into();
-                value
-            },
-            RecordMergeStrategyValue::OverwriteWithLatest.as_ref(),
+            actual,
+            RecordMergeStrategyValue::OverwriteWithLatest.as_ref()
         );
     }
 }

--- a/crates/core/src/config/table.rs
+++ b/crates/core/src/config/table.rs
@@ -245,9 +245,9 @@ impl ConfigParser for HudiTableConfig {
         self.parse_value(configs).unwrap_or_else(|_| {
             match self {
                 Self::RecordMergeStrategy => {
-                    let populates_meta_fields = HudiTableConfig::PopulatesMetaFields
+                    let populates_meta_fields: bool = HudiTableConfig::PopulatesMetaFields
                         .parse_value_or_default(configs)
-                        .to::<bool>();
+                        .into();
                     if !populates_meta_fields {
                         // When populatesMetaFields is false, meta fields such as record key and
                         // partition path are null, the table is supposed to be append-only.
@@ -484,18 +484,24 @@ mod tests {
             (HudiTableConfig::PrecombineField, "ts"),
         ]);
         assert_eq!(
-            hudi_configs
-                .get_or_default(HudiTableConfig::RecordMergeStrategy)
-                .to::<String>(),
+            {
+                let value: String = hudi_configs
+                    .get_or_default(HudiTableConfig::RecordMergeStrategy)
+                    .into();
+                value
+            },
             RecordMergeStrategyValue::AppendOnly.as_ref(),
             "Should derive as append-only due to populatesMetaFields=false"
         );
 
         let hudi_configs = HudiConfigs::new(vec![(HudiTableConfig::PopulatesMetaFields, "true")]);
         assert_eq!(
-            hudi_configs
-                .get_or_default(HudiTableConfig::RecordMergeStrategy)
-                .to::<String>(),
+            {
+                let value: String = hudi_configs
+                    .get_or_default(HudiTableConfig::RecordMergeStrategy)
+                    .into();
+                value
+            },
             RecordMergeStrategyValue::AppendOnly.as_ref(),
             "Should derive as append-only due to missing precombine field"
         );
@@ -505,9 +511,12 @@ mod tests {
             (HudiTableConfig::PrecombineField, "ts"),
         ]);
         assert_eq!(
-            hudi_configs
-                .get_or_default(HudiTableConfig::RecordMergeStrategy)
-                .to::<String>(),
+            {
+                let value: String = hudi_configs
+                    .get_or_default(HudiTableConfig::RecordMergeStrategy)
+                    .into();
+                value
+            },
             RecordMergeStrategyValue::OverwriteWithLatest.as_ref(),
         );
     }

--- a/crates/core/src/file_group/log_file/reader.rs
+++ b/crates/core/src/file_group/log_file/reader.rs
@@ -55,9 +55,9 @@ impl LogFileReader<StorageReader> {
         relative_path: &str,
     ) -> Result<Self> {
         let reader = storage.get_storage_reader(relative_path).await?;
-        let timezone = hudi_configs
+        let timezone: String = hudi_configs
             .get_or_default(HudiTableConfig::TimelineTimezone)
-            .to::<String>();
+            .into();
         Ok(Self {
             hudi_configs,
             storage,

--- a/crates/core/src/file_group/reader.rs
+++ b/crates/core/src/file_group/reader.rs
@@ -107,10 +107,10 @@ impl FileGroupReader {
         &self,
         records: &RecordBatch,
     ) -> Result<Option<BooleanArray>> {
-        let populates_meta_fields = self
+        let populates_meta_fields: bool = self
             .hudi_configs
             .get_or_default(HudiTableConfig::PopulatesMetaFields)
-            .to::<bool>();
+            .into();
         if !populates_meta_fields {
             // If meta fields are not populated, commit time filtering is not applicable.
             return Ok(None);
@@ -121,7 +121,7 @@ impl FileGroupReader {
         if let Some(start) = self
             .hudi_configs
             .try_get(HudiReadConfig::FileGroupStartTimestamp)
-            .map(|v| v.to::<String>())
+            .map(|v| -> String { v.into() })
         {
             let filter: Filter =
                 Filter::try_from((MetaField::CommitTime.as_ref(), ">", start.as_str()))?;
@@ -137,7 +137,7 @@ impl FileGroupReader {
         if let Some(end) = self
             .hudi_configs
             .try_get(HudiReadConfig::FileGroupEndTimestamp)
-            .map(|v| v.to::<String>())
+            .map(|v| -> String { v.into() })
         {
             let filter = Filter::try_from((MetaField::CommitTime.as_ref(), "<=", end.as_str()))?;
             let filter = SchemableFilter::try_from((filter, schema.as_ref()))?;
@@ -201,15 +201,15 @@ impl FileGroupReader {
         let timezone = self
             .hudi_configs
             .get_or_default(HudiTableConfig::TimelineTimezone)
-            .to::<String>();
+            .into();
         let start_timestamp = self
             .hudi_configs
             .try_get(HudiReadConfig::FileGroupStartTimestamp)
-            .map(|v| v.to::<String>());
+            .map(|v| -> String { v.into() });
         let end_timestamp = self
             .hudi_configs
             .try_get(HudiReadConfig::FileGroupEndTimestamp)
-            .map(|v| v.to::<String>());
+            .map(|v| -> String { v.into() });
         InstantRange::new(timezone, start_timestamp, end_timestamp, false, true)
     }
 
@@ -226,7 +226,7 @@ impl FileGroupReader {
             || self
                 .hudi_configs
                 .get_or_default(HudiReadConfig::UseReadOptimizedMode)
-                .to::<bool>();
+                .into();
         if base_file_only {
             self.read_file_slice_by_base_file_path(&relative_path).await
         } else {

--- a/crates/core/src/file_group/record_batches.rs
+++ b/crates/core/src/file_group/record_batches.rs
@@ -115,9 +115,7 @@ impl RecordBatches {
         &self,
         hudi_configs: Arc<HudiConfigs>,
     ) -> Result<RecordBatch> {
-        let ordering_field: String = hudi_configs
-            .get(HudiTableConfig::PrecombineField)?
-            .into();
+        let ordering_field: String = hudi_configs.get(HudiTableConfig::PrecombineField)?.into();
 
         if self.num_delete_rows == 0 {
             return Ok(RecordBatch::new_empty(SchemaRef::from(Schema::empty())));

--- a/crates/core/src/file_group/record_batches.rs
+++ b/crates/core/src/file_group/record_batches.rs
@@ -115,9 +115,9 @@ impl RecordBatches {
         &self,
         hudi_configs: Arc<HudiConfigs>,
     ) -> Result<RecordBatch> {
-        let ordering_field = hudi_configs
+        let ordering_field: String = hudi_configs
             .get(HudiTableConfig::PrecombineField)?
-            .to::<String>();
+            .into();
 
         if self.num_delete_rows == 0 {
             return Ok(RecordBatch::new_empty(SchemaRef::from(Schema::empty())));

--- a/crates/core/src/merge/ordering.rs
+++ b/crates/core/src/merge/ordering.rs
@@ -62,9 +62,7 @@ pub fn process_batch_for_max_orderings(
         return Ok(());
     }
 
-    let ordering_field: String = hudi_configs
-        .get(HudiTableConfig::PrecombineField)?
-        .into();
+    let ordering_field: String = hudi_configs.get(HudiTableConfig::PrecombineField)?.into();
 
     let keys = extract_record_keys(key_converter, batch)?;
     let event_times =

--- a/crates/core/src/merge/ordering.rs
+++ b/crates/core/src/merge/ordering.rs
@@ -62,9 +62,9 @@ pub fn process_batch_for_max_orderings(
         return Ok(());
     }
 
-    let ordering_field = hudi_configs
+    let ordering_field: String = hudi_configs
         .get(HudiTableConfig::PrecombineField)?
-        .to::<String>();
+        .into();
 
     let keys = extract_record_keys(key_converter, batch)?;
     let event_times =

--- a/crates/core/src/merge/record_merger.rs
+++ b/crates/core/src/merge/record_merger.rs
@@ -51,14 +51,10 @@ pub struct RecordMerger {
 impl RecordMerger {
     /// Validates the given [HudiConfigs] against the [RecordMergeStrategy].
     pub fn validate_configs(hudi_configs: &HudiConfigs) -> ConfigResult<()> {
-        let merge_strategy: String = hudi_configs
-            .get_or_default(RecordMergeStrategy)
-            .into();
+        let merge_strategy: String = hudi_configs.get_or_default(RecordMergeStrategy).into();
         let merge_strategy = RecordMergeStrategyValue::from_str(&merge_strategy)?;
 
-        let populate_meta_fields: bool = hudi_configs
-            .get_or_default(PopulatesMetaFields)
-            .into();
+        let populate_meta_fields: bool = hudi_configs.get_or_default(PopulatesMetaFields).into();
         if !populate_meta_fields && merge_strategy != RecordMergeStrategyValue::AppendOnly {
             return Err(ConfigError::InvalidValue(format!(
                 "When {:?} is false, {:?} must be {:?}.",
@@ -91,10 +87,7 @@ impl RecordMerger {
     }
 
     pub fn merge_record_batches(&self, record_batches: RecordBatches) -> Result<RecordBatch> {
-        let merge_strategy: String = self
-            .hudi_configs
-            .get_or_default(RecordMergeStrategy)
-            .into();
+        let merge_strategy: String = self.hudi_configs.get_or_default(RecordMergeStrategy).into();
         let merge_strategy = RecordMergeStrategyValue::from_str(&merge_strategy)?;
         match merge_strategy {
             RecordMergeStrategyValue::AppendOnly => {

--- a/crates/core/src/merge/record_merger.rs
+++ b/crates/core/src/merge/record_merger.rs
@@ -51,14 +51,14 @@ pub struct RecordMerger {
 impl RecordMerger {
     /// Validates the given [HudiConfigs] against the [RecordMergeStrategy].
     pub fn validate_configs(hudi_configs: &HudiConfigs) -> ConfigResult<()> {
-        let merge_strategy = hudi_configs
+        let merge_strategy: String = hudi_configs
             .get_or_default(RecordMergeStrategy)
-            .to::<String>();
+            .into();
         let merge_strategy = RecordMergeStrategyValue::from_str(&merge_strategy)?;
 
-        let populate_meta_fields = hudi_configs
+        let populate_meta_fields: bool = hudi_configs
             .get_or_default(PopulatesMetaFields)
-            .to::<bool>();
+            .into();
         if !populate_meta_fields && merge_strategy != RecordMergeStrategyValue::AppendOnly {
             return Err(ConfigError::InvalidValue(format!(
                 "When {:?} is false, {:?} must be {:?}.",
@@ -91,10 +91,10 @@ impl RecordMerger {
     }
 
     pub fn merge_record_batches(&self, record_batches: RecordBatches) -> Result<RecordBatch> {
-        let merge_strategy = self
+        let merge_strategy: String = self
             .hudi_configs
             .get_or_default(RecordMergeStrategy)
-            .to::<String>();
+            .into();
         let merge_strategy = RecordMergeStrategyValue::from_str(&merge_strategy)?;
         match merge_strategy {
             RecordMergeStrategyValue::AppendOnly => {
@@ -109,7 +109,7 @@ impl RecordMerger {
 
                 // Use sorting fields to get sorted indices of the data batch (inserts and updates)
                 let key_array = data_batch.get_array(MetaField::RecordKey.as_ref())?;
-                let ordering_field = self.hudi_configs.get(PrecombineField)?.to::<String>();
+                let ordering_field: String = self.hudi_configs.get(PrecombineField)?.into();
                 let ordering_array = data_batch.get_array(&ordering_field)?;
                 let commit_seqno_array = data_batch.get_array(MetaField::CommitSeqno.as_ref())?;
                 let desc_indices =
@@ -117,7 +117,7 @@ impl RecordMerger {
 
                 // Create shared converters for record keys and ordering values
                 let key_converter = create_record_key_converter(data_batch.schema())?;
-                let ordering_field = self.hudi_configs.get(PrecombineField)?.to::<String>();
+                let ordering_field: String = self.hudi_configs.get(PrecombineField)?.into();
                 let event_time_converter =
                     create_event_time_ordering_converter(data_batch.schema(), &ordering_field)?;
                 let commit_time_converter =

--- a/crates/core/src/schema/resolver.rs
+++ b/crates/core/src/schema/resolver.rs
@@ -43,7 +43,7 @@ pub async fn resolve_schema(table: &Table) -> Result<Schema> {
         }
         Err(CoreError::TimelineNoCommit) => {
             if let Some(create_schema) = table.hudi_configs.try_get(HudiTableConfig::CreateSchema) {
-                let avro_schema_str = create_schema.to::<String>();
+                let avro_schema_str: String = create_schema.into();
                 let arrow_schema = arrow_schema_from_avro_schema_str(&avro_schema_str)?;
                 prepend_meta_fields(SchemaRef::new(arrow_schema))
             } else {
@@ -72,7 +72,7 @@ pub async fn resolve_avro_schema(table: &Table) -> Result<String> {
         Ok(metadata) => resolve_avro_schema_from_commit_metadata(&metadata),
         Err(CoreError::TimelineNoCommit) => {
             if let Some(create_schema) = table.hudi_configs.try_get(HudiTableConfig::CreateSchema) {
-                let create_schema = create_schema.to::<String>();
+                let create_schema: String = create_schema.into();
                 Ok(sanitize_avro_schema_str(&create_schema))
             } else {
                 Err(CoreError::SchemaNotFound(

--- a/crates/core/src/table/listing.rs
+++ b/crates/core/src/table/listing.rs
@@ -61,10 +61,10 @@ impl FileLister {
     }
 
     async fn list_file_groups_for_partition(&self, partition_path: &str) -> Result<Vec<FileGroup>> {
-        let base_file_format = self
+        let base_file_format: String = self
             .hudi_configs
             .get_or_default(BaseFileFormat)
-            .to::<String>();
+            .into();
 
         let listed_file_metadata = self.storage.list_files(Some(partition_path)).await?;
 
@@ -167,7 +167,7 @@ impl FileLister {
         let parallelism = self
             .hudi_configs
             .get_or_default(ListingParallelism)
-            .to::<usize>();
+            .into();
         stream::iter(pruned_partition_paths)
             .map(|p| async move {
                 let file_groups = self.list_file_groups_for_partition(&p).await?;

--- a/crates/core/src/table/listing.rs
+++ b/crates/core/src/table/listing.rs
@@ -61,10 +61,7 @@ impl FileLister {
     }
 
     async fn list_file_groups_for_partition(&self, partition_path: &str) -> Result<Vec<FileGroup>> {
-        let base_file_format: String = self
-            .hudi_configs
-            .get_or_default(BaseFileFormat)
-            .into();
+        let base_file_format: String = self.hudi_configs.get_or_default(BaseFileFormat).into();
 
         let listed_file_metadata = self.storage.list_files(Some(partition_path)).await?;
 
@@ -164,10 +161,7 @@ impl FileLister {
 
         let pruned_partition_paths = self.list_relevant_partition_paths().await?;
         let file_groups_map = Arc::new(DashMap::with_capacity(pruned_partition_paths.len()));
-        let parallelism = self
-            .hudi_configs
-            .get_or_default(ListingParallelism)
-            .into();
+        let parallelism = self.hudi_configs.get_or_default(ListingParallelism).into();
         stream::iter(pruned_partition_paths)
             .map(|p| async move {
                 let file_groups = self.list_file_groups_for_partition(&p).await?;

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -262,10 +262,7 @@ impl Table {
     /// Get the latest partition [arrow_schema::Schema] of the table.
     pub async fn get_partition_schema(&self) -> Result<Schema> {
         let partition_fields: HashSet<String> = {
-            let fields: Vec<String> = self
-                .hudi_configs
-                .get_or_default(PartitionFields)
-                .into();
+            let fields: Vec<String> = self.hudi_configs.get_or_default(PartitionFields).into();
             fields.into_iter().collect()
         };
 
@@ -1013,83 +1010,67 @@ mod tests {
     fn get_default_for_invalid_table_props() {
         let table = get_test_table_without_validation("table_props_invalid");
         let configs = table.hudi_configs;
-        assert_eq!({
-            let value: String = configs.get_or_default(BaseFileFormat).into();
-            value
-        }, "parquet");
+        let actual: String = configs.get_or_default(BaseFileFormat).into();
+        assert_eq!(actual, "parquet");
         assert!(panic::catch_unwind(|| configs.get_or_default(Checksum)).is_err());
-        assert_eq!({
-            let value: String = configs.get_or_default(DatabaseName).into();
-            value
-        }, "default");
-        assert!({
-            let value: bool = configs.get_or_default(DropsPartitionFields).into();
-            !value
-        });
+        let actual: String = configs.get_or_default(DatabaseName).into();
+        assert_eq!(actual, "default");
+        let actual: bool = configs.get_or_default(DropsPartitionFields).into();
+        assert!(!actual);
         assert!(panic::catch_unwind(|| configs.get_or_default(IsHiveStylePartitioning)).is_err());
         assert!(panic::catch_unwind(|| configs.get_or_default(IsPartitionPathUrlencoded)).is_err());
         assert!(panic::catch_unwind(|| configs.get_or_default(KeyGeneratorClass)).is_err());
-        assert!({
-            let value: Vec<String> = configs.get_or_default(PartitionFields).into();
-            value.is_empty()
-        });
+        let actual: Vec<String> = configs.get_or_default(PartitionFields).into();
+        assert!(actual.is_empty());
         assert!(panic::catch_unwind(|| configs.get_or_default(PrecombineField)).is_err());
-        assert!({
-            let value: bool = configs.get_or_default(PopulatesMetaFields).into();
-            value
-        });
+        let actual: bool = configs.get_or_default(PopulatesMetaFields).into();
+        assert!(actual);
         assert!(panic::catch_unwind(|| configs.get_or_default(RecordKeyFields)).is_err());
         assert!(panic::catch_unwind(|| configs.get_or_default(TableName)).is_err());
-        assert_eq!(
-            { let value: String = configs.get_or_default(TableType).into(); value },
-            "COPY_ON_WRITE"
-        );
+        let actual: String = configs.get_or_default(TableType).into();
+        assert_eq!(actual, "COPY_ON_WRITE");
         assert!(panic::catch_unwind(|| configs.get_or_default(TableVersion)).is_err());
         assert!(panic::catch_unwind(|| configs.get_or_default(TimelineLayoutVersion)).is_err());
-        assert_eq!(
-            { let value: String = configs.get_or_default(TimelineTimezone).into(); value },
-            "utc"
-        );
+        let actual: String = configs.get_or_default(TimelineTimezone).into();
+        assert_eq!(actual, "utc");
     }
 
     #[test]
     fn get_valid_table_props() {
         let table = get_test_table_without_validation("table_props_valid");
         let configs = table.hudi_configs;
-        assert_eq!(
-            { let value: String = configs.get(BaseFileFormat).unwrap().into(); value },
-            "parquet"
-        );
-        assert_eq!({ let value: isize = configs.get(Checksum).unwrap().into(); value }, 3761586722);
-        assert_eq!({ let value: String = configs.get(DatabaseName).unwrap().into(); value }, "db");
-        assert!({ let value: bool = configs.get(DropsPartitionFields).unwrap().into(); !value });
-        assert!({ let value: bool = configs.get(IsHiveStylePartitioning).unwrap().into(); !value });
-        assert!({ let value: bool = configs.get(IsPartitionPathUrlencoded).unwrap().into(); !value });
-        assert_eq!(
-            { let value: String = configs.get(KeyGeneratorClass).unwrap().into(); value },
-            "org.apache.hudi.keygen.SimpleKeyGenerator"
-        );
-        assert_eq!(
-            { let value: Vec<String> = configs.get(PartitionFields).unwrap().into(); value },
-            vec!["city"]
-        );
-        assert_eq!({ let value: String = configs.get(PrecombineField).unwrap().into(); value }, "ts");
-        assert!({ let value: bool = configs.get(PopulatesMetaFields).unwrap().into(); value });
-        assert_eq!(
-            { let value: Vec<String> = configs.get(RecordKeyFields).unwrap().into(); value },
-            vec!["uuid"]
-        );
-        assert_eq!({ let value: String = configs.get(TableName).unwrap().into(); value }, "trips");
-        assert_eq!(
-            { let value: String = configs.get(TableType).unwrap().into(); value },
-            "COPY_ON_WRITE"
-        );
-        assert_eq!({ let value: isize = configs.get(TableVersion).unwrap().into(); value }, 6);
-        assert_eq!({ let value: isize = configs.get(TimelineLayoutVersion).unwrap().into(); value }, 1);
-        assert_eq!(
-            { let value: String = configs.get(TimelineTimezone).unwrap().into(); value },
-            "local"
-        );
+        let actual: String = configs.get(BaseFileFormat).unwrap().into();
+        assert_eq!(actual, "parquet");
+        let actual: isize = configs.get(Checksum).unwrap().into();
+        assert_eq!(actual, 3761586722);
+        let actual: String = configs.get(DatabaseName).unwrap().into();
+        assert_eq!(actual, "db");
+        let actual: bool = configs.get(DropsPartitionFields).unwrap().into();
+        assert!(!actual);
+        let actual: bool = configs.get(IsHiveStylePartitioning).unwrap().into();
+        assert!(!actual);
+        let actual: bool = configs.get(IsPartitionPathUrlencoded).unwrap().into();
+        assert!(!actual);
+        let actual: String = configs.get(KeyGeneratorClass).unwrap().into();
+        assert_eq!(actual, "org.apache.hudi.keygen.SimpleKeyGenerator");
+        let actual: Vec<String> = configs.get(PartitionFields).unwrap().into();
+        assert_eq!(actual, vec!["city"]);
+        let actual: String = configs.get(PrecombineField).unwrap().into();
+        assert_eq!(actual, "ts");
+        let actual: bool = configs.get(PopulatesMetaFields).unwrap().into();
+        assert!(actual);
+        let actual: Vec<String> = configs.get(RecordKeyFields).unwrap().into();
+        assert_eq!(actual, vec!["uuid"]);
+        let actual: String = configs.get(TableName).unwrap().into();
+        assert_eq!(actual, "trips");
+        let actual: String = configs.get(TableType).unwrap().into();
+        assert_eq!(actual, "COPY_ON_WRITE");
+        let actual: isize = configs.get(TableVersion).unwrap().into();
+        assert_eq!(actual, 6);
+        let actual: isize = configs.get(TimelineLayoutVersion).unwrap().into();
+        assert_eq!(actual, 1);
+        let actual: String = configs.get(TimelineTimezone).unwrap().into();
+        assert_eq!(actual, "local");
     }
 
     #[test]
@@ -1099,7 +1080,8 @@ mod tests {
         let configs = table.hudi_configs;
         assert!(configs.get(DatabaseName).is_err());
         assert!(configs.get(TableType).is_err());
-        assert_eq!({ let value: String = configs.get(TableName).unwrap().into(); value }, "trips");
+        let actual: String = configs.get(TableName).unwrap().into();
+        assert_eq!(actual, "trips");
 
         // Environment variable HUDI_CONF_DIR points to nothing
         let base_path = env::current_dir().unwrap();
@@ -1109,7 +1091,8 @@ mod tests {
         let configs = table.hudi_configs;
         assert!(configs.get(DatabaseName).is_err());
         assert!(configs.get(TableType).is_err());
-        assert_eq!({ let value: String = configs.get(TableName).unwrap().into(); value }, "trips");
+        let actual: String = configs.get(TableName).unwrap().into();
+        assert_eq!(actual, "trips");
 
         // With global config
         let base_path = env::current_dir().unwrap();
@@ -1117,12 +1100,12 @@ mod tests {
         env::set_var(HUDI_CONF_DIR, hudi_conf_dir.as_os_str());
         let table = get_test_table_without_validation("table_props_partial");
         let configs = table.hudi_configs;
-        assert_eq!({ let value: String = configs.get(DatabaseName).unwrap().into(); value }, "tmpdb");
-        assert_eq!(
-            { let value: String = configs.get(TableType).unwrap().into(); value },
-            "MERGE_ON_READ"
-        );
-        assert_eq!({ let value: String = configs.get(TableName).unwrap().into(); value }, "trips");
+        let actual: String = configs.get(DatabaseName).unwrap().into();
+        assert_eq!(actual, "tmpdb");
+        let actual: String = configs.get(TableType).unwrap().into();
+        assert_eq!(actual, "MERGE_ON_READ");
+        let actual: String = configs.get(TableName).unwrap().into();
+        assert_eq!(actual, "trips");
         env::remove_var(HUDI_CONF_DIR)
     }
 

--- a/crates/core/src/table/partition.rs
+++ b/crates/core/src/table/partition.rs
@@ -33,15 +33,18 @@ pub const PARTITION_METAFIELD_PREFIX: &str = ".hoodie_partition_metadata";
 pub const EMPTY_PARTITION_PATH: &str = "";
 
 pub fn is_table_partitioned(hudi_configs: &HudiConfigs) -> bool {
-    let has_partition_fields = !hudi_configs
-        .get_or_default(PartitionFields)
-        .to::<Vec<String>>()
-        .is_empty();
+    let has_partition_fields = {
+        let partition_fields: Vec<String> = hudi_configs
+            .get_or_default(PartitionFields)
+            .into();
+        !partition_fields.is_empty()
+    };
 
     let uses_non_partitioned_key_gen = hudi_configs
         .try_get(KeyGeneratorClass)
         .map(|key_gen| {
-            key_gen.to::<String>() == "org.apache.hudi.keygen.NonpartitionedKeyGenerator"
+            let key_gen_str: String = key_gen.into();
+            key_gen_str == "org.apache.hudi.keygen.NonpartitionedKeyGenerator"
         })
         .unwrap_or(false);
 
@@ -71,10 +74,10 @@ impl PartitionPruner {
         let schema = Arc::new(partition_schema.clone());
         let is_hive_style: bool = hudi_configs
             .get_or_default(HudiTableConfig::IsHiveStylePartitioning)
-            .to();
+            .into();
         let is_url_encoded: bool = hudi_configs
             .get_or_default(HudiTableConfig::IsPartitionPathUrlencoded)
-            .to();
+            .into();
         Ok(PartitionPruner {
             schema,
             is_hive_style,

--- a/crates/core/src/table/partition.rs
+++ b/crates/core/src/table/partition.rs
@@ -34,9 +34,7 @@ pub const EMPTY_PARTITION_PATH: &str = "";
 
 pub fn is_table_partitioned(hudi_configs: &HudiConfigs) -> bool {
     let has_partition_fields = {
-        let partition_fields: Vec<String> = hudi_configs
-            .get_or_default(PartitionFields)
-            .into();
+        let partition_fields: Vec<String> = hudi_configs.get_or_default(PartitionFields).into();
         !partition_fields.is_empty()
     };
 

--- a/crates/core/src/table/validation.rs
+++ b/crates/core/src/table/validation.rs
@@ -28,10 +28,7 @@ use crate::merge::record_merger::RecordMerger;
 use strum::IntoEnumIterator;
 
 pub fn validate_configs(hudi_configs: &HudiConfigs) -> crate::error::Result<()> {
-    if hudi_configs
-        .get_or_default(SkipConfigValidation)
-        .into()
-    {
+    if hudi_configs.get_or_default(SkipConfigValidation).into() {
         return Ok(());
     }
 
@@ -58,9 +55,7 @@ pub fn validate_configs(hudi_configs: &HudiConfigs) -> crate::error::Result<()> 
         ));
     }
 
-    let drops_partition_cols = hudi_configs
-        .get_or_default(DropsPartitionFields)
-        .into();
+    let drops_partition_cols = hudi_configs.get_or_default(DropsPartitionFields).into();
     if drops_partition_cols {
         return Err(CoreError::Unsupported(format!(
             "Only support when `{}` is disabled",

--- a/crates/core/src/table/validation.rs
+++ b/crates/core/src/table/validation.rs
@@ -30,7 +30,7 @@ use strum::IntoEnumIterator;
 pub fn validate_configs(hudi_configs: &HudiConfigs) -> crate::error::Result<()> {
     if hudi_configs
         .get_or_default(SkipConfigValidation)
-        .to::<bool>()
+        .into()
     {
         return Ok(());
     }
@@ -44,14 +44,14 @@ pub fn validate_configs(hudi_configs: &HudiConfigs) -> crate::error::Result<()> 
     }
 
     // additional validation
-    let table_version = hudi_configs.get(TableVersion)?.to::<isize>();
+    let table_version: isize = hudi_configs.get(TableVersion)?.into();
     if table_version != 6 {
         return Err(CoreError::Unsupported(
             "Only support table version 6.".to_string(),
         ));
     }
 
-    let timeline_layout_version = hudi_configs.get(TimelineLayoutVersion)?.to::<isize>();
+    let timeline_layout_version: isize = hudi_configs.get(TimelineLayoutVersion)?.into();
     if timeline_layout_version != 1 {
         return Err(CoreError::Unsupported(
             "Only support timeline layout version 1.".to_string(),
@@ -60,7 +60,7 @@ pub fn validate_configs(hudi_configs: &HudiConfigs) -> crate::error::Result<()> 
 
     let drops_partition_cols = hudi_configs
         .get_or_default(DropsPartitionFields)
-        .to::<bool>();
+        .into();
     if drops_partition_cols {
         return Err(CoreError::Unsupported(format!(
             "Only support when `{}` is disabled",

--- a/crates/core/src/timeline/selector.rs
+++ b/crates/core/src/timeline/selector.rs
@@ -149,7 +149,7 @@ impl TimelineSelector {
     fn get_timezone_from_configs(hudi_configs: &HudiConfigs) -> String {
         hudi_configs
             .get_or_default(HudiTableConfig::TimelineTimezone)
-            .to::<String>()
+            .into()
     }
 
     fn parse_datetime(timezone: &str, timestamp: Option<&str>) -> Result<Option<DateTime<Utc>>> {

--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -101,7 +101,7 @@ impl HudiDataSource {
         self.table
             .hudi_configs
             .get_or_default(InputPartitions)
-            .to::<usize>()
+            .into()
     }
 
     /// Check if the given expression can be pushed down to the Hudi table.


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
- delete custom `.to::<T>()` method from `HudiConfigValue`
- replaced all `.to::<Type>()` calls with standard `.into()` patterns across the codebase
<!--- If it fixes an open issue, please link to the issue here. -->
closes #368
<!--- Please link any related issues and PRs as well. -->

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
