### PR TITLE
fix: consolidate file metadata population for snapshot and incremental queries

### DIFF
--- a/crates/core/src/file_group/file_slice.rs
+++ b/crates/core/src/file_group/file_slice.rs
@@ -136,6 +136,15 @@ impl FileSlice {
     }
 }
 
+/// Load [crate::storage::file_metadata::FileMetadata] for all given [FileSlice]s that don't
+/// already have fully populated metadata.
+pub async fn load_metadata(file_slices: &mut [FileSlice], storage: &Storage) -> Result<()> {
+    for fsl in file_slices {
+        fsl.load_metadata_if_needed(storage).await?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/src/table/fs_view.rs
+++ b/crates/core/src/table/fs_view.rs
@@ -27,7 +27,7 @@ use crate::config::HudiConfigs;
 use crate::config::table::HudiTableConfig::BaseFileFormat;
 use crate::file_group::FileGroup;
 use crate::file_group::builder::file_groups_from_files_partition_records;
-use crate::file_group::file_slice::FileSlice;
+use crate::file_group::file_slice::{self, FileSlice};
 use crate::metadata::table::records::FilesPartitionRecord;
 use crate::storage::Storage;
 use crate::table::Table;
@@ -238,9 +238,7 @@ impl FileSystemView {
             }
         }
 
-        for fsl in &mut file_slices {
-            fsl.load_metadata_if_needed(&self.storage).await?;
-        }
+        file_slice::load_metadata(&mut file_slices, &self.storage).await?;
 
         Ok(file_slices)
     }

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -103,7 +103,7 @@ use crate::config::read::HudiReadConfig;
 use crate::config::table::HudiTableConfig::PartitionFields;
 use crate::config::table::{HudiTableConfig, TableTypeValue};
 use crate::expr::filter::{Filter, from_str_tuples};
-use crate::file_group::file_slice::FileSlice;
+use crate::file_group::file_slice::{self, FileSlice};
 use crate::file_group::reader::FileGroupReader;
 use crate::keygen::is_timestamp_based_keygen;
 use crate::metadata::METADATA_TABLE_PARTITION_FIELD;
@@ -530,6 +530,8 @@ impl Table {
                 file_slices.push(file_slice.clone());
             }
         }
+
+        file_slice::load_metadata(&mut file_slices, &self.file_system_view.storage).await?;
 
         Ok(file_slices)
     }
@@ -1404,6 +1406,18 @@ mod tests {
             "de3550df-e12c-4591-9335-92ff992258a2-0"
         );
         assert!(file_slice_2.log_files.is_empty());
+
+        // Verify file metadata is populated for all file slices (issue #401)
+        for fsl in &file_slices {
+            let metadata = fsl
+                .base_file
+                .file_metadata
+                .as_ref()
+                .expect("file_metadata should be populated");
+            assert!(metadata.fully_populated);
+            assert!(metadata.num_records > 0);
+            assert!(metadata.size > 0);
+        }
     }
 
     #[tokio::test]

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -1408,16 +1408,17 @@ mod tests {
         assert!(file_slice_2.log_files.is_empty());
 
         // Verify file metadata is populated for all file slices (issue #401)
-        for fsl in &file_slices {
-            let metadata = fsl
-                .base_file
-                .file_metadata
-                .as_ref()
-                .expect("file_metadata should be populated");
-            assert!(metadata.fully_populated);
-            assert!(metadata.num_records > 0);
-            assert!(metadata.size > 0);
-        }
+        let metadata_0 = file_slice_0.base_file.file_metadata.as_ref().unwrap();
+        assert!(metadata_0.fully_populated);
+        assert_eq!(metadata_0.num_records, 2);
+
+        let metadata_1 = file_slice_1.base_file.file_metadata.as_ref().unwrap();
+        assert!(metadata_1.fully_populated);
+        assert_eq!(metadata_1.num_records, 1);
+
+        let metadata_2 = file_slice_2.base_file.file_metadata.as_ref().unwrap();
+        assert!(metadata_2.fully_populated);
+        assert_eq!(metadata_2.num_records, 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

Fixes #401.

`get_file_slices_internal()` (snapshot) and `get_file_slices_between_internal()` (incremental) previously diverged on \`FileMetadata\` population. After #548, the snapshot path used a sample-once \`FileStatsEstimator\` cached on \`FileSystemView\`, while the incremental path still returned file slices with \`file_metadata: None\`.

This PR consolidates both paths around a single mechanism:

- \`FileStatsEstimator\` cache moves from \`FileSystemView\` to \`Table\` (single \`OnceCell\` shared across all queries on the same instance).
- \`Table::get_or_init_estimator\` is the single gatekeeper that validates parquet eligibility for the estimator. Documented as data-table-only; HFile metadata tables short-circuit through the same check.
- Estimator is seeded from a base parquet path discovered in commit metadata (latest commit ≤ as-of for snapshot; latest ≤ end-of-window for incremental). MOR delta-only-latest is handled by walking back through prior commits.
- \`file_groups_from_commit_metadata\` now accepts the estimator and populates \`FileMetadata\` from \`HoodieWriteStat::file_size_in_bytes\` exactly like \`file_groups_from_files_partition_records\`.
- \`FileSystemView\` is no longer responsible for estimator lifecycle: \`OnceCell\`, \`get_or_init_estimator\`, and \`find_sample_base_file_path_from_records\` are removed; the parquet check inside \`apply_stats_pruning_from_footers\` (a separate column-stats concern) is inlined.

Net effect: incremental queries now return \`FileSlice\`s with \`size\`, \`byte_size\`, and \`num_records\` populated, matching the snapshot path. The storage-listing snapshot path also gains \`byte_size\` / \`num_records\` as a free side effect of unification.

## How are the changes test-covered

- [x] Automated tests (unit and/or integration tests)