### PR TITLE
refactor: introduce TimelineView and reorganize MDT read APIs for partition pruning

### DIFF
--- a/crates/core/src/file_group/base_file.rs
+++ b/crates/core/src/file_group/base_file.rs
@@ -18,7 +18,7 @@
  */
 use crate::error::CoreError;
 use crate::storage::file_metadata::FileMetadata;
-use crate::timeline::completion_time::TimelineViewByCompletionTime;
+use crate::timeline::completion_time::CompletionTimeView;
 use crate::Result;
 use std::fmt::Display;
 use std::str::FromStr;
@@ -106,7 +106,7 @@ impl BaseFile {
     ///
     /// For v6 tables, the view returns `None` and this is a no-op.
     /// For v8+ tables, this sets the completion timestamp for completed commits.
-    pub fn set_completion_time<V: TimelineViewByCompletionTime>(&mut self, view: &V) {
+    pub fn set_completion_time<V: CompletionTimeView>(&mut self, view: &V) {
         self.completion_timestamp = view
             .get_completion_time(&self.commit_timestamp)
             .map(|s| s.to_string());

--- a/crates/core/src/file_group/log_file/content.rs
+++ b/crates/core/src/file_group/log_file/content.rs
@@ -232,7 +232,7 @@ impl Decoder {
     ///
     /// HFile blocks are used in metadata table log files. Unlike Avro/Parquet blocks,
     /// the content is NOT converted to Arrow RecordBatch because:
-    /// - MDT operations need key-based lookup/merge
+    /// - Metadata table operations need key-based lookup/merge
     /// - Values are Avro-serialized payloads decoded on demand
     ///
     /// The HFile content structure:

--- a/crates/core/src/file_group/log_file/mod.rs
+++ b/crates/core/src/file_group/log_file/mod.rs
@@ -18,7 +18,7 @@
  */
 use crate::error::CoreError;
 use crate::storage::file_metadata::FileMetadata;
-use crate::timeline::completion_time::TimelineViewByCompletionTime;
+use crate::timeline::completion_time::CompletionTimeView;
 use crate::Result;
 use std::cmp::Ordering;
 use std::fmt::Display;
@@ -148,7 +148,7 @@ impl LogFile {
     ///
     /// For v6 tables, the view returns `None` and this is a no-op.
     /// For v8+ tables, this sets the completion timestamp for completed commits.
-    pub fn set_completion_time<V: TimelineViewByCompletionTime>(&mut self, view: &V) {
+    pub fn set_completion_time<V: CompletionTimeView>(&mut self, view: &V) {
         self.completion_timestamp = view
             .get_completion_time(&self.timestamp)
             .map(|s| s.to_string());

--- a/crates/core/src/file_group/log_file/scanner.rs
+++ b/crates/core/src/file_group/log_file/scanner.rs
@@ -304,7 +304,9 @@ mod tests {
     use crate::config::HudiConfigs;
     use crate::file_group::record_batches::RecordBatches;
     use crate::hfile::HFileReader;
-    use crate::metadata::table_record::decode_files_partition_record_with_schema;
+    use crate::metadata::table_record::{
+        decode_files_partition_record_with_schema, FilesPartitionRecord,
+    };
     use crate::storage::util::parse_uri;
     use apache_avro::Schema as AvroSchema;
     use hudi_test::QuickstartTripsTable;
@@ -511,7 +513,7 @@ mod tests {
 
         // Validate __all_partitions__ records
         let all_partitions = records_by_key
-            .get("__all_partitions__")
+            .get(FilesPartitionRecord::ALL_PARTITIONS_KEY)
             .expect("Should have __all_partitions__ records");
         assert_eq!(
             all_partitions.len(),

--- a/crates/core/src/hfile/reader.rs
+++ b/crates/core/src/hfile/reader.rs
@@ -879,20 +879,20 @@ impl HFileReader {
         Ok(HFileIterator { reader: self })
     }
 
-    // ================== HFileRecord API for MDT ==================
+    // ================== HFileRecord API for metadata table ==================
 
     /// Convert a KeyValue to an owned HFileRecord.
     ///
     /// This extracts the key content (without length prefix) and value bytes
-    /// into an owned struct suitable for MDT operations.
+    /// into an owned struct suitable for metadata table operations.
     fn key_value_to_record(kv: &KeyValue) -> HFileRecord {
         HFileRecord::new(kv.key().content().to_vec(), kv.value().to_vec())
     }
 
     /// Collect all records from the HFile as owned HFileRecords.
     ///
-    /// This is useful for MDT operations where records need to be stored
-    /// and merged with log file records.
+    /// This is useful for metadata table operations where records need to be
+    /// stored and merged with log file records.
     ///
     /// # Example
     /// ```ignore
@@ -1998,7 +1998,7 @@ mod tests {
     // 3. "city=san_francisco" - 2 parquet files (UUID: 036ded81-9ed4-479f-bcea-7145dfa0079b)
     // 4. "city=sao_paulo" - 2 parquet files (UUID: 8aa68f7e-afd6-4c94-b86c-8a886552e08d)
 
-    use crate::metadata::table_record::decode_files_partition_record;
+    use crate::metadata::table_record::{decode_files_partition_record, FilesPartitionRecord};
     use hudi_test::QuickstartTripsTable;
 
     /// Get the path to the files partition directory in the test table.
@@ -2062,7 +2062,7 @@ mod tests {
         assert_eq!(
             keys,
             vec![
-                "__all_partitions__",
+                FilesPartitionRecord::ALL_PARTITIONS_KEY,
                 "city=chennai",
                 "city=san_francisco",
                 "city=sao_paulo"
@@ -2100,7 +2100,7 @@ mod tests {
                 .unwrap_or_else(|e| panic!("Failed to decode record for key {}: {}", key, e));
 
             match key {
-                "__all_partitions__" => {
+                FilesPartitionRecord::ALL_PARTITIONS_KEY => {
                     // Validate ALL_PARTITIONS record type and partitions
                     assert_eq!(
                         files_record.record_type,

--- a/crates/core/src/hfile/record.rs
+++ b/crates/core/src/hfile/record.rs
@@ -16,10 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-//! HFile record types for MDT (Metadata Table) operations.
+//! HFile record types for metadata table operations.
 //!
 //! This module provides simple, owned record types for HFile key-value pairs.
-//! These are designed for use in MDT operations where:
+//! These are designed for use in metadata table operations where:
 //! - Records need to be passed around and stored
 //! - Key-based lookups and merging are primary operations
 //! - Values are Avro-serialized payloads decoded on demand
@@ -31,8 +31,8 @@ use std::cmp::Ordering;
 
 /// An owned HFile record with key and value.
 ///
-/// This is a simple struct designed for MDT operations. The key is the
-/// UTF-8 record key (content only, without HFile key structure), and
+/// This is a simple struct designed for metadata table operations. The key is
+/// the UTF-8 record key (content only, without HFile key structure), and
 /// the value is the raw bytes (typically Avro-serialized payload).
 ///
 /// # Example
@@ -83,7 +83,7 @@ impl HFileRecord {
 
     /// Returns whether this record represents a deletion.
     ///
-    /// In MDT, a deleted record has an empty value.
+    /// In metadata table, a deleted record has an empty value.
     pub fn is_deleted(&self) -> bool {
         self.value.is_empty()
     }

--- a/crates/core/src/metadata/mod.rs
+++ b/crates/core/src/metadata/mod.rs
@@ -20,7 +20,8 @@ pub mod commit;
 pub mod merger;
 pub mod meta_field;
 pub mod replace_commit;
-pub mod table_record;
+pub mod table;
+pub use table::records as table_record;
 
 pub const HUDI_METADATA_DIR: &str = ".hoodie";
 pub const DELTALAKE_METADATA_DIR: &str = "_delta_log";

--- a/crates/core/src/metadata/table/mod.rs
+++ b/crates/core/src/metadata/table/mod.rs
@@ -1,0 +1,441 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//! Metadata table APIs for the Hudi Table.
+//!
+//! This module provides methods for interacting with Hudi's metadata table,
+//! which stores file listings and other metadata for efficient table operations.
+
+pub mod records;
+
+use std::collections::HashMap;
+
+use crate::config::read::HudiReadConfig;
+use crate::config::table::HudiTableConfig::{
+    MetadataTableEnabled, MetadataTablePartitions, PartitionFields, TableVersion,
+};
+use crate::error::CoreError;
+use crate::expr::filter::from_str_tuples;
+use crate::metadata::METADATA_TABLE_PARTITION_FIELD;
+use crate::storage::util::join_url_segments;
+use crate::table::partition::PartitionPruner;
+use crate::table::Table;
+use crate::Result;
+
+use records::FilesPartitionRecord;
+
+impl Table {
+    /// Check if this table is a metadata table.
+    ///
+    /// Detection is based on the base path ending with `.hoodie/metadata`.
+    pub fn is_metadata_table(&self) -> bool {
+        let base_path: String = self
+            .hudi_configs
+            .get_or_default(crate::config::table::HudiTableConfig::BasePath)
+            .into();
+        crate::util::path::is_metadata_table_path(&base_path)
+    }
+
+    /// Get the list of available metadata table partitions for this table.
+    ///
+    /// Returns the partitions configured in [`MetadataTablePartitions`].
+    pub fn get_metadata_table_partitions(&self) -> Vec<String> {
+        self.hudi_configs
+            .get_or_default(MetadataTablePartitions)
+            .into()
+    }
+
+    /// Check if the metadata table is enabled.
+    ///
+    /// Returns `true` if:
+    /// 1. Table version is >= 8 (metadata table support is only for v8+ tables), AND
+    /// 2. Table is not a metadata table itself, AND
+    /// 3. Either:
+    ///    - `hoodie.metadata.enable` is explicitly true, OR
+    ///    - `files` is in the configured [`MetadataTablePartitions`]
+    ///
+    /// # Note
+    /// The metadata table is considered active when partitions are configured,
+    /// even without explicit `hoodie.metadata.enable=true`. When metadata table
+    /// is enabled, it must have at least the `files` partition enabled.
+    pub fn is_metadata_table_enabled(&self) -> bool {
+        // TODO: drop v6 support then no need to check table version here
+        let table_version: isize = self
+            .hudi_configs
+            .get(TableVersion)
+            .map(|v| v.into())
+            .unwrap_or(0);
+
+        if table_version < 8 {
+            return false;
+        }
+
+        if self.is_metadata_table() {
+            return false;
+        }
+
+        // Check if "files" partition is configured
+        let has_files_partition = self
+            .get_metadata_table_partitions()
+            .contains(&FilesPartitionRecord::PARTITION_NAME.to_string());
+
+        // Explicit check for hoodie.metadata.enable
+        let metadata_explicitly_enabled: bool = self
+            .hudi_configs
+            .get_or_default(MetadataTableEnabled)
+            .into();
+
+        metadata_explicitly_enabled || has_files_partition
+    }
+
+    /// Create a metadata table instance for this data table.
+    ///
+    /// TODO: support more partitions. Only "files" is used currently.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the metadata table cannot be created or if there are
+    /// no metadata table partitions configured.
+    ///
+    /// # Note
+    /// Must be called on a DATA table, not a METADATA table.
+    pub async fn new_metadata_table(&self) -> Result<Table> {
+        if self.is_metadata_table() {
+            return Err(CoreError::MetadataTable(
+                "Cannot create metadata table from another metadata table".to_string(),
+            ));
+        }
+
+        let mdt_partitions = self.get_metadata_table_partitions();
+        if mdt_partitions.is_empty() {
+            return Err(CoreError::MetadataTable(
+                "No metadata table partitions configured".to_string(),
+            ));
+        }
+
+        let mdt_url = join_url_segments(&self.base_url(), &[".hoodie", "metadata"])?;
+        Table::new_with_options(
+            mdt_url.as_str(),
+            [(PartitionFields.as_ref(), METADATA_TABLE_PARTITION_FIELD)],
+        )
+        .await
+    }
+
+    /// Same as [Table::new_metadata_table], but blocking.
+    pub fn new_metadata_table_blocking(&self) -> Result<Table> {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?
+            .block_on(async { self.new_metadata_table().await })
+    }
+
+    /// Fetch records from the `files` partition of metadata table
+    /// with optional data table partition pruning.
+    ///
+    /// # Note
+    /// Must be called on a DATA table, not a METADATA table.
+    pub async fn read_metadata_table_files_partition(
+        &self,
+        partition_pruner: &PartitionPruner,
+    ) -> Result<HashMap<String, FilesPartitionRecord>> {
+        let metadata_table = self.new_metadata_table().await?;
+        metadata_table
+            .fetch_files_partition_records(partition_pruner)
+            .await
+    }
+
+    /// Same as [Table::read_metadata_table_files_partition], but blocking.
+    pub fn read_metadata_table_files_partition_blocking(
+        &self,
+        partition_pruner: &PartitionPruner,
+    ) -> Result<HashMap<String, FilesPartitionRecord>> {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?
+            .block_on(self.read_metadata_table_files_partition(partition_pruner))
+    }
+
+    /// Fetch records from the `files` partition with optional partition pruning.
+    ///
+    /// # Arguments
+    /// * `partition_pruner` - Data table's partition pruner to filter partitions.
+    ///
+    /// # Note
+    /// Must be called on a METADATA table instance.
+    pub async fn fetch_files_partition_records(
+        &self,
+        partition_pruner: &PartitionPruner,
+    ) -> Result<HashMap<String, FilesPartitionRecord>> {
+        // If no partition filters, read all records (pass empty keys)
+        if partition_pruner.is_empty() {
+            return self.read_files_partition(&[]).await;
+        }
+
+        // Step 1: Get all partition paths
+        let all_partitions_records = self
+            .read_files_partition(&[FilesPartitionRecord::ALL_PARTITIONS_KEY])
+            .await?;
+
+        let partition_names: Vec<&str> = all_partitions_records
+            .get(FilesPartitionRecord::ALL_PARTITIONS_KEY)
+            .map(|r| r.partition_names())
+            .unwrap_or_default();
+
+        // Step 2: Apply partition pruning
+        let pruned: Vec<&str> = partition_names
+            .into_iter()
+            .filter(|p| partition_pruner.should_include(p))
+            .collect();
+
+        if pruned.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        // Step 3: Read only the pruned partition records
+        self.read_files_partition(&pruned).await
+    }
+
+    /// Read records from the `files` partition.
+    ///
+    /// If keys is empty, reads all records. Otherwise, reads only the specified keys.
+    ///
+    /// # Note
+    /// Must be called on a METADATA table instance.
+    async fn read_files_partition(
+        &self,
+        keys: &[&str],
+    ) -> Result<HashMap<String, FilesPartitionRecord>> {
+        let Some(timestamp) = self.timeline.get_latest_commit_timestamp_as_option() else {
+            return Ok(HashMap::new());
+        };
+
+        let timeline_view = self.timeline.create_view_as_of(timestamp).await?;
+
+        let filters = from_str_tuples([(
+            METADATA_TABLE_PARTITION_FIELD,
+            "=",
+            FilesPartitionRecord::PARTITION_NAME,
+        )])?;
+        let partition_schema = self.get_partition_schema().await?;
+        let partition_pruner =
+            PartitionPruner::new(&filters, &partition_schema, self.hudi_configs.as_ref())?;
+
+        let file_slices = self
+            .file_system_view
+            .get_file_slices_by_storage_listing(&partition_pruner, &timeline_view)
+            .await?;
+
+        if file_slices.len() != 1 {
+            return Err(CoreError::MetadataTable(format!(
+                "Expected 1 file slice for {} partition, got {}",
+                FilesPartitionRecord::PARTITION_NAME,
+                file_slices.len()
+            )));
+        }
+
+        let file_slice = file_slices.into_iter().next().unwrap();
+        let fg_reader = self.create_file_group_reader_with_options([(
+            HudiReadConfig::FileGroupEndTimestamp,
+            timestamp,
+        )])?;
+
+        fg_reader
+            .read_metadata_table_files_partition(&file_slice, keys)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::table::HudiTableConfig::TableVersion;
+    use crate::table::partition::PartitionPruner;
+    use hudi_test::{QuickstartTripsTable, SampleTable};
+    use records::{FilesPartitionRecord, MetadataRecordType};
+    use std::collections::HashSet;
+
+    fn get_data_table() -> Table {
+        let table_path = QuickstartTripsTable::V8Trips8I3U1D.path_to_mor_avro();
+        Table::new_blocking(&table_path).unwrap()
+    }
+
+    #[test]
+    fn hudi_table_read_metadata_table_files_partition() {
+        let data_table = get_data_table();
+        let partition_schema = data_table.get_partition_schema_blocking().unwrap();
+        let partition_pruner =
+            PartitionPruner::new(&[], &partition_schema, data_table.hudi_configs.as_ref()).unwrap();
+
+        let records = data_table
+            .read_metadata_table_files_partition_blocking(&partition_pruner)
+            .unwrap();
+
+        // Should have 4 records: __all_partitions__ + 3 city partitions
+        assert_eq!(records.len(), 4);
+
+        // Validate __all_partitions__ record
+        let all_partitions = records
+            .get(FilesPartitionRecord::ALL_PARTITIONS_KEY)
+            .unwrap();
+        assert_eq!(
+            all_partitions.record_type,
+            MetadataRecordType::AllPartitions
+        );
+        let partition_names: HashSet<&str> = all_partitions.partition_names().into_iter().collect();
+        assert_eq!(
+            partition_names,
+            HashSet::from(["city=chennai", "city=san_francisco", "city=sao_paulo"])
+        );
+
+        // Validate city=chennai record with actual file names
+        let chennai = records.get("city=chennai").unwrap();
+        assert_eq!(chennai.record_type, MetadataRecordType::Files);
+        let chennai_files: HashSet<_> = chennai.active_file_names().into_iter().collect();
+        assert_eq!(
+            chennai_files,
+            HashSet::from([
+                "6e1d5cc4-c487-487d-abbe-fe9b30b1c0cc-0_2-986-2794_20251220210108078.parquet",
+                "6e1d5cc4-c487-487d-abbe-fe9b30b1c0cc-0_0-1112-3190_20251220210129235.parquet",
+                ".6e1d5cc4-c487-487d-abbe-fe9b30b1c0cc-0_20251220210127080.log.1_0-1072-3078",
+                ".6e1d5cc4-c487-487d-abbe-fe9b30b1c0cc-0_20251220210128625.log.1_0-1097-3150",
+            ])
+        );
+        assert!(chennai.total_size() > 0);
+    }
+
+    #[test]
+    fn hudi_table_get_metadata_table_partitions() {
+        let data_table = get_data_table();
+
+        // Verify we can get the metadata table partitions from the data table
+        let partitions = data_table.get_metadata_table_partitions();
+
+        // The test table has 5 metadata table partitions configured
+        assert_eq!(
+            partitions.len(),
+            5,
+            "Should have 5 metadata table partitions, got: {:?}",
+            partitions
+        );
+
+        // Verify all expected partitions are present
+        let expected = [
+            "column_stats",
+            "files",
+            "partition_stats",
+            "record_index",
+            "secondary_index_rider_idx",
+        ];
+        for partition in &expected {
+            assert!(
+                partitions.contains(&partition.to_string()),
+                "Should contain '{}' partition, got: {:?}",
+                partition,
+                partitions
+            );
+        }
+    }
+
+    #[test]
+    fn hudi_table_is_metadata_table_enabled() {
+        // V8 table with files partition configured should enable metadata table
+        // even without explicit hoodie.metadata.enable=true
+        let data_table = get_data_table();
+
+        // Verify it's a v8 table
+        let table_version: isize = data_table
+            .hudi_configs
+            .get(TableVersion)
+            .map(|v| v.into())
+            .unwrap_or(0);
+        assert_eq!(table_version, 8, "Test table should be v8");
+
+        // Verify files partition is configured
+        let partitions = data_table.get_metadata_table_partitions();
+        assert!(
+            partitions.contains(&"files".to_string()),
+            "Should have 'files' partition configured"
+        );
+
+        // Verify is_metadata_table_enabled returns true (implicit enablement)
+        assert!(
+            data_table.is_metadata_table_enabled(),
+            "is_metadata_table_enabled should return true for v8 table with files partition"
+        );
+    }
+
+    #[test]
+    fn hudi_table_v6_metadata_table_not_enabled() {
+        // V6 tables should NOT have metadata table enabled, even with explicit setting
+        let base_url = SampleTable::V6Nonpartitioned.url_to_cow();
+        let hudi_table = Table::new_blocking(base_url.path()).unwrap();
+
+        // Verify it's a v6 table
+        let table_version: isize = hudi_table
+            .hudi_configs
+            .get(TableVersion)
+            .map(|v| v.into())
+            .unwrap_or(0);
+        assert_eq!(table_version, 6, "Test table should be v6");
+
+        // V6 tables should not have metadata table enabled
+        assert!(
+            !hudi_table.is_metadata_table_enabled(),
+            "is_metadata_table_enabled should return false for v6 table"
+        );
+    }
+
+    #[test]
+    fn hudi_table_is_not_metadata_table() {
+        // A regular data table should not be a metadata table
+        let base_url = SampleTable::V6Nonpartitioned.url_to_cow();
+        let hudi_table = Table::new_blocking(base_url.path()).unwrap();
+        assert!(
+            !hudi_table.is_metadata_table(),
+            "Regular data table should not be a metadata table"
+        );
+    }
+
+    #[test]
+    fn hudi_table_metadata_table_is_metadata_table() {
+        // Create a metadata table and verify it's recognized as such
+        let data_table = get_data_table();
+        let metadata_table = data_table.new_metadata_table_blocking().unwrap();
+        assert!(
+            metadata_table.is_metadata_table(),
+            "Metadata table should be recognized as a metadata table"
+        );
+    }
+
+    #[test]
+    fn hudi_table_new_metadata_table_from_metadata_table_errors() {
+        // Trying to create a metadata table from a metadata table should fail
+        let data_table = get_data_table();
+        let metadata_table = data_table.new_metadata_table_blocking().unwrap();
+
+        let result = metadata_table.new_metadata_table_blocking();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Cannot create metadata table from another metadata table"),
+            "Error message should indicate cannot create from metadata table"
+        );
+    }
+}

--- a/crates/core/src/timeline/completion_time.rs
+++ b/crates/core/src/timeline/completion_time.rs
@@ -19,201 +19,39 @@
 
 //! Completion time query view for looking up completion timestamps from request timestamps.
 //!
-//! This module provides the [`TimelineViewByCompletionTime`] trait and implementations
-//! for mapping request timestamps to completion timestamps. This is essential for
-//! v8+ tables where file names contain request timestamps but file ordering and
-//! association must be based on completion timestamps.
+//! This module provides the [`CompletionTimeView`] trait for mapping request timestamps
+//! to completion timestamps. This is essential for timeline layout v2 where file names contain
+//! request timestamps but file ordering and association must be based on completion timestamps.
 //!
-//! # Table Version Differences
+//! # Timeline Layout Differences
 //!
-//! - **v6 tables**: Completion timestamps are not tracked. Use [`V6CompletionTimeView`]
-//!   which returns `None` for all lookups (completion_timestamp remains unset).
+//! - **Timeline layout v1**: Completion timestamps are not tracked. The completion time map is empty
+//!   and `get_completion_time()` always returns `None`.
 //!
-//! - **v8+ tables**: Request and completion timestamps are different. The completion timestamp
+//! - **Timeline layout v2**: Completion timestamps are tracked in completed instants. The completion timestamp
 //!   is stored in the timeline instant filename as `{request}_{completion}.{action}`.
-//!   Use [`CompletionTimeView`] to look up completion timestamps from a map.
-
-use crate::timeline::instant::Instant;
-use std::collections::HashMap;
+//!   The completion time map is populated from timeline instants.
+//!
+//! # Implementation
+//!
+//! [`TimelineView`] is the main implementation of this trait. It checks
+//! [`HudiTableConfig::TimelineLayoutVersion`] to determine whether to build the completion time map.
+//!
+//! [`TimelineView`]: crate::timeline::view::TimelineView
+//! [`HudiTableConfig::TimelineLayoutVersion`]: crate::config::table::HudiTableConfig::TimelineLayoutVersion
 
 /// A view for querying completion timestamps from request timestamps.
 ///
 /// This trait abstracts the completion time lookup logic to support both
-/// v6 tables (where completion time is not tracked) and v8+ tables (where
-/// request and completion timestamps differ).
-pub trait TimelineViewByCompletionTime {
+/// V1 and V2 timeline layouts.
+pub trait CompletionTimeView {
     /// Get the completion timestamp for a given request timestamp.
     ///
     /// Returns `Some(completion_timestamp)` if the request timestamp corresponds
     /// to a completed commit, `None` if the commit is pending/unknown or if
-    /// completion time is not tracked (v6 tables).
+    /// completion time is not tracked.
     fn get_completion_time(&self, request_timestamp: &str) -> Option<&str>;
 
     /// Returns true if uncommitted files should be filtered out.
-    ///
-    /// For v8+ tables, this returns true because we track completion times
-    /// and can distinguish committed from uncommitted files.
-    /// For v6 tables, this returns false because completion time is not tracked.
-    fn should_filter_uncommitted(&self) -> bool {
-        false
-    }
-}
-
-/// Completion time view for v6 tables.
-///
-/// In v6, completion time is not tracked separately from request time.
-/// This view always returns `None`, meaning the caller should use the
-/// request timestamp directly for any completion-time-based logic.
-#[derive(Debug, Default)]
-pub struct V6CompletionTimeView;
-
-impl V6CompletionTimeView {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
-impl TimelineViewByCompletionTime for V6CompletionTimeView {
-    fn get_completion_time(&self, _request_timestamp: &str) -> Option<&str> {
-        None
-    }
-}
-
-/// Completion time view for v8+ tables backed by a HashMap.
-///
-/// This view is built from timeline instants and maps request timestamps
-/// to their corresponding completion timestamps.
-#[derive(Debug)]
-pub struct CompletionTimeView {
-    /// Map from request timestamp to completion timestamp
-    request_to_completion: HashMap<String, String>,
-}
-
-impl CompletionTimeView {
-    /// Create a new completion time view from timeline instants.
-    ///
-    /// Only completed instants with a completion timestamp are included.
-    pub fn from_instants<'a, I>(instants: I) -> Self
-    where
-        I: IntoIterator<Item = &'a Instant>,
-    {
-        let request_to_completion = instants
-            .into_iter()
-            .filter_map(|instant| {
-                instant
-                    .completion_timestamp
-                    .as_ref()
-                    .map(|completion_ts| (instant.timestamp.clone(), completion_ts.clone()))
-            })
-            .collect();
-
-        Self {
-            request_to_completion,
-        }
-    }
-
-    /// Create a new empty completion time view.
-    pub fn empty() -> Self {
-        Self {
-            request_to_completion: HashMap::new(),
-        }
-    }
-
-    /// Check if this view has any completion time mappings.
-    pub fn is_empty(&self) -> bool {
-        self.request_to_completion.is_empty()
-    }
-
-    /// Get the number of completion time mappings.
-    pub fn len(&self) -> usize {
-        self.request_to_completion.len()
-    }
-}
-
-impl TimelineViewByCompletionTime for CompletionTimeView {
-    fn get_completion_time(&self, request_timestamp: &str) -> Option<&str> {
-        self.request_to_completion
-            .get(request_timestamp)
-            .map(|s| s.as_str())
-    }
-
-    fn should_filter_uncommitted(&self) -> bool {
-        // Only filter if we have completion time data (v8+ table)
-        !self.is_empty()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::timeline::instant::{Action, State};
-
-    fn create_instant(request_ts: &str, completion_ts: Option<&str>) -> Instant {
-        Instant {
-            timestamp: request_ts.to_string(),
-            completion_timestamp: completion_ts.map(|s| s.to_string()),
-            action: Action::Commit,
-            state: State::Completed,
-            epoch_millis: 0,
-        }
-    }
-
-    #[test]
-    fn test_v6_completion_time_view() {
-        let view = V6CompletionTimeView::new();
-
-        // V6 view always returns None for completion time
-        // (caller should use request time directly for v6 tables)
-        assert!(view.get_completion_time("20240101120000000").is_none());
-        assert!(view.get_completion_time("any_timestamp").is_none());
-    }
-
-    #[test]
-    fn test_timeline_completion_time_view_from_instants() {
-        let instants = vec![
-            create_instant("20240101120000000", Some("20240101120005000")),
-            create_instant("20240101130000000", Some("20240101130010000")),
-            create_instant("20240101140000000", None), // Pending instant
-        ];
-
-        let view = CompletionTimeView::from_instants(&instants);
-
-        // Completed instants should have completion times
-        assert_eq!(
-            view.get_completion_time("20240101120000000"),
-            Some("20240101120005000")
-        );
-        assert_eq!(
-            view.get_completion_time("20240101130000000"),
-            Some("20240101130010000")
-        );
-
-        // Pending instant should not have completion time
-        assert!(view.get_completion_time("20240101140000000").is_none());
-
-        // Unknown timestamp should return None
-        assert!(view.get_completion_time("unknown").is_none());
-    }
-
-    #[test]
-    fn test_timeline_completion_time_view_empty() {
-        let view = CompletionTimeView::empty();
-
-        assert!(view.is_empty());
-        assert_eq!(view.len(), 0);
-        assert!(view.get_completion_time("any").is_none());
-    }
-
-    #[test]
-    fn test_timeline_completion_time_view_len() {
-        let instants = vec![
-            create_instant("20240101120000000", Some("20240101120005000")),
-            create_instant("20240101130000000", Some("20240101130010000")),
-        ];
-
-        let view = CompletionTimeView::from_instants(&instants);
-
-        assert!(!view.is_empty());
-        assert_eq!(view.len(), 2);
-    }
+    fn should_filter_uncommitted(&self) -> bool;
 }

--- a/crates/core/src/timeline/view.rs
+++ b/crates/core/src/timeline/view.rs
@@ -1,0 +1,312 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//! Timeline view for filtering file slices.
+//!
+//! This module provides the [`TimelineView`] struct which encapsulates all
+//! timeline-derived context needed for file slice queries:
+//! - Query timestamp (as of)
+//! - Start timestamp (for incremental queries)
+//! - Completion time mappings
+//! - File groups to be excluded (e.g., replaced by clustering)
+//!
+//! [`TimelineView`] implements [`CompletionTimeView`] trait and is the main
+//! type used for completion time lookups throughout the codebase.
+
+use crate::config::table::HudiTableConfig::TimelineLayoutVersion;
+use crate::config::HudiConfigs;
+use crate::file_group::FileGroup;
+use crate::timeline::completion_time::CompletionTimeView;
+use crate::timeline::instant::Instant;
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+/// Timeline view for filtering file slices.
+///
+/// See module-level documentation for details.
+#[derive(Debug)]
+pub struct TimelineView {
+    /// The "as of" timestamp for the snapshot query.
+    /// It is also the end timestamp for incremental queries.
+    as_of_timestamp: String,
+
+    /// The start timestamp when the view is used for incremental queries.
+    #[allow(dead_code)]
+    start_timestamp: Option<String>,
+
+    /// File groups to exclude from the query result.
+    ///
+    /// These are file groups that have been replaced by clustering
+    /// or insert overwrite operations before the query timestamp.
+    excluding_file_groups: HashSet<FileGroup>,
+
+    /// Map from request timestamp to completion timestamp.
+    ///
+    /// Populated for timeline layout v2. Empty for v1.
+    request_to_completion: HashMap<String, String>,
+
+    /// Whether this table uses timeline layout v2 (completion time tracking).
+    is_timeline_layout_v2: bool,
+}
+
+impl TimelineView {
+    /// Create a new timeline view.
+    ///
+    /// # Arguments
+    /// * `as_of_timestamp` - The "as of" timestamp for the snapshot and time-travel query; also the end timestamp for incremental queries
+    /// * `start_timestamp` - The start timestamp for incremental queries
+    /// * `completed_commits` - Iterator over completed commit instants to build the view from
+    /// * `excluding_file_groups` - File groups to exclude (e.g., replaced by clustering)
+    /// * `hudi_configs` - The shared Hudi configurations
+    pub fn new<'a, I>(
+        as_of_timestamp: String,
+        start_timestamp: Option<String>,
+        completed_commits: I,
+        excluding_file_groups: HashSet<FileGroup>,
+        hudi_configs: &Arc<HudiConfigs>,
+    ) -> Self
+    where
+        I: IntoIterator<Item = &'a Instant>,
+    {
+        // Only build completion time map for timeline layout v2
+        let timeline_layout_version: isize = hudi_configs
+            .get(TimelineLayoutVersion)
+            .map(|v| v.into())
+            .unwrap_or(0);
+
+        let is_timeline_layout_v2 = timeline_layout_version >= 2;
+        let request_to_completion = if is_timeline_layout_v2 {
+            Self::build_completion_time_map(completed_commits)
+        } else {
+            HashMap::new()
+        };
+
+        Self {
+            as_of_timestamp,
+            start_timestamp,
+            excluding_file_groups,
+            request_to_completion,
+            is_timeline_layout_v2,
+        }
+    }
+
+    /// Build the completion time map from instants.
+    fn build_completion_time_map<'a, I>(instants: I) -> HashMap<String, String>
+    where
+        I: IntoIterator<Item = &'a Instant>,
+    {
+        instants
+            .into_iter()
+            .filter_map(|instant| {
+                instant
+                    .completion_timestamp
+                    .as_ref()
+                    .map(|completion_ts| (instant.timestamp.clone(), completion_ts.clone()))
+            })
+            .collect()
+    }
+
+    /// Get the "as of" timestamp for this view.
+    #[inline]
+    pub fn as_of_timestamp(&self) -> &str {
+        &self.as_of_timestamp
+    }
+
+    /// Get the file groups to exclude from the query.
+    #[inline]
+    pub fn excluding_file_groups(&self) -> &HashSet<FileGroup> {
+        &self.excluding_file_groups
+    }
+}
+
+impl CompletionTimeView for TimelineView {
+    fn get_completion_time(&self, request_timestamp: &str) -> Option<&str> {
+        self.request_to_completion
+            .get(request_timestamp)
+            .map(|s| s.as_str())
+    }
+
+    fn should_filter_uncommitted(&self) -> bool {
+        self.is_timeline_layout_v2
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::HudiConfigs;
+    use crate::timeline::instant::{Action, State};
+    fn create_instant(request_ts: &str, completion_ts: Option<&str>) -> Instant {
+        Instant {
+            timestamp: request_ts.to_string(),
+            completion_timestamp: completion_ts.map(|s| s.to_string()),
+            action: Action::Commit,
+            state: State::Completed,
+            epoch_millis: 0,
+        }
+    }
+
+    fn create_layout_v1_configs() -> Arc<HudiConfigs> {
+        Arc::new(HudiConfigs::new([("hoodie.timeline.layout.version", "1")]))
+    }
+
+    fn create_layout_v2_configs() -> Arc<HudiConfigs> {
+        Arc::new(HudiConfigs::new([("hoodie.timeline.layout.version", "2")]))
+    }
+
+    #[test]
+    fn test_snapshot_view_creation_layout_v2() {
+        let instants = vec![
+            create_instant("20240101120000000", Some("20240101120005000")),
+            create_instant("20240101130000000", Some("20240101130010000")),
+        ];
+        let configs = create_layout_v2_configs();
+
+        let view = TimelineView::new(
+            "20240101130000000".to_string(),
+            None,
+            &instants,
+            HashSet::new(),
+            &configs,
+        );
+
+        assert_eq!(view.as_of_timestamp(), "20240101130000000");
+        assert!(view.excluding_file_groups().is_empty());
+        // Layout v2 should have completion time map populated
+        assert!(view.should_filter_uncommitted());
+    }
+
+    #[test]
+    fn test_snapshot_view_creation_layout_v1() {
+        let instants = vec![
+            create_instant("20240101120000000", Some("20240101120005000")),
+            create_instant("20240101130000000", Some("20240101130010000")),
+        ];
+        let configs = create_layout_v1_configs();
+
+        let view = TimelineView::new(
+            "20240101130000000".to_string(),
+            None,
+            &instants,
+            HashSet::new(),
+            &configs,
+        );
+
+        assert_eq!(view.as_of_timestamp(), "20240101130000000");
+        // Layout v1 should NOT have completion time map (empty)
+        assert!(!view.should_filter_uncommitted());
+        assert!(view.get_completion_time("20240101120000000").is_none());
+    }
+
+    #[test]
+    fn test_completion_time_lookup_layout_v2() {
+        let instants = vec![
+            create_instant("20240101120000000", Some("20240101120005000")),
+            create_instant("20240101130000000", Some("20240101130010000")),
+            create_instant("20240101140000000", None), // Pending
+        ];
+        let configs = create_layout_v2_configs();
+
+        let view = TimelineView::new(
+            "20240101140000000".to_string(),
+            None,
+            &instants,
+            HashSet::new(),
+            &configs,
+        );
+
+        // Completed instants have completion time
+        assert_eq!(
+            view.get_completion_time("20240101120000000"),
+            Some("20240101120005000")
+        );
+        assert_eq!(
+            view.get_completion_time("20240101130000000"),
+            Some("20240101130010000")
+        );
+
+        // Pending instant has no completion time
+        assert!(view.get_completion_time("20240101140000000").is_none());
+
+        // Unknown timestamp returns None
+        assert!(view.get_completion_time("unknown").is_none());
+    }
+
+    #[test]
+    fn test_should_filter_uncommitted_layout_v2() {
+        let instants = vec![create_instant(
+            "20240101120000000",
+            Some("20240101120005000"),
+        )];
+        let configs = create_layout_v2_configs();
+
+        let view = TimelineView::new(
+            "20240101120000000".to_string(),
+            None,
+            &instants,
+            HashSet::new(),
+            &configs,
+        );
+
+        // Layout v2 should filter uncommitted
+        assert!(view.should_filter_uncommitted());
+    }
+
+    #[test]
+    fn test_should_not_filter_uncommitted_layout_v1() {
+        // Layout v1 - even with instants that have completion timestamps,
+        // the map is not built, so should_filter_uncommitted returns false
+        let instants = vec![create_instant(
+            "20240101120000000",
+            Some("20240101120005000"),
+        )];
+        let configs = create_layout_v1_configs();
+
+        let view = TimelineView::new(
+            "20240101120000000".to_string(),
+            None,
+            &instants,
+            HashSet::new(),
+            &configs,
+        );
+
+        // Layout v1 does not track completion time
+        assert!(!view.should_filter_uncommitted());
+    }
+
+    #[test]
+    fn test_excluding_file_groups() {
+        let instants: Vec<Instant> = vec![];
+        let configs = create_layout_v2_configs();
+        let mut excludes = HashSet::new();
+        excludes.insert(FileGroup::new("file-id-1".to_string(), "p1".to_string()));
+        excludes.insert(FileGroup::new("file-id-2".to_string(), "p2".to_string()));
+
+        let view = TimelineView::new(
+            "20240101120000000".to_string(),
+            None,
+            &instants,
+            excludes,
+            &configs,
+        );
+
+        assert_eq!(view.excluding_file_groups().len(), 2);
+    }
+}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

- Introduce `TimelineView` struct in `timeline/view.rs` that encapsulates all timeline-derived context for file slice queries (query timestamp, completion time mappings, excluding file groups)
- Reorganize metadata table code into `metadata/table/` module with targeted lookup APIs to support partition pruning
- Simplify `CompletionTimeView` trait to focus on completion time lookup; move implementation logic to `TimelineView`
- Consolidate file group reader's MDT reading APIs

<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please link any related issues and PRs as well. -->

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
