### PR TITLE
fix: replace Windows backslashes with forward slashes in paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: add windows which does not support container
         os: [ ubuntu-24.04 ]
     runs-on: ${{ matrix.os }}
     container:
@@ -76,6 +75,13 @@ jobs:
           name: cov-report-rust-tests-${{ runner.os }}
           path: ./cov-reports
           if-no-files-found: 'error'
+
+  rust-tests-windows:
+    runs-on: windows-2025
+    steps:
+      - uses: actions/checkout@v5
+      - name: Run unit tests on Windows with no coverage report
+        run: cargo test --no-fail-fast --all-targets --all-features --workspace
 
   python-tests:
     strategy:

--- a/crates/core/src/file_group/file_slice.rs
+++ b/crates/core/src/file_group/file_slice.rs
@@ -19,7 +19,7 @@
 use crate::error::CoreError;
 use crate::file_group::base_file::BaseFile;
 use crate::file_group::log_file::LogFile;
-use crate::storage::util::join_storage_path;
+use crate::storage::util::join_path_segments;
 use crate::storage::Storage;
 use crate::Result;
 use std::collections::BTreeSet;
@@ -78,10 +78,10 @@ impl FileSlice {
     }
 
     fn relative_path_for_file(&self, file_name: &str) -> Result<String> {
-        Ok(join_storage_path(&[
+        Ok(join_path_segments(&[
             self.partition_path.as_str(),
             file_name,
-        ]))
+        ])?)
     }
 
     /// Returns the relative path of the [BaseFile] in the [FileSlice].

--- a/crates/core/src/file_group/file_slice.rs
+++ b/crates/core/src/file_group/file_slice.rs
@@ -19,11 +19,11 @@
 use crate::error::CoreError;
 use crate::file_group::base_file::BaseFile;
 use crate::file_group::log_file::LogFile;
+use crate::storage::util::join_storage_path;
 use crate::storage::Storage;
 use crate::Result;
 use std::collections::BTreeSet;
 use std::fmt::Display;
-use std::path::PathBuf;
 
 /// Within a [crate::file_group::FileGroup],
 /// a [FileSlice] is a logical group of [BaseFile] and [LogFile]s.
@@ -78,10 +78,10 @@ impl FileSlice {
     }
 
     fn relative_path_for_file(&self, file_name: &str) -> Result<String> {
-        let path = PathBuf::from(self.partition_path.as_str()).join(file_name);
-        path.to_str().map(|s| s.to_string()).ok_or_else(|| {
-            CoreError::FileGroup(format!("Failed to get relative path for file: {file_name}",))
-        })
+        Ok(join_storage_path(&[
+            self.partition_path.as_str(),
+            file_name,
+        ]))
     }
 
     /// Returns the relative path of the [BaseFile] in the [FileSlice].

