### PR TITLE
fix: order partition schema by config and error on missing fields

### DIFF
--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -102,7 +102,6 @@ use crate::config::HudiConfigs;
 use crate::config::read::HudiReadConfig;
 use crate::config::table::HudiTableConfig::PartitionFields;
 use crate::config::table::{HudiTableConfig, TableTypeValue};
-use crate::error::CoreError;
 use crate::expr::filter::{Filter, from_str_tuples};
 use crate::file_group::file_slice::FileSlice;
 use crate::file_group::reader::FileGroupReader;
@@ -115,7 +114,7 @@ use crate::schema::resolver::{
 use crate::table::builder::TableBuilder;
 use crate::table::file_pruner::FilePruner;
 use crate::table::fs_view::FileSystemView;
-use crate::table::partition::PartitionPruner;
+use crate::table::partition::{PartitionPruner, project_partition_schema};
 use crate::timeline::util::format_timestamp;
 use crate::timeline::{EARLIEST_START_TIMESTAMP, Timeline};
 use crate::util::collection::split_into_chunks;
@@ -806,35 +805,6 @@ impl Table {
     }
 }
 
-/// Build the partition [Schema] in the order declared by `partition_field_names`.
-///
-/// The resulting schema order must match the on-disk partition path segment order
-/// (which follows the `hoodie.table.partition.fields` config), not the arbitrary
-/// column order of the underlying Parquet schema. Returns an error if any declared
-/// partition field is not present in `table_schema`: silently dropping such a field
-/// would make the schema and on-disk path lengths disagree, which `parse_segments`
-/// rejects and `should_include` then treats as fail-open (full-table scan).
-fn project_partition_schema(
-    table_schema: &Schema,
-    partition_field_names: &[String],
-) -> Result<Schema> {
-    let fields: Vec<Arc<Field>> = partition_field_names
-        .iter()
-        .map(|name| {
-            table_schema
-                .field_with_name(name)
-                .map(|f| Arc::new(f.clone()))
-                .map_err(|_| {
-                    CoreError::Schema(format!(
-                        "Partition field `{name}` declared in \
-                         `hoodie.table.partition.fields` is not present in the table schema"
-                    ))
-                })
-        })
-        .collect::<Result<_>>()?;
-    Ok(Schema::new(fields))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1035,53 +1005,6 @@ mod tests {
         assert!(schema.is_ok());
         let schema = schema.unwrap();
         assert_arrow_field_names_eq!(schema, [MetaField::PartitionPath.as_ref()]);
-    }
-
-    #[test]
-    fn project_partition_schema_preserves_config_order() {
-        use arrow::datatypes::{DataType, Field};
-        let table_schema = Schema::new(vec![
-            Field::new("id", DataType::Int32, false),
-            Field::new("integration_id", DataType::Utf8, false),
-            Field::new("resource_type", DataType::Utf8, false),
-            Field::new("org", DataType::Utf8, false),
-            Field::new("payload", DataType::Utf8, false),
-        ]);
-        let partition_field_names = vec![
-            "org".to_string(),
-            "resource_type".to_string(),
-            "integration_id".to_string(),
-        ];
-
-        let projected = project_partition_schema(&table_schema, &partition_field_names).unwrap();
-
-        assert_eq!(projected.fields().len(), 3);
-        assert_eq!(projected.field(0).name(), "org");
-        assert_eq!(projected.field(1).name(), "resource_type");
-        assert_eq!(projected.field(2).name(), "integration_id");
-    }
-
-    #[test]
-    fn project_partition_schema_errors_when_field_missing_from_table_schema() {
-        use arrow::datatypes::{DataType, Field};
-        let table_schema = Schema::new(vec![
-            Field::new("id", DataType::Int32, false),
-            Field::new("org", DataType::Utf8, false),
-        ]);
-        let partition_field_names = vec!["org".to_string(), "not_in_schema".to_string()];
-
-        let err = project_partition_schema(&table_schema, &partition_field_names).unwrap_err();
-
-        assert!(matches!(err, CoreError::Schema(_)));
-        assert!(err.to_string().contains("not_in_schema"));
-    }
-
-    #[test]
-    fn project_partition_schema_empty_config_returns_empty_schema() {
-        use arrow::datatypes::{DataType, Field};
-        let table_schema = Schema::new(vec![Field::new("id", DataType::Int32, false)]);
-        let projected = project_partition_schema(&table_schema, &[]).unwrap();
-        assert_eq!(projected.fields().len(), 0);
     }
 
     #[tokio::test]

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -102,6 +102,7 @@ use crate::config::HudiConfigs;
 use crate::config::read::HudiReadConfig;
 use crate::config::table::HudiTableConfig::PartitionFields;
 use crate::config::table::{HudiTableConfig, TableTypeValue};
+use crate::error::CoreError;
 use crate::expr::filter::{Filter, from_str_tuples};
 use crate::file_group::file_slice::FileSlice;
 use crate::file_group::reader::FileGroupReader;
@@ -287,7 +288,7 @@ impl Table {
             self.hudi_configs.get_or_default(PartitionFields).into();
 
         let schema = self.get_schema().await?;
-        Ok(project_partition_schema(&schema, &partition_field_names))
+        project_partition_schema(&schema, &partition_field_names)
     }
 
     /// Get the [Timeline] of the table.
@@ -807,21 +808,31 @@ impl Table {
 
 /// Build the partition [Schema] in the order declared by `partition_field_names`.
 ///
-/// Fields whose names are not present in `table_schema` are skipped. This is critical
-/// for partition pruning correctness: the resulting schema order must match the
-/// on-disk partition path segment order (which follows the `hoodie.table.partition.fields`
-/// config), not the arbitrary column order of the underlying Parquet schema.
-fn project_partition_schema(table_schema: &Schema, partition_field_names: &[String]) -> Schema {
+/// The resulting schema order must match the on-disk partition path segment order
+/// (which follows the `hoodie.table.partition.fields` config), not the arbitrary
+/// column order of the underlying Parquet schema. Returns an error if any declared
+/// partition field is not present in `table_schema`: silently dropping such a field
+/// would make the schema and on-disk path lengths disagree, which `parse_segments`
+/// rejects and `should_include` then treats as fail-open (full-table scan).
+fn project_partition_schema(
+    table_schema: &Schema,
+    partition_field_names: &[String],
+) -> Result<Schema> {
     let fields: Vec<Arc<Field>> = partition_field_names
         .iter()
-        .filter_map(|name| {
+        .map(|name| {
             table_schema
                 .field_with_name(name)
-                .ok()
                 .map(|f| Arc::new(f.clone()))
+                .map_err(|_| {
+                    CoreError::Schema(format!(
+                        "Partition field `{name}` declared in \
+                         `hoodie.table.partition.fields` is not present in the table schema"
+                    ))
+                })
         })
-        .collect();
-    Schema::new(fields)
+        .collect::<Result<_>>()?;
+    Ok(Schema::new(fields))
 }
 
 #[cfg(test)]
@@ -1042,7 +1053,7 @@ mod tests {
             "integration_id".to_string(),
         ];
 
-        let projected = project_partition_schema(&table_schema, &partition_field_names);
+        let projected = project_partition_schema(&table_schema, &partition_field_names).unwrap();
 
         assert_eq!(projected.fields().len(), 3);
         assert_eq!(projected.field(0).name(), "org");
@@ -1051,7 +1062,7 @@ mod tests {
     }
 
     #[test]
-    fn project_partition_schema_skips_fields_missing_from_table_schema() {
+    fn project_partition_schema_errors_when_field_missing_from_table_schema() {
         use arrow::datatypes::{DataType, Field};
         let table_schema = Schema::new(vec![
             Field::new("id", DataType::Int32, false),
@@ -1059,17 +1070,17 @@ mod tests {
         ]);
         let partition_field_names = vec!["org".to_string(), "not_in_schema".to_string()];
 
-        let projected = project_partition_schema(&table_schema, &partition_field_names);
+        let err = project_partition_schema(&table_schema, &partition_field_names).unwrap_err();
 
-        assert_eq!(projected.fields().len(), 1);
-        assert_eq!(projected.field(0).name(), "org");
+        assert!(matches!(err, CoreError::Schema(_)));
+        assert!(err.to_string().contains("not_in_schema"));
     }
 
     #[test]
     fn project_partition_schema_empty_config_returns_empty_schema() {
         use arrow::datatypes::{DataType, Field};
         let table_schema = Schema::new(vec![Field::new("id", DataType::Int32, false)]);
-        let projected = project_partition_schema(&table_schema, &[]);
+        let projected = project_partition_schema(&table_schema, &[]).unwrap();
         assert_eq!(projected.fields().len(), 0);
     }
 

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -120,7 +120,7 @@ use crate::timeline::{EARLIEST_START_TIMESTAMP, Timeline};
 use crate::util::collection::split_into_chunks;
 use arrow::record_batch::RecordBatch;
 use arrow_schema::{Field, Schema};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 use url::Url;
 
@@ -283,20 +283,11 @@ impl Table {
             )]));
         }
 
-        let partition_fields: HashSet<String> = {
-            let fields: Vec<String> = self.hudi_configs.get_or_default(PartitionFields).into();
-            fields.into_iter().collect()
-        };
+        let partition_field_names: Vec<String> =
+            self.hudi_configs.get_or_default(PartitionFields).into();
 
         let schema = self.get_schema().await?;
-        let partition_fields: Vec<Arc<Field>> = schema
-            .fields()
-            .iter()
-            .filter(|field| partition_fields.contains(field.name()))
-            .cloned()
-            .collect();
-
-        Ok(Schema::new(partition_fields))
+        Ok(project_partition_schema(&schema, &partition_field_names))
     }
 
     /// Get the [Timeline] of the table.
@@ -814,6 +805,25 @@ impl Table {
     }
 }
 
+/// Build the partition [Schema] in the order declared by `partition_field_names`.
+///
+/// Fields whose names are not present in `table_schema` are skipped. This is critical
+/// for partition pruning correctness: the resulting schema order must match the
+/// on-disk partition path segment order (which follows the `hoodie.table.partition.fields`
+/// config), not the arbitrary column order of the underlying Parquet schema.
+fn project_partition_schema(table_schema: &Schema, partition_field_names: &[String]) -> Schema {
+    let fields: Vec<Arc<Field>> = partition_field_names
+        .iter()
+        .filter_map(|name| {
+            table_schema
+                .field_with_name(name)
+                .ok()
+                .map(|f| Arc::new(f.clone()))
+        })
+        .collect();
+    Schema::new(fields)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1014,6 +1024,64 @@ mod tests {
         assert!(schema.is_ok());
         let schema = schema.unwrap();
         assert_arrow_field_names_eq!(schema, [MetaField::PartitionPath.as_ref()]);
+    }
+
+    #[test]
+    fn project_partition_schema_preserves_config_order() {
+        use arrow::datatypes::{DataType, Field};
+        let table_schema = Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("integration_id", DataType::Utf8, false),
+            Field::new("resource_type", DataType::Utf8, false),
+            Field::new("org", DataType::Utf8, false),
+            Field::new("payload", DataType::Utf8, false),
+        ]);
+        let partition_field_names = vec![
+            "org".to_string(),
+            "resource_type".to_string(),
+            "integration_id".to_string(),
+        ];
+
+        let projected = project_partition_schema(&table_schema, &partition_field_names);
+
+        assert_eq!(projected.fields().len(), 3);
+        assert_eq!(projected.field(0).name(), "org");
+        assert_eq!(projected.field(1).name(), "resource_type");
+        assert_eq!(projected.field(2).name(), "integration_id");
+    }
+
+    #[test]
+    fn project_partition_schema_skips_fields_missing_from_table_schema() {
+        use arrow::datatypes::{DataType, Field};
+        let table_schema = Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("org", DataType::Utf8, false),
+        ]);
+        let partition_field_names = vec!["org".to_string(), "not_in_schema".to_string()];
+
+        let projected = project_partition_schema(&table_schema, &partition_field_names);
+
+        assert_eq!(projected.fields().len(), 1);
+        assert_eq!(projected.field(0).name(), "org");
+    }
+
+    #[test]
+    fn project_partition_schema_empty_config_returns_empty_schema() {
+        use arrow::datatypes::{DataType, Field};
+        let table_schema = Schema::new(vec![Field::new("id", DataType::Int32, false)]);
+        let projected = project_partition_schema(&table_schema, &[]);
+        assert_eq!(projected.fields().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn hudi_table_get_partition_schema_uses_config_order_not_table_schema_order() {
+        // V6ComplexkeygenHivestyle declares PARTITIONED BY (byteField, shortField).
+        // The returned partition schema must follow the partition.fields config order,
+        // which also matches the on-disk partition path order: byteField=.../shortField=...
+        let base_url = SampleTable::V6ComplexkeygenHivestyle.url_to_cow();
+        let hudi_table = Table::new(base_url.path()).await.unwrap();
+        let schema = hudi_table.get_partition_schema().await.unwrap();
+        assert_arrow_field_names_eq!(schema, ["byteField", "shortField"]);
     }
 
     #[tokio::test]

--- a/crates/core/src/table/partition.rs
+++ b/crates/core/src/table/partition.rs
@@ -19,13 +19,13 @@
 use crate::Result;
 use crate::config::HudiConfigs;
 use crate::config::table::HudiTableConfig;
-use crate::error::CoreError::InvalidPartitionPath;
+use crate::error::CoreError::{self, InvalidPartitionPath};
 use crate::expr::filter::{Filter, SchemableFilter};
 use crate::keygen::KeyGeneratorFilterTransformer;
 use crate::keygen::timestamp_based::TimestampBasedKeyGenerator;
 
 use arrow_array::{ArrayRef, Scalar};
-use arrow_schema::Schema;
+use arrow_schema::{Field, Schema};
 
 use crate::config::table::HudiTableConfig::{KeyGeneratorClass, KeyGeneratorType, PartitionFields};
 use crate::keygen::is_timestamp_based_keygen;
@@ -35,6 +35,35 @@ use std::sync::Arc;
 
 pub const PARTITION_METAFIELD_PREFIX: &str = ".hoodie_partition_metadata";
 pub const EMPTY_PARTITION_PATH: &str = "";
+
+/// Build the partition [Schema] in the order declared by `partition_field_names`.
+///
+/// The resulting schema order must match the on-disk partition path segment order
+/// (which follows the `hoodie.table.partition.fields` config), not the arbitrary
+/// column order of the underlying Parquet schema. Returns an error if any declared
+/// partition field is not present in `table_schema`: silently dropping such a field
+/// would make the schema and on-disk path lengths disagree, which `parse_segments`
+/// rejects and `should_include` then treats as fail-open (full-table scan).
+pub(crate) fn project_partition_schema(
+    table_schema: &Schema,
+    partition_field_names: &[String],
+) -> Result<Schema> {
+    let fields: Vec<Arc<Field>> = partition_field_names
+        .iter()
+        .map(|name| {
+            table_schema
+                .field_with_name(name)
+                .map(|f| Arc::new(f.clone()))
+                .map_err(|_| {
+                    CoreError::Schema(format!(
+                        "Partition field `{name}` declared in \
+                         `hoodie.table.partition.fields` is not present in the table schema"
+                    ))
+                })
+        })
+        .collect::<Result<_>>()?;
+    Ok(Schema::new(fields))
+}
 
 pub fn is_table_partitioned(hudi_configs: &HudiConfigs) -> bool {
     let has_partition_fields = {
@@ -267,6 +296,51 @@ mod tests {
             (IsPartitionPathUrlencoded, is_url_encoded.to_string()),
         ])
     }
+
+    #[test]
+    fn project_partition_schema_preserves_config_order() {
+        let table_schema = Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("integration_id", DataType::Utf8, false),
+            Field::new("resource_type", DataType::Utf8, false),
+            Field::new("org", DataType::Utf8, false),
+            Field::new("payload", DataType::Utf8, false),
+        ]);
+        let partition_field_names = vec![
+            "org".to_string(),
+            "resource_type".to_string(),
+            "integration_id".to_string(),
+        ];
+
+        let projected = project_partition_schema(&table_schema, &partition_field_names).unwrap();
+
+        assert_eq!(projected.fields().len(), 3);
+        assert_eq!(projected.field(0).name(), "org");
+        assert_eq!(projected.field(1).name(), "resource_type");
+        assert_eq!(projected.field(2).name(), "integration_id");
+    }
+
+    #[test]
+    fn project_partition_schema_errors_when_field_missing_from_table_schema() {
+        let table_schema = Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("org", DataType::Utf8, false),
+        ]);
+        let partition_field_names = vec!["org".to_string(), "not_in_schema".to_string()];
+
+        let err = project_partition_schema(&table_schema, &partition_field_names).unwrap_err();
+
+        assert!(matches!(err, CoreError::Schema(_)));
+        assert!(err.to_string().contains("not_in_schema"));
+    }
+
+    #[test]
+    fn project_partition_schema_empty_config_returns_empty_schema() {
+        let table_schema = Schema::new(vec![Field::new("id", DataType::Int32, false)]);
+        let projected = project_partition_schema(&table_schema, &[]).unwrap();
+        assert_eq!(projected.fields().len(), 0);
+    }
+
     #[test]
     fn test_partition_pruner_new() {
         let schema = create_test_schema();


### PR DESCRIPTION
## Change Logs

`Table::get_partition_schema` built the partition schema in Parquet column order, but `PartitionPruner::parse_segments` zips it positionally against on-disk path segments (which follow `hoodie.table.partition.fields` order). When the two disagree:

- Hive-style: parsing fails, `should_include` fail-opens, every partition is scanned.
- Non-hive-style: values silently associate to the wrong fields, returning incorrect results.

Fix: build the partition schema in config order, and error when a declared partition field is missing from the table schema (previously silently dropped, which produced the same fail-open downstream).

Closes #580.

## Impact

Correctness. Filtered queries on affected tables previously degraded to full-table scans (hive-style) or returned wrong results (non-hive-style). Tables whose partition order already matched Parquet column order are unaffected.

Behavior change: `partition.fields` entries referencing a column that no longer exists in the schema now error instead of being silently dropped.

## Risk level

low

## Documentation Update

None required.