### PR TITLE
refactor: ignore `.crc` files at storage level

### DIFF
--- a/crates/core/src/table/listing.rs
+++ b/crates/core/src/table/listing.rs
@@ -57,7 +57,7 @@ impl FileLister {
     }
 
     fn should_exclude_for_listing(file_name: &str) -> bool {
-        file_name.starts_with(PARTITION_METAFIELD_PREFIX) || file_name.ends_with(".crc")
+        file_name.starts_with(PARTITION_METAFIELD_PREFIX)
     }
 
     async fn list_file_groups_for_partition(&self, partition_path: &str) -> Result<Vec<FileGroup>> {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Moves `.crc` file filtering logic from table layer to storage layer to make sure all storage consumers automatically exclude `.crc` files.

<!--- If it fixes an open issue, please link to the issue here. -->
closes: #438 
<!--- Please link any related issues and PRs as well. -->

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