--- a/crates/core/src/file_group/log_file/reader.rs
+++ b/crates/core/src/file_group/log_file/reader.rs
@@ -289,36 +289,47 @@ mod tests {
     use crate::storage::util::parse_uri;
     use apache_avro::schema::Schema as AvroSchema;
     use std::fs::canonicalize;
-    use std::path::PathBuf;
 
     fn get_valid_log_avro_data() -> (String, String) {
-        let dir = PathBuf::from("tests/data/log_files/valid_log_avro_data");
         (
-            canonicalize(dir).unwrap().to_str().unwrap().to_string(),
+            canonicalize("tests/data/log_files/valid_log_avro_data")
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string(),
             ".ff32ab89-5ad0-4968-83b4-89a34c95d32f-0_20250316025816068.log.1_0-54-122".to_string(),
         )
     }
 
     fn get_valid_log_parquet_data() -> (String, String) {
-        let dir = PathBuf::from("tests/data/log_files/valid_log_parquet_data");
         (
-            canonicalize(dir).unwrap().to_str().unwrap().to_string(),
+            canonicalize("tests/data/log_files/valid_log_parquet_data")
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string(),
             ".ee2ace10-7667-40f5-9848-0a144b5ea064-0_20250113230302428.log.1_0-188-387".to_string(),
         )
     }
 
     fn get_valid_log_delete() -> (String, String) {
-        let dir = PathBuf::from("tests/data/log_files/valid_log_delete");
         (
-            canonicalize(dir).unwrap().to_str().unwrap().to_string(),
+            canonicalize("tests/data/log_files/valid_log_delete")
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string(),
             ".6d3d1d6e-2298-4080-a0c1-494877d6f40a-0_20250618054711154.log.1_0-26-85".to_string(),
         )
     }
 
     fn get_valid_log_rollback() -> (String, String) {
-        let dir = PathBuf::from("tests/data/log_files/valid_log_rollback");
         (
-            canonicalize(dir).unwrap().to_str().unwrap().to_string(),
+            canonicalize("tests/data/log_files/valid_log_rollback")
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string(),
             ".0712b9f9-d2d5-4cae-bcf4-8fd7146af503-0_20250126040823628.log.2_1-0-1".to_string(),
         )
     }

--- a/crates/core/src/file_group/reader.rs
+++ b/crates/core/src/file_group/reader.rs
@@ -275,51 +275,34 @@ mod tests {
     use arrow::record_batch::RecordBatch;
     use arrow_schema::{DataType, Field, Schema};
     use std::fs::canonicalize;
-    use std::path::PathBuf;
     use std::sync::Arc;
-    use url::Url;
 
     fn get_non_existent_base_uri() -> String {
         "file:///non-existent-path/table".to_string()
     }
 
     fn get_base_uri_with_valid_props() -> String {
-        let url = Url::from_file_path(
-            canonicalize(
-                PathBuf::from("tests")
-                    .join("data")
-                    .join("table_props_valid"),
-            )
-            .unwrap(),
-        )
-        .unwrap();
-        url.as_ref().to_string()
+        canonicalize("tests/data/table_props_valid")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string()
     }
 
     fn get_base_uri_with_valid_props_minimum() -> String {
-        let url = Url::from_file_path(
-            canonicalize(
-                PathBuf::from("tests")
-                    .join("data")
-                    .join("table_props_valid_minimum"),
-            )
-            .unwrap(),
-        )
-        .unwrap();
-        url.as_ref().to_string()
+        canonicalize("tests/data/table_props_valid_minimum")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string()
     }
 
     fn get_base_uri_with_invalid_props() -> String {
-        let url = Url::from_file_path(
-            canonicalize(
-                PathBuf::from("tests")
-                    .join("data")
-                    .join("table_props_invalid"),
-            )
-            .unwrap(),
-        )
-        .unwrap();
-        url.as_ref().to_string()
+        canonicalize("tests/data/table_props_invalid")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string()
     }
 
     #[test]

--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -173,8 +173,8 @@ impl Storage {
         Ok(bytes)
     }
 
-    pub async fn get_file_data_from_absolute_path(&self, absolute_path: &str) -> Result<Bytes> {
-        let obj_path = ObjPath::from(absolute_path);
+    pub async fn get_file_data_from_url_path(&self, path: impl AsRef<str>) -> Result<Bytes> {
+        let obj_path = ObjPath::from_url_path(path)?;
         let result = self.object_store.get(&obj_path).await?;
         let bytes = result.bytes().await?;
         Ok(bytes)
@@ -283,10 +283,12 @@ pub async fn get_leaf_dirs(storage: &Storage, subdir: Option<&str>) -> Result<Ve
                 next_subdir.push(curr);
             }
             next_subdir.push(child_dir);
-            let next_subdir = next_subdir
+            let next_subdir_str = next_subdir
                 .to_str()
                 .ok_or_else(|| InvalidPath(format!("Failed to convert path: {:?}", next_subdir)))?;
-            let curr_leaf_dir = get_leaf_dirs(storage, Some(next_subdir)).await?;
+            // Normalize to forward slashes for consistency across platforms
+            let next_subdir_normalized = next_subdir_str.replace('\\', "/");
+            let curr_leaf_dir = get_leaf_dirs(storage, Some(&next_subdir_normalized)).await?;
             leaf_dirs.extend(curr_leaf_dir);
         }
     }

--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -40,7 +40,7 @@ use crate::storage::error::StorageError::{Creation, InvalidPath};
 use crate::storage::error::{Result, StorageError};
 use crate::storage::file_metadata::FileMetadata;
 use crate::storage::reader::StorageReader;
-use crate::storage::util::{join_path_for_cloud, join_path_for_local_fs, join_url_segments};
+use crate::storage::util::join_url_segments;
 
 pub mod error;
 pub mod file_metadata;
@@ -95,20 +95,6 @@ impl Storage {
             Arc::new(HashMap::new()),
             Arc::new(HudiConfigs::new(hudi_options)),
         )
-    }
-
-    /// Joins path segments into a storage path based on the storage type.
-    ///
-    /// # Arguments
-    /// * `segments` - Path segments to join
-    ///
-    /// # Returns
-    /// A normalized path string
-    pub fn join_path(&self, segments: &[&str]) -> String {
-        match self.base_url.scheme() {
-            "file" => join_path_for_local_fs(segments),
-            _ => join_path_for_cloud(segments),
-        }
     }
 
     #[cfg(feature = "datafusion")]
@@ -188,7 +174,7 @@ impl Storage {
     }
 
     pub async fn get_file_data_from_absolute_path(&self, absolute_path: &str) -> Result<Bytes> {
-        let obj_path = ObjPath::from_absolute_path(PathBuf::from(absolute_path))?;
+        let obj_path = ObjPath::from(absolute_path);
         let result = self.object_store.get(&obj_path).await?;
         let bytes = result.bytes().await?;
         Ok(bytes)
@@ -292,12 +278,15 @@ pub async fn get_leaf_dirs(storage: &Storage, subdir: Option<&str>) -> Result<Ve
         leaf_dirs.push(subdir.unwrap_or_default().to_owned());
     } else {
         for child_dir in child_dirs {
-            let next_subdir = if let Some(curr) = subdir {
-                storage.join_path(&[curr, &child_dir])
-            } else {
-                child_dir
-            };
-            let curr_leaf_dir = get_leaf_dirs(storage, Some(&next_subdir)).await?;
+            let mut next_subdir = PathBuf::new();
+            if let Some(curr) = subdir {
+                next_subdir.push(curr);
+            }
+            next_subdir.push(child_dir);
+            let next_subdir = next_subdir
+                .to_str()
+                .ok_or_else(|| InvalidPath(format!("Failed to convert path: {:?}", next_subdir)))?;
+            let curr_leaf_dir = get_leaf_dirs(storage, Some(next_subdir)).await?;
             leaf_dirs.extend(curr_leaf_dir);
         }
     }

--- a/crates/core/src/storage/util.rs
+++ b/crates/core/src/storage/util.rs
@@ -18,6 +18,7 @@
  */
 
 //! Utility functions for storage.
+use object_store::path::Path as ObjectPath;
 use url::Url;
 
 use crate::storage::error::StorageError::{InvalidPath, UrlParseError};
@@ -27,7 +28,25 @@ use crate::storage::Result;
 pub fn parse_uri(uri: &str) -> Result<Url> {
     let mut url = match Url::parse(uri) {
         Ok(url) => url,
-        Err(e) => Url::from_directory_path(uri).map_err(|_| UrlParseError(e))?,
+        Err(e) => {
+            let path = std::path::Path::new(uri);
+
+            let absolute_path = if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                std::env::current_dir()
+                    .map_err(|_| UrlParseError(e))?
+                    .join(path)
+            };
+
+            let final_path = if absolute_path.exists() {
+                absolute_path
+            } else {
+                absolute_path.canonicalize().unwrap_or(absolute_path)
+            };
+
+            Url::from_file_path(&final_path).map_err(|_| UrlParseError(e))?
+        }
     };
 
     if url.path().ends_with('/') {
@@ -41,6 +60,73 @@ pub fn parse_uri(uri: &str) -> Result<Url> {
 /// Returns the scheme and authority of a URL in the form of `scheme://authority`.
 pub fn get_scheme_authority(url: &Url) -> String {
     format!("{}://{}", url.scheme(), url.authority())
+}
+
+/// Normalizes and flattens path segments by splitting on '/' and filtering empty parts.
+///
+/// # Arguments
+/// * `segments` - Path segments to normalize
+///
+/// # Returns
+/// A vector of non-empty, trimmed path parts
+fn normalize_path_segments(segments: &[&str]) -> Vec<String> {
+    segments
+        .iter()
+        .flat_map(|s| {
+            s.split('/')
+                .filter(|part| !part.is_empty())
+                .map(|part| part.trim().to_string())
+        })
+        .collect()
+}
+
+/// Joins path segments for local filesystem using `std::path::PathBuf`.
+///
+/// # Arguments
+/// * `segments` - Path segments to join
+///
+/// # Returns
+/// A normalized path string with platform-specific separators
+pub fn join_path_for_local_fs(segments: &[&str]) -> String {
+    let parts = normalize_path_segments(segments);
+    if parts.is_empty() {
+        return String::new();
+    }
+
+    let mut path = std::path::PathBuf::new();
+    for part in parts {
+        path.push(part);
+    }
+    path.to_string_lossy().to_string()
+}
+
+/// Joins path segments for cloud storage using `object_store::path::Path`.
+///
+/// # Arguments
+/// * `segments` - Path segments to join
+///
+/// # Returns
+/// A normalized path string with forward slashes as separators
+pub fn join_path_for_cloud(segments: &[&str]) -> String {
+    let parts = normalize_path_segments(segments);
+    if parts.is_empty() {
+        return String::new();
+    }
+    ObjectPath::from_iter(parts).as_ref().to_string()
+}
+
+/// Joins path segments into a storage path.
+///
+/// This function uses `object_store::path::Path` which handles path normalization
+/// consistently across local filesystem and cloud storage (S3, GCS, Azure, etc.).
+///
+/// # Arguments
+/// * `segments` - Path segments to join
+///
+/// # Returns
+/// A normalized path string with forward slashes as separators
+pub fn join_storage_path(segments: &[&str]) -> String {
+    join_path_for_cloud(segments)
 }
 
 /// Joins a base URL with a list of segments.
@@ -124,5 +210,100 @@ mod tests {
         let base_url = Url::from_str("foo:text/plain,bar").unwrap();
         let result = join_url_segments(&base_url, &["foo"]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_join_storage_path() {
+        assert_eq!(
+            join_storage_path(&[".hoodie", "file.commit"]),
+            ".hoodie/file.commit"
+        );
+        assert_eq!(join_storage_path(&["path", "to", "file"]), "path/to/file");
+        assert_eq!(
+            join_storage_path(&["/path/", "/to/", "/file/"]),
+            "path/to/file"
+        );
+        assert_eq!(join_storage_path(&[""]), "");
+        assert_eq!(
+            join_storage_path(&["", "path", "", "file", ""]),
+            "path/file"
+        );
+        assert_eq!(
+            join_storage_path(&["part1", "part2", "subpart"]),
+            "part1/part2/subpart"
+        );
+    }
+
+    #[test]
+    fn test_parse_uri_path_handling() {
+        // Relative path made absolute
+        let result = parse_uri("my_data/hudi_table").unwrap();
+        assert_eq!(result.scheme(), "file");
+        let path = result.path();
+        assert!(
+            path.starts_with('/') || path.contains(":/"),
+            "Path should be absolute but got: {}",
+            path
+        );
+        assert!(path.contains("my_data"));
+        assert!(path.contains("hudi_table"));
+
+        // Current directory relative
+        let result = parse_uri(".").unwrap();
+        assert_eq!(result.scheme(), "file");
+        let path = result.path();
+        assert!(
+            path.starts_with('/') || path.contains(":/"),
+            "Current dir should resolve to absolute path"
+        );
+
+        // Non-existent path
+        let nonexistent = "/this/path/definitely/does/not/exist/xyz123";
+        let result = parse_uri(nonexistent).unwrap();
+        assert_eq!(result.scheme(), "file");
+        assert!(result.path().contains("this/path/definitely"));
+
+        // Temp directory
+        let temp_dir = std::env::temp_dir();
+        let temp_path_str = temp_dir.to_string_lossy().to_string();
+        let result = parse_uri(&temp_path_str).unwrap();
+        assert_eq!(result.scheme(), "file");
+        assert!(!result.path().is_empty());
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn test_parse_uri_windows_paths() {
+        // Windows absolute path
+        let result = parse_uri(r"C:\Users\test\data").unwrap();
+        assert_eq!(result.scheme(), "file");
+        let path = result.path();
+        assert!(
+            path.contains("Users") && path.contains("test") && path.contains("data"),
+            "Path should contain all components but got: {}",
+            path
+        );
+
+        // Windows temp path
+        let temp_dir = std::env::temp_dir();
+        let temp_str = temp_dir.to_string_lossy().to_string();
+        let result = parse_uri(&temp_str);
+        assert!(
+            result.is_ok(),
+            "Windows temp path should parse successfully"
+        );
+        if let Ok(url) = result {
+            assert_eq!(url.scheme(), "file");
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_parse_uri_unix_symlinks() {
+        // Symlinks not resolved for existing paths
+        let result = parse_uri("/tmp").unwrap();
+        assert_eq!(result.scheme(), "file");
+        let path = result.path();
+        assert!(path.ends_with("tmp") || path.contains("/tmp"));
     }
 }

--- a/crates/core/src/storage/util.rs
+++ b/crates/core/src/storage/util.rs
@@ -27,15 +27,10 @@ use crate::storage::Result;
 
 /// Parses a URI string into a URL.
 pub fn parse_uri(uri: &str) -> Result<Url> {
-    let mut url = match Url::parse(uri) {
-        Ok(url) => url,
-        Err(e) => Url::from_directory_path(uri).map_err(|_| UrlParseError(e))?,
-    };
-
-    if url.path().ends_with('/') {
-        let err = InvalidPath(format!("Url {:?} cannot be a base", url));
-        url.path_segments_mut().map_err(|_| err)?.pop();
-    }
+    let url = Url::parse(uri).or_else(|e| {
+        let assumed_path = PathBuf::from(uri);
+        Url::from_file_path(assumed_path).map_err(|_| UrlParseError(e))
+    })?;
 
     Ok(url)
 }
@@ -57,10 +52,9 @@ pub fn join_url_segments(base_url: &Url, segments: &[&str]) -> Result<Url> {
     let mut url = base_url.clone();
 
     // Verify URL can be used as a base and get mutable path segments
-    let url_str = url.to_string();
     let mut path_segments = url
         .path_segments_mut()
-        .map_err(|_| InvalidPath(format!("URL '{}' cannot be a base", url_str)))?;
+        .map_err(|_| InvalidPath(format!("URL '{}' cannot be a base", base_url)))?;
 
     // Remove trailing empty segment if path ends with '/'
     path_segments.pop_if_empty();
@@ -76,7 +70,7 @@ pub fn join_url_segments(base_url: &Url, segments: &[&str]) -> Result<Url> {
         }
     }
 
-    drop(path_segments); // Release mutable borrow
+    drop(path_segments);
 
     Ok(url)
 }
@@ -95,307 +89,225 @@ pub fn join_path_segments(segments: &[&str]) -> Result<String> {
         .ok_or_else(|| InvalidPath(format!("Path contains invalid UTF-8: {:?}", path)))
 }
 
-pub fn join_base_path_with_relative_path(base: &str, relative: &str) -> Result<String> {
-    join_base_path_with_segments(base, &[relative])
-}
-
-/// Joins a base path with segments, handling URLs, Windows paths, and Unix paths.
-///
-/// # Arguments
-/// * `base` - Base path (URL like "s3://bucket", Windows like "C:\foo", or Unix like "/tmp")
-/// * `segments` - Path segments to append
-///
-/// # Returns
-/// The joined path as a string, or an error if the input is invalid
-pub fn join_base_path_with_segments(base: &str, segments: &[&str]) -> Result<String> {
-    // 1) Windows absolute path check FIRST (before URL parsing)
-    //    This prevents "C:/foo" from being parsed as a URL with scheme "C"
-    if is_windows_drive_path(base) {
-        let mut path = PathBuf::from(base);
-        for segment in segments {
-            // Split by both separators for flexibility
-            for part in segment.split(&['/', '\\']) {
-                if !part.is_empty() {
-                    path.push(part);
-                }
-            }
-        }
-        return Ok(path.to_string_lossy().into_owned());
-    }
-
-    // 2) Try URL mode: parse base as absolute URL
-    if let Ok(mut url) = Url::parse(base) {
-        // Verify URL can be used as a base (has path segments)
-        let mut path_segments = url
-            .path_segments_mut()
-            .map_err(|_| InvalidPath(format!("URL '{}' cannot be a base", base)))?;
-
-        path_segments.pop_if_empty();
-
-        for segment in segments {
-            // Normalize backslashes to forward slashes for URLs
-            let normalized = segment.replace('\\', "/");
-            for part in normalized.split('/') {
-                if !part.is_empty() {
-                    path_segments.push(part);
-                }
-            }
-        }
-        drop(path_segments); // Release mutable borrow
-
-        return Ok(url.to_string());
-    }
-
-    // 3) Fallback: Unix absolute/relative filesystem paths
-    //    Use PathBuf for proper platform handling
-    let mut path = PathBuf::from(base);
-    for segment in segments {
-        // Split by both separators for flexibility
-        for part in segment.split(&['/', '\\']) {
-            if !part.is_empty() {
-                path.push(part);
-            }
-        }
-    }
-    Ok(path.to_string_lossy().into_owned())
-}
-
-/// Detects if a string starts like a Windows drive path: `C:\` or `C:/`
-fn is_windows_drive_path(path: &str) -> bool {
-    let mut chars = path.chars();
-    match (chars.next(), chars.next(), chars.next()) {
-        (Some(drive), Some(':'), third) if drive.is_ascii_alphabetic() => {
-            third.map(|c| c == '\\' || c == '/').unwrap_or(true)
-        }
-        _ => false,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::str::FromStr;
 
     #[test]
-    fn parse_valid_uri_in_various_forms() {
-        let urls = vec![
-            parse_uri("/foo/").unwrap(),
-            parse_uri("file:/foo/").unwrap(),
-            parse_uri("file:///foo/").unwrap(),
-            parse_uri("hdfs://foo/").unwrap(),
-            parse_uri("s3://foo").unwrap(),
-            parse_uri("s3://foo/").unwrap(),
-            parse_uri("s3a://foo/bar/").unwrap(),
-            parse_uri("gs://foo/").unwrap(),
-            parse_uri("wasb://foo/bar").unwrap(),
-            parse_uri("wasbs://foo/").unwrap(),
-        ];
-        let schemes = vec![
-            "file", "file", "file", "hdfs", "s3", "s3", "s3a", "gs", "wasb", "wasbs",
-        ];
-        let paths = vec![
-            "/foo", "/foo", "/foo", "/", "", "/", "/bar", "/", "/bar", "/",
-        ];
-        assert_eq!(urls.iter().map(|u| u.scheme()).collect::<Vec<_>>(), schemes);
-        assert_eq!(urls.iter().map(|u| u.path()).collect::<Vec<_>>(), paths);
+    fn test_parse_uri_with_valid_url() {
+        let uri = "s3://bucket/path/to/file";
+        let result = parse_uri(uri);
+        assert!(result.is_ok());
+        let url = result.unwrap();
+        assert_eq!(url.scheme(), "s3");
+        assert_eq!(url.host_str(), Some("bucket"));
+        assert_eq!(url.path(), "/path/to/file");
     }
 
     #[test]
-    fn join_base_url_with_segments() {
-        let base_url = Url::from_str("file:///base").unwrap();
-
-        assert_eq!(
-            join_url_segments(&base_url, &["foo"]).unwrap(),
-            Url::from_str("file:///base/foo").unwrap()
-        );
-
-        assert_eq!(
-            join_url_segments(&base_url, &["/foo"]).unwrap(),
-            Url::from_str("file:///base/foo").unwrap()
-        );
-
-        assert_eq!(
-            join_url_segments(&base_url, &["/foo", "bar/", "/baz/"]).unwrap(),
-            Url::from_str("file:///base/foo/bar/baz").unwrap()
-        );
-
-        assert_eq!(
-            join_url_segments(&base_url, &["foo/", "", "bar/baz"]).unwrap(),
-            Url::from_str("file:///base/foo/bar/baz").unwrap()
-        );
-
-        assert_eq!(
-            join_url_segments(&base_url, &["foo1/bar1", "foo2/bar2"]).unwrap(),
-            Url::from_str("file:///base/foo1/bar1/foo2/bar2").unwrap()
-        );
+    fn test_parse_uri_with_http_url() {
+        let uri = "http://example.com:8080/path?query=value";
+        let result = parse_uri(uri);
+        assert!(result.is_ok());
+        let url = result.unwrap();
+        assert_eq!(url.scheme(), "http");
+        assert_eq!(url.host_str(), Some("example.com"));
+        assert_eq!(url.port(), Some(8080));
+        assert_eq!(url.path(), "/path");
+        assert_eq!(url.query(), Some("query=value"));
     }
 
     #[test]
-    fn join_failed_due_to_invalid_base() {
-        let base_url = Url::from_str("foo:text/plain,bar").unwrap();
-        let result = join_url_segments(&base_url, &["foo"]);
+    fn test_parse_uri_with_file_path() {
+        // Test parsing a file path - should convert to file:// URL
+        let uri = "/tmp/test/file.txt";
+        let result = parse_uri(uri);
+        assert!(result.is_ok());
+        let url = result.unwrap();
+        assert_eq!(url.scheme(), "file");
+    }
+
+    #[test]
+    fn test_parse_uri_with_relative_path() {
+        let uri = "relative/path/to/file";
+        let result = parse_uri(uri);
+        // Relative paths should fail with Url::parse but might succeed with from_file_path
+        // depending on the current working directory
+        assert!(result.is_ok() || result.is_err());
+    }
+
+    #[test]
+    fn test_parse_uri_with_windows_path() {
+        let uri = "C:\\Users\\test\\file.txt";
+        let result = parse_uri(uri);
+        // Windows paths should be converted to file:// URLs
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_parse_uri_with_hdfs_url() {
+        let uri = "hdfs://namenode:9000/user/hive/warehouse";
+        let result = parse_uri(uri);
+        assert!(result.is_ok());
+        let url = result.unwrap();
+        assert_eq!(url.scheme(), "hdfs");
+        assert_eq!(url.host_str(), Some("namenode"));
+        assert_eq!(url.port(), Some(9000));
+    }
+
+    #[test]
+    fn test_get_scheme_authority_with_s3() {
+        let url = Url::parse("s3://my-bucket/path/to/file").unwrap();
+        let result = get_scheme_authority(&url);
+        assert_eq!(result, "s3://my-bucket");
+    }
+
+    #[test]
+    fn test_get_scheme_authority_with_http() {
+        let url = Url::parse("http://example.com:8080/path").unwrap();
+        let result = get_scheme_authority(&url);
+        assert_eq!(result, "http://example.com:8080");
+    }
+
+    #[test]
+    fn test_get_scheme_authority_with_file() {
+        let url = Url::parse("file:///tmp/test").unwrap();
+        let result = get_scheme_authority(&url);
+        assert_eq!(result, "file://");
+    }
+
+    #[test]
+    fn test_join_url_segments_basic() {
+        let base_url = Url::parse("s3://bucket/base").unwrap();
+        let segments = vec!["path", "to", "file"];
+        let result = join_url_segments(&base_url, &segments);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().path(), "/base/path/to/file");
+    }
+
+    #[test]
+    fn test_join_url_segments_with_trailing_slash() {
+        let base_url = Url::parse("s3://bucket/base/").unwrap();
+        let segments = vec!["path", "to", "file"];
+        let result = join_url_segments(&base_url, &segments);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().path(), "/base/path/to/file");
+    }
+
+    #[test]
+    fn test_join_url_segments_with_empty_segments() {
+        let base_url = Url::parse("s3://bucket/base").unwrap();
+        let segments = vec!["path", "", "file"];
+        let result = join_url_segments(&base_url, &segments);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().path(), "/base/path/file");
+    }
+
+    #[test]
+    fn test_join_url_segments_with_backslashes() {
+        let base_url = Url::parse("s3://bucket/base").unwrap();
+        let segments = vec!["path\\to", "file"];
+        let result = join_url_segments(&base_url, &segments);
+        assert!(result.is_ok());
+        // Backslashes should be converted to forward slashes
+        assert_eq!(result.unwrap().path(), "/base/path/to/file");
+    }
+
+    #[test]
+    fn test_join_url_segments_with_nested_slashes() {
+        let base_url = Url::parse("s3://bucket/base").unwrap();
+        let segments = vec!["path/to/nested", "file"];
+        let result = join_url_segments(&base_url, &segments);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().path(), "/base/path/to/nested/file");
+    }
+
+    #[test]
+    fn test_join_url_segments_with_non_base_url() {
+        // Cannot-be-a-base URLs like "mailto:" should fail
+        let base_url = Url::parse("mailto:user@example.com").unwrap();
+        let segments = vec!["path"];
+        let result = join_url_segments(&base_url, &segments);
         assert!(result.is_err());
     }
 
     #[test]
-    fn test_join_url_segments_backslash_normalization() {
-        let base_url = Url::from_str("s3://bucket/data").unwrap();
+    fn test_join_url_segments_empty_segments_list() {
+        let base_url = Url::parse("s3://bucket/base").unwrap();
+        let segments: Vec<&str> = vec![];
+        let result = join_url_segments(&base_url, &segments);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().path(), "/base");
+    }
 
-        // Backslashes should be normalized to forward slashes
-        assert_eq!(
-            join_url_segments(&base_url, &[r"dir\subdir", "file.txt"]).unwrap(),
-            Url::from_str("s3://bucket/data/dir/subdir/file.txt").unwrap()
-        );
+    #[test]
+    fn test_join_path_segments_basic() {
+        let segments = vec!["path", "to", "file"];
+        let result = join_path_segments(&segments);
+        assert!(result.is_ok());
+        let path = result.unwrap();
+        // Result will vary based on OS
+        assert!(path.contains("path"));
+        assert!(path.contains("to"));
+        assert!(path.contains("file"));
+    }
 
-        // Mixed slashes
+    #[test]
+    fn test_join_path_segments_empty() {
+        let segments: Vec<&str> = vec![];
+        let result = join_path_segments(&segments);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "");
+    }
+
+    #[test]
+    fn test_join_path_segments_single() {
+        let segments = vec!["file"];
+        let result = join_path_segments(&segments);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "file");
+    }
+
+    #[test]
+    fn test_parse_uri_with_gcs_url() {
+        let uri = "gs://my-bucket/path/to/data";
+        let result = parse_uri(uri);
+        assert!(result.is_ok());
+        let url = result.unwrap();
+        assert_eq!(url.scheme(), "gs");
+        assert_eq!(url.host_str(), Some("my-bucket"));
+        assert_eq!(url.path(), "/path/to/data");
+    }
+
+    #[test]
+    fn test_parse_uri_with_azure_url() {
+        let uri = "wasbs://container@account.blob.core.windows.net/path";
+        let result = parse_uri(uri);
+        assert!(result.is_ok());
+        let url = result.unwrap();
+        assert_eq!(url.scheme(), "wasbs");
+    }
+
+    #[test]
+    fn test_join_url_segments_with_special_characters() {
+        let base_url = Url::parse("s3://bucket/base").unwrap();
+        let segments = vec!["path-with-dash", "file_with_underscore"];
+        let result = join_url_segments(&base_url, &segments);
+        assert!(result.is_ok());
         assert_eq!(
-            join_url_segments(&base_url, &[r"dir\sub/dir", r"more\files"]).unwrap(),
-            Url::from_str("s3://bucket/data/dir/sub/dir/more/files").unwrap()
+            result.unwrap().path(),
+            "/base/path-with-dash/file_with_underscore"
         );
     }
 
     #[test]
-    fn test_join_base_path_with_segments_url() {
-        // S3 URL
-        assert_eq!(
-            join_base_path_with_segments("s3://bucket/prefix", &["foo", "bar"]).unwrap(),
-            "s3://bucket/prefix/foo/bar"
-        );
-
-        // File URL
-        assert_eq!(
-            join_base_path_with_segments("file:///tmp", &["foo", "bar.txt"]).unwrap(),
-            "file:///tmp/foo/bar.txt"
-        );
-
-        // URL with backslashes in segments (should normalize to forward slashes)
-        assert_eq!(
-            join_base_path_with_segments("s3://bucket/data", &["dir\\subdir", "file.txt"]).unwrap(),
-            "s3://bucket/data/dir/subdir/file.txt"
-        );
-
-        // URL with empty segments
-        assert_eq!(
-            join_base_path_with_segments("s3://bucket", &["", "foo", "", "bar"]).unwrap(),
-            "s3://bucket/foo/bar"
-        );
-    }
-
-    #[test]
-    fn test_join_base_path_with_segments_windows() {
-        // Windows path with backslash
-        let result =
-            join_base_path_with_segments(r"C:\Users\test", &["Documents", "file.txt"]).unwrap();
-        assert!(result.contains("Users"));
-        assert!(result.contains("test"));
-        assert!(result.contains("Documents"));
-        assert!(result.contains("file.txt"));
-
-        // Windows path with forward slash
-        let result =
-            join_base_path_with_segments("C:/Users/test", &["Documents", "file.txt"]).unwrap();
-        assert!(result.contains("Users"));
-        assert!(result.contains("test"));
-        assert!(result.contains("Documents"));
-        assert!(result.contains("file.txt"));
-
-        // Windows path with mixed separators in segments
-        let result =
-            join_base_path_with_segments(r"D:\data", &["dir/subdir", r"more\files"]).unwrap();
-        assert!(result.contains("data"));
-        assert!(result.contains("dir"));
-        assert!(result.contains("subdir"));
-        assert!(result.contains("more"));
-        assert!(result.contains("files"));
-
-        // Just drive letter
-        let result = join_base_path_with_segments("C:", &["temp", "file.txt"]).unwrap();
-        assert!(result.contains("temp"));
-        assert!(result.contains("file.txt"));
-    }
-
-    #[test]
-    fn test_join_base_path_with_segments_unix() {
-        // Unix absolute path
-        assert_eq!(
-            join_base_path_with_segments("/tmp/data", &["foo", "bar.txt"]).unwrap(),
-            "/tmp/data/foo/bar.txt"
-        );
-
-        // Unix path with backslashes in segments (treated as path separators)
-        let result =
-            join_base_path_with_segments("/home/user", &[r"dir\subdir", "file.txt"]).unwrap();
-        assert!(result.contains("home"));
-        assert!(result.contains("user"));
-        assert!(result.contains("dir"));
-        assert!(result.contains("subdir"));
-        assert!(result.contains("file.txt"));
-
-        // Unix path with empty segments
-        assert_eq!(
-            join_base_path_with_segments("/tmp", &["", "foo", "", "bar"]).unwrap(),
-            "/tmp/foo/bar"
-        );
-    }
-
-    #[test]
-    fn test_join_base_path_with_segments_relative() {
-        // Relative path
-        let result = join_base_path_with_segments("./data", &["foo", "bar.txt"]).unwrap();
-        assert!(result.contains("data"));
-        assert!(result.contains("foo"));
-        assert!(result.contains("bar.txt"));
-
-        // Relative path without prefix
-        let result = join_base_path_with_segments("data/dir", &["foo", "bar.txt"]).unwrap();
-        assert!(result.contains("data"));
-        assert!(result.contains("dir"));
-        assert!(result.contains("foo"));
-        assert!(result.contains("bar.txt"));
-    }
-
-    #[test]
-    fn test_join_base_path_with_segments_error_cases() {
-        // Cannot-be-a-base URL
-        let result = join_base_path_with_segments("mailto:test@example.com", &["foo"]);
-        assert!(result.is_err());
-
-        // Another cannot-be-a-base URL
-        let result = join_base_path_with_segments("data:text/plain,hello", &["bar"]);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_is_windows_drive_path() {
-        // Valid Windows paths
-        assert!(is_windows_drive_path("C:\\"));
-        assert!(is_windows_drive_path("C:/"));
-        assert!(is_windows_drive_path("D:\\path"));
-        assert!(is_windows_drive_path("E:/path"));
-        assert!(is_windows_drive_path("C:"));
-        assert!(is_windows_drive_path("z:"));
-        assert!(is_windows_drive_path("Z:\\"));
-
-        // Invalid Windows paths
-        assert!(!is_windows_drive_path("C"));
-        assert!(!is_windows_drive_path("/C:/"));
-        assert!(!is_windows_drive_path("CC:/"));
-        assert!(!is_windows_drive_path("1:/"));
-        assert!(!is_windows_drive_path("/tmp"));
-        assert!(!is_windows_drive_path("s3://bucket"));
-    }
-
-    #[test]
-    fn test_join_base_path_with_relative_path() {
-        // Test the wrapper function
-        assert_eq!(
-            join_base_path_with_relative_path("s3://bucket/data", "file.txt").unwrap(),
-            "s3://bucket/data/file.txt"
-        );
-
-        assert_eq!(
-            join_base_path_with_relative_path("/tmp", "file.txt").unwrap(),
-            "/tmp/file.txt"
-        );
+    fn test_join_url_segments_preserves_query_params() {
+        let base_url = Url::parse("s3://bucket/base?key=value").unwrap();
+        let segments = vec!["path"];
+        let result = join_url_segments(&base_url, &segments);
+        assert!(result.is_ok());
+        let url = result.unwrap();
+        assert_eq!(url.path(), "/base/path");
+        assert_eq!(url.query(), Some("key=value"));
     }
 }

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -775,7 +775,6 @@ mod tests {
     use hudi_test::{assert_arrow_field_names_eq, assert_avro_field_names_eq, SampleTable};
     use std::collections::HashSet;
     use std::fs::canonicalize;
-    use std::path::PathBuf;
     use std::{env, panic};
 
     /// Test helper to create a new `Table` instance without validating the configuration.
@@ -784,12 +783,9 @@ mod tests {
     ///
     /// * `table_dir_name` - Name of the table root directory; all under `crates/core/tests/data/`.
     fn get_test_table_without_validation(table_dir_name: &str) -> Table {
-        let base_url = Url::from_file_path(
-            canonicalize(PathBuf::from("tests").join("data").join(table_dir_name)).unwrap(),
-        )
-        .unwrap();
+        let base_path = canonicalize("tests/data").unwrap().join(table_dir_name);
         Table::new_with_options_blocking(
-            base_url.as_str(),
+            base_path.to_str().unwrap(),
             [("hoodie.internal.skip.config.validation", "true")],
         )
         .unwrap()

--- a/crates/core/src/timeline/instant.rs
+++ b/crates/core/src/timeline/instant.rs
@@ -19,11 +19,10 @@
 use crate::config::table::TimelineTimezoneValue;
 use crate::error::CoreError;
 use crate::metadata::HUDI_METADATA_DIR;
-use crate::storage::error::StorageError;
+use crate::storage::util::join_storage_path;
 use crate::Result;
 use chrono::{DateTime, Local, NaiveDateTime, TimeZone, Timelike, Utc};
 use std::cmp::Ordering;
-use std::path::PathBuf;
 use std::str::FromStr;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -217,16 +216,7 @@ impl Instant {
     }
 
     pub fn relative_path(&self) -> Result<String> {
-        let mut commit_file_path = PathBuf::from(HUDI_METADATA_DIR);
-        commit_file_path.push(self.file_name());
-        commit_file_path
-            .to_str()
-            .ok_or(StorageError::InvalidPath(format!(
-                "Failed to get file path for {:?}",
-                self
-            )))
-            .map_err(CoreError::Storage)
-            .map(|s| s.to_string())
+        Ok(join_storage_path(&[HUDI_METADATA_DIR, &self.file_name()]))
     }
 
     pub fn is_replacecommit(&self) -> bool {

--- a/crates/core/src/timeline/instant.rs
+++ b/crates/core/src/timeline/instant.rs
@@ -19,7 +19,7 @@
 use crate::config::table::TimelineTimezoneValue;
 use crate::error::CoreError;
 use crate::metadata::HUDI_METADATA_DIR;
-use crate::storage::util::join_storage_path;
+use crate::storage::util::join_path_segments;
 use crate::Result;
 use chrono::{DateTime, Local, NaiveDateTime, TimeZone, Timelike, Utc};
 use std::cmp::Ordering;
@@ -216,7 +216,7 @@ impl Instant {
     }
 
     pub fn relative_path(&self) -> Result<String> {
-        Ok(join_storage_path(&[HUDI_METADATA_DIR, &self.file_name()]))
+        Ok(join_path_segments(&[HUDI_METADATA_DIR, &self.file_name()])?)
     }
 
     pub fn is_replacecommit(&self) -> bool {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Write util functions to replace backslashes with forward slashes when constructing file paths.

<!--- If it fixes an open issue, please link to the issue here. -->
fixes: #445 
<!--- Please link any related issues and PRs as well. -->

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [x] Manual tests (OS: Windows 11, Python: 3.13.7, in real AWS S3 env)
  - [ ] Details are described below
