### PR TITLE
refactor: consolidate file metadata population for snapshot and incremental queries

### DIFF
--- a/crates/core/src/file_group/builder.rs
+++ b/crates/core/src/file_group/builder.rs
@@ -78,8 +78,9 @@ pub fn file_groups_from_commit_metadata<V: CompletionTimeView>(
 /// * `commit_metadata` - The commit metadata JSON map
 /// * `completion_time_view` - View to look up completion timestamps.
 /// * `estimator` - Optional [FileStatsEstimator] used to populate `byte_size`
-///   and `num_records` on each base file. When `None`, those fields stay at 0
-///   while `size` is still populated from `HoodieWriteStat::file_size_in_bytes`.
+///   and `num_records` on each base file. When `None`, those fields stay at 0.
+///   `size` is populated from `HoodieWriteStat::file_size_in_bytes` only when
+///   the write stat path identifies the base file.
 pub(crate) fn file_groups_from_commit_metadata_with_estimator<V: CompletionTimeView>(
     commit_metadata: &Map<String, Value>,
     completion_time_view: &V,
@@ -117,10 +118,20 @@ pub(crate) fn file_groups_from_commit_metadata_with_estimator<V: CompletionTimeV
         let mut base_file = BaseFile::from_str(&base_file_name)?;
         base_file.set_completion_time(completion_time_view);
 
-        // Populate FileMetadata when we have a recorded on-disk size. This aligns
-        // the incremental query path with file_groups_from_files_partition_records
-        // so query engines see size/byte_size/num_records consistently.
-        if let Some(file_size) = write_stat.file_size_in_bytes.filter(|s| *s > 0) {
+        let path_file_name = write_stat
+            .path
+            .as_deref()
+            .and_then(|path| Path::new(path).file_name())
+            .and_then(|name| name.to_str());
+        let write_stat_size_is_for_base_file = path_file_name == Some(base_file_name.as_str());
+
+        // Populate FileMetadata only when the write-stat size belongs to the base
+        // file. MOR delta commits can have `baseFile` set while `path` and
+        // `fileSizeInBytes` describe a newly written log file.
+        if let Some(file_size) = write_stat
+            .file_size_in_bytes
+            .filter(|s| write_stat_size_is_for_base_file && *s > 0)
+        {
             let size = file_size as u64;
             let (byte_size, num_records) = estimator.map(|e| e.estimate(size)).unwrap_or((0, 0));
             base_file.file_metadata = Some(FileMetadata {
@@ -714,6 +725,7 @@ mod tests {
                     "p1": [{
                         "fileId": "fid-0",
                         "baseFile": "fid-0_0-7-24_20240418173200000.parquet",
+                        "path": "p1/fid-0_0-7-24_20240418173200000.parquet",
                         "fileSizeInBytes": 4096
                     }]
                 }
@@ -766,6 +778,43 @@ mod tests {
             assert_eq!(m.size, 4096);
             assert_eq!(m.byte_size, 10240); // 4096 * 2.5
             assert_eq!(m.num_records, 40); // 4096 / 100
+        }
+
+        #[test]
+        fn test_mor_log_write_stat_does_not_assign_log_size_to_base_file() {
+            let json = r#"{
+                "partitionToWriteStats": {
+                    "p1": [{
+                        "fileId": "fid-0",
+                        "baseFile": "fid-0_0-7-24_20240418173200000.parquet",
+                        "path": "p1/.fid-0_20240418173200000.log.1_0-8-25",
+                        "fileSizeInBytes": 1148,
+                        "logFiles": [
+                            ".fid-0_20240418173200000.log.1_0-8-25"
+                        ]
+                    }]
+                }
+            }"#;
+            let metadata: Map<String, Value> = serde_json::from_str(json).unwrap();
+            let estimator = FileStatsEstimator::new(100.0, 2.5);
+
+            let groups = file_groups_from_commit_metadata_with_estimator(
+                &metadata,
+                &create_layout_v1_view(),
+                Some(&estimator),
+            )
+            .unwrap();
+            let file_slice = groups
+                .iter()
+                .next()
+                .unwrap()
+                .file_slices
+                .values()
+                .next()
+                .unwrap();
+
+            assert_eq!(file_slice.log_files.len(), 1);
+            assert!(file_slice.base_file.file_metadata.is_none());
         }
 
         #[test]

--- a/crates/core/src/file_group/builder.rs
+++ b/crates/core/src/file_group/builder.rs
@@ -66,10 +66,21 @@ impl FileGroupMerger for HashSet<FileGroup> {
 ///
 /// * `commit_metadata` - The commit metadata JSON map
 /// * `completion_time_view` - View to look up completion timestamps.
+pub fn file_groups_from_commit_metadata<V: CompletionTimeView>(
+    commit_metadata: &Map<String, Value>,
+    completion_time_view: &V,
+) -> Result<HashSet<FileGroup>> {
+    file_groups_from_commit_metadata_with_estimator(commit_metadata, completion_time_view, None)
+}
+
+/// # Arguments
+///
+/// * `commit_metadata` - The commit metadata JSON map
+/// * `completion_time_view` - View to look up completion timestamps.
 /// * `estimator` - Optional [FileStatsEstimator] used to populate `byte_size`
 ///   and `num_records` on each base file. When `None`, those fields stay at 0
 ///   while `size` is still populated from `HoodieWriteStat::file_size_in_bytes`.
-pub(crate) fn file_groups_from_commit_metadata<V: CompletionTimeView>(
+pub(crate) fn file_groups_from_commit_metadata_with_estimator<V: CompletionTimeView>(
     commit_metadata: &Map<String, Value>,
     completion_time_view: &V,
     estimator: Option<&FileStatsEstimator>,
@@ -343,8 +354,11 @@ mod tests {
             .clone();
 
             // Use layout v1 view (no completion time tracking)
-            let result =
-                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
+            let result = file_groups_from_commit_metadata_with_estimator(
+                &metadata,
+                &create_layout_v1_view(),
+                None,
+            );
             // With the new implementation, this returns Ok with an empty HashSet
             // because iter_write_stats() returns an empty iterator when partition_to_write_stats is None
             assert!(result.is_ok());
@@ -362,8 +376,11 @@ mod tests {
             .unwrap()
             .clone();
 
-            let result =
-                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
+            let result = file_groups_from_commit_metadata_with_estimator(
+                &metadata,
+                &create_layout_v1_view(),
+                None,
+            );
             assert!(matches!(
                 result,
                 Err(CoreError::CommitMetadata(msg)) if msg.contains("Failed to parse commit metadata")
@@ -383,8 +400,11 @@ mod tests {
             .unwrap()
             .clone();
 
-            let result =
-                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
+            let result = file_groups_from_commit_metadata_with_estimator(
+                &metadata,
+                &create_layout_v1_view(),
+                None,
+            );
             assert!(matches!(
                 result,
                 Err(CoreError::CommitMetadata(msg)) if msg == "Missing fileId in write stats"
@@ -404,8 +424,11 @@ mod tests {
             .unwrap()
             .clone();
 
-            let result =
-                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
+            let result = file_groups_from_commit_metadata_with_estimator(
+                &metadata,
+                &create_layout_v1_view(),
+                None,
+            );
             assert!(matches!(
                 result,
                 Err(CoreError::CommitMetadata(msg)) if msg == "Missing path in write stats"
@@ -426,8 +449,11 @@ mod tests {
             .unwrap()
             .clone();
 
-            let result =
-                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
+            let result = file_groups_from_commit_metadata_with_estimator(
+                &metadata,
+                &create_layout_v1_view(),
+                None,
+            );
             assert!(matches!(
                 result,
                 Err(CoreError::CommitMetadata(msg)) if msg == "Invalid file name in path"
@@ -448,8 +474,11 @@ mod tests {
             .unwrap()
             .clone();
 
-            let result =
-                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
+            let result = file_groups_from_commit_metadata_with_estimator(
+                &metadata,
+                &create_layout_v1_view(),
+                None,
+            );
             // Serde will fail to parse this and return a deserialization error
             assert!(matches!(
                 result,
@@ -471,8 +500,11 @@ mod tests {
             .unwrap()
             .clone();
 
-            let result =
-                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
+            let result = file_groups_from_commit_metadata_with_estimator(
+                &metadata,
+                &create_layout_v1_view(),
+                None,
+            );
             // Serde will fail to parse this and return a deserialization error
             assert!(matches!(
                 result,
@@ -496,8 +528,11 @@ mod tests {
         }"#;
 
             let metadata: Map<String, Value> = serde_json::from_str(sample_json).unwrap();
-            let result =
-                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
+            let result = file_groups_from_commit_metadata_with_estimator(
+                &metadata,
+                &create_layout_v1_view(),
+                None,
+            );
             assert!(result.is_ok());
             let file_groups = result.unwrap();
             assert_eq!(file_groups.len(), 2);
@@ -527,8 +562,11 @@ mod tests {
         }"#;
 
             let metadata: Map<String, Value> = serde_json::from_str(sample_json).unwrap();
-            let result =
-                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
+            let result = file_groups_from_commit_metadata_with_estimator(
+                &metadata,
+                &create_layout_v1_view(),
+                None,
+            );
             assert!(result.is_ok());
             let file_groups = result.unwrap();
             assert_eq!(file_groups.len(), 1);
@@ -560,8 +598,11 @@ mod tests {
         }"#;
 
             let metadata: Map<String, Value> = serde_json::from_str(sample_json).unwrap();
-            let result =
-                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
+            let result = file_groups_from_commit_metadata_with_estimator(
+                &metadata,
+                &create_layout_v1_view(),
+                None,
+            );
             assert!(result.is_ok());
             let file_groups = result.unwrap();
             assert_eq!(file_groups.len(), 1);
@@ -585,8 +626,11 @@ mod tests {
         }"#;
 
             let metadata: Map<String, Value> = serde_json::from_str(sample_json).unwrap();
-            let result =
-                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
+            let result = file_groups_from_commit_metadata_with_estimator(
+                &metadata,
+                &create_layout_v1_view(),
+                None,
+            );
             assert!(result.is_ok());
             let file_groups = result.unwrap();
             assert_eq!(file_groups.len(), 1);
@@ -619,7 +663,7 @@ mod tests {
             }];
             let view = create_layout_v2_view(&instants);
 
-            let result = file_groups_from_commit_metadata(&metadata, &view, None);
+            let result = file_groups_from_commit_metadata_with_estimator(&metadata, &view, None);
             assert!(result.is_ok());
             let file_groups = result.unwrap();
             assert_eq!(file_groups.len(), 1);
@@ -646,9 +690,12 @@ mod tests {
             let metadata: Map<String, Value> = serde_json::from_str(json).unwrap();
 
             // No estimator -> only `size` is populated.
-            let groups =
-                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None)
-                    .unwrap();
+            let groups = file_groups_from_commit_metadata_with_estimator(
+                &metadata,
+                &create_layout_v1_view(),
+                None,
+            )
+            .unwrap();
             let m = groups
                 .iter()
                 .next()
@@ -667,7 +714,7 @@ mod tests {
 
             // With estimator -> byte_size and num_records derived from on-disk size.
             let estimator = FileStatsEstimator::new(100.0, 2.5);
-            let groups = file_groups_from_commit_metadata(
+            let groups = file_groups_from_commit_metadata_with_estimator(
                 &metadata,
                 &create_layout_v1_view(),
                 Some(&estimator),
@@ -701,9 +748,12 @@ mod tests {
                 }
             }"#;
             let metadata: Map<String, Value> = serde_json::from_str(json).unwrap();
-            let groups =
-                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None)
-                    .unwrap();
+            let groups = file_groups_from_commit_metadata_with_estimator(
+                &metadata,
+                &create_layout_v1_view(),
+                None,
+            )
+            .unwrap();
             let fs = groups
                 .iter()
                 .next()

--- a/crates/core/src/file_group/builder.rs
+++ b/crates/core/src/file_group/builder.rs
@@ -69,7 +69,7 @@ impl FileGroupMerger for HashSet<FileGroup> {
 /// * `estimator` - Optional [FileStatsEstimator] used to populate `byte_size`
 ///   and `num_records` on each base file. When `None`, those fields stay at 0
 ///   while `size` is still populated from `HoodieWriteStat::file_size_in_bytes`.
-pub fn file_groups_from_commit_metadata<V: CompletionTimeView>(
+pub(crate) fn file_groups_from_commit_metadata<V: CompletionTimeView>(
     commit_metadata: &Map<String, Value>,
     completion_time_view: &V,
     estimator: Option<&FileStatsEstimator>,

--- a/crates/core/src/file_group/builder.rs
+++ b/crates/core/src/file_group/builder.rs
@@ -365,11 +365,7 @@ mod tests {
             .clone();
 
             // Use layout v1 view (no completion time tracking)
-            let result = file_groups_from_commit_metadata_with_estimator(
-                &metadata,
-                &create_layout_v1_view(),
-                None,
-            );
+            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view());
             // With the new implementation, this returns Ok with an empty HashSet
             // because iter_write_stats() returns an empty iterator when partition_to_write_stats is None
             assert!(result.is_ok());
@@ -387,11 +383,7 @@ mod tests {
             .unwrap()
             .clone();
 
-            let result = file_groups_from_commit_metadata_with_estimator(
-                &metadata,
-                &create_layout_v1_view(),
-                None,
-            );
+            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view());
             assert!(matches!(
                 result,
                 Err(CoreError::CommitMetadata(msg)) if msg.contains("Failed to parse commit metadata")
@@ -411,11 +403,7 @@ mod tests {
             .unwrap()
             .clone();
 
-            let result = file_groups_from_commit_metadata_with_estimator(
-                &metadata,
-                &create_layout_v1_view(),
-                None,
-            );
+            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view());
             assert!(matches!(
                 result,
                 Err(CoreError::CommitMetadata(msg)) if msg == "Missing fileId in write stats"
@@ -435,11 +423,7 @@ mod tests {
             .unwrap()
             .clone();
 
-            let result = file_groups_from_commit_metadata_with_estimator(
-                &metadata,
-                &create_layout_v1_view(),
-                None,
-            );
+            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view());
             assert!(matches!(
                 result,
                 Err(CoreError::CommitMetadata(msg)) if msg == "Missing path in write stats"
@@ -460,11 +444,7 @@ mod tests {
             .unwrap()
             .clone();
 
-            let result = file_groups_from_commit_metadata_with_estimator(
-                &metadata,
-                &create_layout_v1_view(),
-                None,
-            );
+            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view());
             assert!(matches!(
                 result,
                 Err(CoreError::CommitMetadata(msg)) if msg == "Invalid file name in path"
@@ -472,55 +452,36 @@ mod tests {
         }
 
         #[test]
-        fn test_non_string_file_id() {
-            let metadata: Map<String, Value> = json!({
-                "partitionToWriteStats": {
-                    "byteField=20/shortField=100": [{
-                        "fileId": 123, // number instead of string
-                        "path": "byteField=20/shortField=100/some-file.parquet"
-                    }]
-                }
-            })
-            .as_object()
-            .unwrap()
-            .clone();
+        fn test_non_string_field_types_fail_to_parse() {
+            // Non-string `fileId` or `path` should both surface as a serde
+            // deserialization error from HoodieCommitMetadata::from_json_map.
+            let cases = [
+                json!({
+                    "partitionToWriteStats": {
+                        "byteField=20/shortField=100": [{
+                            "fileId": 123,
+                            "path": "byteField=20/shortField=100/some-file.parquet"
+                        }]
+                    }
+                }),
+                json!({
+                    "partitionToWriteStats": {
+                        "byteField=20/shortField=100": [{
+                            "fileId": "bb7c3a45-387f-490d-aab2-981c3f1a8ada-0",
+                            "path": 123
+                        }]
+                    }
+                }),
+            ];
 
-            let result = file_groups_from_commit_metadata_with_estimator(
-                &metadata,
-                &create_layout_v1_view(),
-                None,
-            );
-            // Serde will fail to parse this and return a deserialization error
-            assert!(matches!(
-                result,
-                Err(CoreError::CommitMetadata(msg)) if msg.contains("Failed to parse commit metadata")
-            ));
-        }
-
-        #[test]
-        fn test_non_string_path() {
-            let metadata: Map<String, Value> = json!({
-                "partitionToWriteStats": {
-                    "byteField=20/shortField=100": [{
-                        "fileId": "bb7c3a45-387f-490d-aab2-981c3f1a8ada-0",
-                        "path": 123 // number instead of string
-                    }]
-                }
-            })
-            .as_object()
-            .unwrap()
-            .clone();
-
-            let result = file_groups_from_commit_metadata_with_estimator(
-                &metadata,
-                &create_layout_v1_view(),
-                None,
-            );
-            // Serde will fail to parse this and return a deserialization error
-            assert!(matches!(
-                result,
-                Err(CoreError::CommitMetadata(msg)) if msg.contains("Failed to parse commit metadata")
-            ));
+            for value in cases {
+                let metadata: Map<String, Value> = value.as_object().unwrap().clone();
+                let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view());
+                assert!(matches!(
+                    result,
+                    Err(CoreError::CommitMetadata(msg)) if msg.contains("Failed to parse commit metadata")
+                ));
+            }
         }
 
         #[test]
@@ -539,11 +500,7 @@ mod tests {
         }"#;
 
             let metadata: Map<String, Value> = serde_json::from_str(sample_json).unwrap();
-            let result = file_groups_from_commit_metadata_with_estimator(
-                &metadata,
-                &create_layout_v1_view(),
-                None,
-            );
+            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view());
             assert!(result.is_ok());
             let file_groups = result.unwrap();
             assert_eq!(file_groups.len(), 2);
@@ -573,11 +530,7 @@ mod tests {
         }"#;
 
             let metadata: Map<String, Value> = serde_json::from_str(sample_json).unwrap();
-            let result = file_groups_from_commit_metadata_with_estimator(
-                &metadata,
-                &create_layout_v1_view(),
-                None,
-            );
+            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view());
             assert!(result.is_ok());
             let file_groups = result.unwrap();
             assert_eq!(file_groups.len(), 1);
@@ -597,58 +550,44 @@ mod tests {
         }
 
         #[test]
-        fn test_mor_table_base_file_no_log_files() {
-            // MOR table with base file but no log files (initial insert)
-            let sample_json = r#"{
-            "partitionToWriteStats": {
-                "partition1": [{
-                    "fileId": "file-id-0",
-                    "baseFile": "file-id-0_0-7-24_20240418173200000.parquet"
-                }]
+        fn test_mor_table_base_file_without_log_files() {
+            // Both `logFiles` absent (initial insert) and `logFiles: []` (empty array)
+            // should yield a file slice with no log files.
+            let cases = [
+                r#"{
+                    "partitionToWriteStats": {
+                        "partition1": [{
+                            "fileId": "file-id-0",
+                            "baseFile": "file-id-0_0-7-24_20240418173200000.parquet"
+                        }]
+                    }
+                }"#,
+                r#"{
+                    "partitionToWriteStats": {
+                        "partition1": [{
+                            "fileId": "file-id-0",
+                            "baseFile": "file-id-0_0-7-24_20240418173200000.parquet",
+                            "logFiles": []
+                        }]
+                    }
+                }"#,
+            ];
+
+            for sample_json in cases {
+                let metadata: Map<String, Value> = serde_json::from_str(sample_json).unwrap();
+                let file_groups =
+                    file_groups_from_commit_metadata(&metadata, &create_layout_v1_view()).unwrap();
+                assert_eq!(file_groups.len(), 1);
+                let (_, file_slice) = file_groups
+                    .iter()
+                    .next()
+                    .unwrap()
+                    .file_slices
+                    .iter()
+                    .next()
+                    .unwrap();
+                assert!(file_slice.log_files.is_empty());
             }
-        }"#;
-
-            let metadata: Map<String, Value> = serde_json::from_str(sample_json).unwrap();
-            let result = file_groups_from_commit_metadata_with_estimator(
-                &metadata,
-                &create_layout_v1_view(),
-                None,
-            );
-            assert!(result.is_ok());
-            let file_groups = result.unwrap();
-            assert_eq!(file_groups.len(), 1);
-
-            let file_group = file_groups.iter().next().unwrap();
-            let (_, file_slice) = file_group.file_slices.iter().next().unwrap();
-            assert!(file_slice.log_files.is_empty());
-        }
-
-        #[test]
-        fn test_mor_table_base_file_empty_log_files() {
-            // MOR table with base file and empty log files array
-            let sample_json = r#"{
-            "partitionToWriteStats": {
-                "partition1": [{
-                    "fileId": "file-id-0",
-                    "baseFile": "file-id-0_0-7-24_20240418173200000.parquet",
-                    "logFiles": []
-                }]
-            }
-        }"#;
-
-            let metadata: Map<String, Value> = serde_json::from_str(sample_json).unwrap();
-            let result = file_groups_from_commit_metadata_with_estimator(
-                &metadata,
-                &create_layout_v1_view(),
-                None,
-            );
-            assert!(result.is_ok());
-            let file_groups = result.unwrap();
-            assert_eq!(file_groups.len(), 1);
-
-            let file_group = file_groups.iter().next().unwrap();
-            let (_, file_slice) = file_group.file_slices.iter().next().unwrap();
-            assert!(file_slice.log_files.is_empty());
         }
 
         #[test]
@@ -674,7 +613,7 @@ mod tests {
             }];
             let view = create_layout_v2_view(&instants);
 
-            let result = file_groups_from_commit_metadata_with_estimator(&metadata, &view, None);
+            let result = file_groups_from_commit_metadata(&metadata, &view);
             assert!(result.is_ok());
             let file_groups = result.unwrap();
             assert_eq!(file_groups.len(), 1);
@@ -719,7 +658,10 @@ mod tests {
         }
 
         #[test]
-        fn test_metadata_populated_from_write_stat_size() {
+        fn test_metadata_populated_from_write_stat_size_with_estimator() {
+            // No-estimator coverage lives in test_public_api_uses_no_estimator_for_cow_path_metadata.
+            // This test focuses on estimator-derived byte_size / num_records for the MOR
+            // baseFile path.
             let json = r#"{
                 "partitionToWriteStats": {
                     "p1": [{
@@ -732,30 +674,6 @@ mod tests {
             }"#;
             let metadata: Map<String, Value> = serde_json::from_str(json).unwrap();
 
-            // No estimator -> only `size` is populated.
-            let groups = file_groups_from_commit_metadata_with_estimator(
-                &metadata,
-                &create_layout_v1_view(),
-                None,
-            )
-            .unwrap();
-            let m = groups
-                .iter()
-                .next()
-                .unwrap()
-                .file_slices
-                .values()
-                .next()
-                .unwrap()
-                .base_file
-                .file_metadata
-                .as_ref()
-                .unwrap();
-            assert_eq!(m.size, 4096);
-            assert_eq!(m.byte_size, 0);
-            assert_eq!(m.num_records, 0);
-
-            // With estimator -> byte_size and num_records derived from on-disk size.
             let estimator = FileStatsEstimator::new(100.0, 2.5);
             let groups = file_groups_from_commit_metadata_with_estimator(
                 &metadata,
@@ -828,12 +746,8 @@ mod tests {
                 }
             }"#;
             let metadata: Map<String, Value> = serde_json::from_str(json).unwrap();
-            let groups = file_groups_from_commit_metadata_with_estimator(
-                &metadata,
-                &create_layout_v1_view(),
-                None,
-            )
-            .unwrap();
+            let groups =
+                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view()).unwrap();
             let fs = groups
                 .iter()
                 .next()

--- a/crates/core/src/file_group/builder.rs
+++ b/crates/core/src/file_group/builder.rs
@@ -677,6 +677,37 @@ mod tests {
         }
 
         #[test]
+        fn test_public_api_uses_no_estimator_for_cow_path_metadata() {
+            let json = r#"{
+                "partitionToWriteStats": {
+                    "p1": [{
+                        "fileId": "fid-0",
+                        "path": "p1/fid-0_0-7-24_20240418173200000.parquet",
+                        "fileSizeInBytes": 4096
+                    }]
+                }
+            }"#;
+            let metadata: Map<String, Value> = serde_json::from_str(json).unwrap();
+
+            let groups =
+                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view()).unwrap();
+            let file_slice = groups
+                .iter()
+                .next()
+                .unwrap()
+                .file_slices
+                .values()
+                .next()
+                .unwrap();
+            assert!(file_slice.log_files.is_empty());
+            let m = file_slice.base_file.file_metadata.as_ref().unwrap();
+            assert_eq!(m.name, "fid-0_0-7-24_20240418173200000.parquet");
+            assert_eq!(m.size, 4096);
+            assert_eq!(m.byte_size, 0);
+            assert_eq!(m.num_records, 0);
+        }
+
+        #[test]
         fn test_metadata_populated_from_write_stat_size() {
             let json = r#"{
                 "partitionToWriteStats": {

--- a/crates/core/src/file_group/builder.rs
+++ b/crates/core/src/file_group/builder.rs
@@ -111,8 +111,7 @@ pub(crate) fn file_groups_from_commit_metadata<V: CompletionTimeView>(
         // so query engines see size/byte_size/num_records consistently.
         if let Some(file_size) = write_stat.file_size_in_bytes.filter(|s| *s > 0) {
             let size = file_size as u64;
-            let (byte_size, num_records) =
-                estimator.map(|e| e.estimate(size)).unwrap_or((0, 0));
+            let (byte_size, num_records) = estimator.map(|e| e.estimate(size)).unwrap_or((0, 0));
             base_file.file_metadata = Some(FileMetadata {
                 name: base_file_name,
                 size,
@@ -344,7 +343,8 @@ mod tests {
             .clone();
 
             // Use layout v1 view (no completion time tracking)
-            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
+            let result =
+                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
             // With the new implementation, this returns Ok with an empty HashSet
             // because iter_write_stats() returns an empty iterator when partition_to_write_stats is None
             assert!(result.is_ok());
@@ -362,7 +362,8 @@ mod tests {
             .unwrap()
             .clone();
 
-            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
+            let result =
+                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
             assert!(matches!(
                 result,
                 Err(CoreError::CommitMetadata(msg)) if msg.contains("Failed to parse commit metadata")
@@ -382,7 +383,8 @@ mod tests {
             .unwrap()
             .clone();
 
-            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
+            let result =
+                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
             assert!(matches!(
                 result,
                 Err(CoreError::CommitMetadata(msg)) if msg == "Missing fileId in write stats"
@@ -402,7 +404,8 @@ mod tests {
             .unwrap()
             .clone();
 
-            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
+            let result =
+                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
             assert!(matches!(
                 result,
                 Err(CoreError::CommitMetadata(msg)) if msg == "Missing path in write stats"
@@ -423,7 +426,8 @@ mod tests {
             .unwrap()
             .clone();
 
-            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
+            let result =
+                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
             assert!(matches!(
                 result,
                 Err(CoreError::CommitMetadata(msg)) if msg == "Invalid file name in path"
@@ -444,7 +448,8 @@ mod tests {
             .unwrap()
             .clone();
 
-            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
+            let result =
+                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
             // Serde will fail to parse this and return a deserialization error
             assert!(matches!(
                 result,
@@ -466,7 +471,8 @@ mod tests {
             .unwrap()
             .clone();
 
-            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
+            let result =
+                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
             // Serde will fail to parse this and return a deserialization error
             assert!(matches!(
                 result,
@@ -490,7 +496,8 @@ mod tests {
         }"#;
 
             let metadata: Map<String, Value> = serde_json::from_str(sample_json).unwrap();
-            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
+            let result =
+                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
             assert!(result.is_ok());
             let file_groups = result.unwrap();
             assert_eq!(file_groups.len(), 2);
@@ -520,7 +527,8 @@ mod tests {
         }"#;
 
             let metadata: Map<String, Value> = serde_json::from_str(sample_json).unwrap();
-            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
+            let result =
+                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
             assert!(result.is_ok());
             let file_groups = result.unwrap();
             assert_eq!(file_groups.len(), 1);
@@ -552,7 +560,8 @@ mod tests {
         }"#;
 
             let metadata: Map<String, Value> = serde_json::from_str(sample_json).unwrap();
-            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
+            let result =
+                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
             assert!(result.is_ok());
             let file_groups = result.unwrap();
             assert_eq!(file_groups.len(), 1);
@@ -576,7 +585,8 @@ mod tests {
         }"#;
 
             let metadata: Map<String, Value> = serde_json::from_str(sample_json).unwrap();
-            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
+            let result =
+                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
             assert!(result.is_ok());
             let file_groups = result.unwrap();
             assert_eq!(file_groups.len(), 1);

--- a/crates/core/src/file_group/builder.rs
+++ b/crates/core/src/file_group/builder.rs
@@ -66,9 +66,13 @@ impl FileGroupMerger for HashSet<FileGroup> {
 ///
 /// * `commit_metadata` - The commit metadata JSON map
 /// * `completion_time_view` - View to look up completion timestamps.
+/// * `estimator` - Optional [FileStatsEstimator] used to populate `byte_size`
+///   and `num_records` on each base file. When `None`, those fields stay at 0
+///   while `size` is still populated from `HoodieWriteStat::file_size_in_bytes`.
 pub fn file_groups_from_commit_metadata<V: CompletionTimeView>(
     commit_metadata: &Map<String, Value>,
     completion_time_view: &V,
+    estimator: Option<&FileStatsEstimator>,
 ) -> Result<HashSet<FileGroup>> {
     let metadata = HoodieCommitMetadata::from_json_map(commit_metadata)?;
 
@@ -82,18 +86,45 @@ pub fn file_groups_from_commit_metadata<V: CompletionTimeView>(
 
         let mut file_group = FileGroup::new(file_id.clone(), partition.clone());
 
-        // Handle two cases:
-        // 1. MOR table with baseFile and optionally logFiles
-        // 2. COW table with path only
-        if let Some(base_file_name) = &write_stat.base_file {
-            let mut base_file = BaseFile::from_str(base_file_name)?;
-            base_file.set_completion_time(completion_time_view);
-            file_group.add_base_file(base_file)?;
+        // Resolve the base file name: MOR write stats record `baseFile`; COW write
+        // stats record `path` (`<partition>/<file>`). Either way, derive the file
+        // name string used to construct the BaseFile.
+        let base_file_name: String = if let Some(name) = &write_stat.base_file {
+            name.clone()
+        } else {
+            let path = write_stat
+                .path
+                .as_ref()
+                .ok_or_else(|| CoreError::CommitMetadata("Missing path in write stats".into()))?;
+            Path::new(path)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .ok_or_else(|| CoreError::CommitMetadata("Invalid file name in path".into()))?
+                .to_string()
+        };
 
-            // Log files are optional - MOR tables may have:
-            // - No log files yet (initial insert)
-            // - Some log files (after updates)
-            // - Empty log files list
+        let mut base_file = BaseFile::from_str(&base_file_name)?;
+        base_file.set_completion_time(completion_time_view);
+
+        // Populate FileMetadata when we have a recorded on-disk size. This aligns
+        // the incremental query path with file_groups_from_files_partition_records
+        // so query engines see size/byte_size/num_records consistently.
+        if let Some(file_size) = write_stat.file_size_in_bytes.filter(|s| *s > 0) {
+            let size = file_size as u64;
+            let (byte_size, num_records) =
+                estimator.map(|e| e.estimate(size)).unwrap_or((0, 0));
+            base_file.file_metadata = Some(FileMetadata {
+                name: base_file_name,
+                size,
+                byte_size,
+                num_records,
+            });
+        }
+
+        file_group.add_base_file(base_file)?;
+
+        // Log files are only present in MOR write stats (the `baseFile` branch).
+        if write_stat.base_file.is_some() {
             if let Some(log_file_names) = &write_stat.log_files {
                 for log_file_name in log_file_names {
                     let mut log_file = LogFile::from_str(log_file_name)?;
@@ -101,21 +132,6 @@ pub fn file_groups_from_commit_metadata<V: CompletionTimeView>(
                     file_group.add_log_file(log_file)?;
                 }
             }
-            // Note: log_files being None is valid for MOR tables
-        } else {
-            let path = write_stat
-                .path
-                .as_ref()
-                .ok_or_else(|| CoreError::CommitMetadata("Missing path in write stats".into()))?;
-
-            let file_name = Path::new(path)
-                .file_name()
-                .and_then(|name| name.to_str())
-                .ok_or_else(|| CoreError::CommitMetadata("Invalid file name in path".into()))?;
-
-            let mut base_file = BaseFile::from_str(file_name)?;
-            base_file.set_completion_time(completion_time_view);
-            file_group.add_base_file(base_file)?;
         }
 
         file_groups.insert(file_group);
@@ -328,7 +344,7 @@ mod tests {
             .clone();
 
             // Use layout v1 view (no completion time tracking)
-            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view());
+            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
             // With the new implementation, this returns Ok with an empty HashSet
             // because iter_write_stats() returns an empty iterator when partition_to_write_stats is None
             assert!(result.is_ok());
@@ -346,7 +362,7 @@ mod tests {
             .unwrap()
             .clone();
 
-            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view());
+            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
             assert!(matches!(
                 result,
                 Err(CoreError::CommitMetadata(msg)) if msg.contains("Failed to parse commit metadata")
@@ -366,7 +382,7 @@ mod tests {
             .unwrap()
             .clone();
 
-            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view());
+            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
             assert!(matches!(
                 result,
                 Err(CoreError::CommitMetadata(msg)) if msg == "Missing fileId in write stats"
@@ -386,7 +402,7 @@ mod tests {
             .unwrap()
             .clone();
 
-            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view());
+            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
             assert!(matches!(
                 result,
                 Err(CoreError::CommitMetadata(msg)) if msg == "Missing path in write stats"
@@ -407,7 +423,7 @@ mod tests {
             .unwrap()
             .clone();
 
-            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view());
+            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
             assert!(matches!(
                 result,
                 Err(CoreError::CommitMetadata(msg)) if msg == "Invalid file name in path"
@@ -428,7 +444,7 @@ mod tests {
             .unwrap()
             .clone();
 
-            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view());
+            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
             // Serde will fail to parse this and return a deserialization error
             assert!(matches!(
                 result,
@@ -450,7 +466,7 @@ mod tests {
             .unwrap()
             .clone();
 
-            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view());
+            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
             // Serde will fail to parse this and return a deserialization error
             assert!(matches!(
                 result,
@@ -474,7 +490,7 @@ mod tests {
         }"#;
 
             let metadata: Map<String, Value> = serde_json::from_str(sample_json).unwrap();
-            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view());
+            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
             assert!(result.is_ok());
             let file_groups = result.unwrap();
             assert_eq!(file_groups.len(), 2);
@@ -504,7 +520,7 @@ mod tests {
         }"#;
 
             let metadata: Map<String, Value> = serde_json::from_str(sample_json).unwrap();
-            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view());
+            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
             assert!(result.is_ok());
             let file_groups = result.unwrap();
             assert_eq!(file_groups.len(), 1);
@@ -536,7 +552,7 @@ mod tests {
         }"#;
 
             let metadata: Map<String, Value> = serde_json::from_str(sample_json).unwrap();
-            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view());
+            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
             assert!(result.is_ok());
             let file_groups = result.unwrap();
             assert_eq!(file_groups.len(), 1);
@@ -560,7 +576,7 @@ mod tests {
         }"#;
 
             let metadata: Map<String, Value> = serde_json::from_str(sample_json).unwrap();
-            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view());
+            let result = file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None);
             assert!(result.is_ok());
             let file_groups = result.unwrap();
             assert_eq!(file_groups.len(), 1);
@@ -593,7 +609,7 @@ mod tests {
             }];
             let view = create_layout_v2_view(&instants);
 
-            let result = file_groups_from_commit_metadata(&metadata, &view);
+            let result = file_groups_from_commit_metadata(&metadata, &view, None);
             assert!(result.is_ok());
             let file_groups = result.unwrap();
             assert_eq!(file_groups.len(), 1);
@@ -604,6 +620,89 @@ mod tests {
                 file_slice.base_file.completion_timestamp,
                 Some("20240418173210000".to_string())
             );
+        }
+
+        #[test]
+        fn test_metadata_populated_from_write_stat_size() {
+            let json = r#"{
+                "partitionToWriteStats": {
+                    "p1": [{
+                        "fileId": "fid-0",
+                        "baseFile": "fid-0_0-7-24_20240418173200000.parquet",
+                        "fileSizeInBytes": 4096
+                    }]
+                }
+            }"#;
+            let metadata: Map<String, Value> = serde_json::from_str(json).unwrap();
+
+            // No estimator -> only `size` is populated.
+            let groups =
+                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None)
+                    .unwrap();
+            let m = groups
+                .iter()
+                .next()
+                .unwrap()
+                .file_slices
+                .values()
+                .next()
+                .unwrap()
+                .base_file
+                .file_metadata
+                .as_ref()
+                .unwrap();
+            assert_eq!(m.size, 4096);
+            assert_eq!(m.byte_size, 0);
+            assert_eq!(m.num_records, 0);
+
+            // With estimator -> byte_size and num_records derived from on-disk size.
+            let estimator = FileStatsEstimator::new(100.0, 2.5);
+            let groups = file_groups_from_commit_metadata(
+                &metadata,
+                &create_layout_v1_view(),
+                Some(&estimator),
+            )
+            .unwrap();
+            let m = groups
+                .iter()
+                .next()
+                .unwrap()
+                .file_slices
+                .values()
+                .next()
+                .unwrap()
+                .base_file
+                .file_metadata
+                .as_ref()
+                .unwrap();
+            assert_eq!(m.size, 4096);
+            assert_eq!(m.byte_size, 10240); // 4096 * 2.5
+            assert_eq!(m.num_records, 40); // 4096 / 100
+        }
+
+        #[test]
+        fn test_metadata_absent_when_no_file_size() {
+            let json = r#"{
+                "partitionToWriteStats": {
+                    "p1": [{
+                        "fileId": "fid-0",
+                        "baseFile": "fid-0_0-7-24_20240418173200000.parquet"
+                    }]
+                }
+            }"#;
+            let metadata: Map<String, Value> = serde_json::from_str(json).unwrap();
+            let groups =
+                file_groups_from_commit_metadata(&metadata, &create_layout_v1_view(), None)
+                    .unwrap();
+            let fs = groups
+                .iter()
+                .next()
+                .unwrap()
+                .file_slices
+                .values()
+                .next()
+                .unwrap();
+            assert!(fs.base_file.file_metadata.is_none());
         }
     }
 

--- a/crates/core/src/metadata/commit.rs
+++ b/crates/core/src/metadata/commit.rs
@@ -224,17 +224,35 @@ impl HoodieCommitMetadata {
     ///
     /// For MOR write stats, returns `<partition>/<baseFile>`.
     /// For COW write stats, returns the recorded `path` as-is.
-    /// Skips entries that have neither a base file nor a path.
+    /// Skips entries whose recorded name does not look like a base file:
+    /// - empty
+    /// - ends with `/` (a directory)
+    /// - file name starts with `.` (Hudi log file convention)
+    /// - has no extension (no `.`)
     pub fn iter_base_file_paths(&self) -> impl Iterator<Item = String> + '_ {
+        fn looks_like_base_file(name: &str) -> bool {
+            if name.is_empty() || name.ends_with('/') {
+                return false;
+            }
+            let file_name = name.rsplit('/').next().unwrap_or(name);
+            !file_name.starts_with('.') && file_name.contains('.')
+        }
         self.iter_write_stats().filter_map(|(partition, stat)| {
-            if let Some(base_file) = &stat.base_file {
+            if let Some(base_file) = stat
+                .base_file
+                .as_deref()
+                .filter(|s| looks_like_base_file(s))
+            {
                 if partition.is_empty() {
-                    Some(base_file.clone())
+                    Some(base_file.to_string())
                 } else {
                     Some(format!("{partition}/{base_file}"))
                 }
             } else {
-                stat.path.clone()
+                stat.path
+                    .as_deref()
+                    .filter(|s| looks_like_base_file(s))
+                    .map(|s| s.to_string())
             }
         })
     }
@@ -702,6 +720,38 @@ mod tests {
                 "fid-1_0-7-24_20240418173200001.parquet".to_string(),
                 "p1/fid-0_0-7-24_20240418173200000.parquet".to_string(),
             ]
+        );
+    }
+
+    #[test]
+    fn test_iter_base_file_paths_filters_log_files_and_invalid_paths() {
+        // baseFile holding a log file name (Hudi log files start with `.`),
+        // a partition-only path, and an empty string must all be filtered out.
+        let json = json!({
+            "partitionToWriteStats": {
+                "p1": [{
+                    "fileId": "fid-0",
+                    "baseFile": ".fid-0_20240418173200000.log.1_0-1-2"
+                }],
+                "p2": [{
+                    "fileId": "fid-1",
+                    "path": "p2/"
+                }],
+                "p3": [{
+                    "fileId": "fid-2",
+                    "baseFile": ""
+                }],
+                "p4": [{
+                    "fileId": "fid-3",
+                    "baseFile": "fid-3_0-7-24_20240418173200000.parquet"
+                }]
+            }
+        });
+        let metadata: HoodieCommitMetadata = serde_json::from_value(json).unwrap();
+        let paths: Vec<String> = metadata.iter_base_file_paths().collect();
+        assert_eq!(
+            paths,
+            vec!["p4/fid-3_0-7-24_20240418173200000.parquet".to_string()]
         );
     }
 }

--- a/crates/core/src/metadata/commit.rs
+++ b/crates/core/src/metadata/commit.rs
@@ -220,6 +220,25 @@ impl HoodieCommitMetadata {
             })
     }
 
+    /// Iterate over relative base-file paths recorded in the commit's write stats.
+    ///
+    /// For MOR write stats, returns `<partition>/<baseFile>`.
+    /// For COW write stats, returns the recorded `path` as-is.
+    /// Skips entries that have neither a base file nor a path.
+    pub fn iter_base_file_paths(&self) -> impl Iterator<Item = String> + '_ {
+        self.iter_write_stats().filter_map(|(partition, stat)| {
+            if let Some(base_file) = &stat.base_file {
+                if partition.is_empty() {
+                    Some(base_file.clone())
+                } else {
+                    Some(format!("{partition}/{base_file}"))
+                }
+            } else {
+                stat.path.clone()
+            }
+        })
+    }
+
     /// Iterate over all replace file IDs across all partitions
     pub fn iter_replace_file_ids(&self) -> impl Iterator<Item = (&String, &String)> {
         self.partition_to_replace_file_ids
@@ -658,5 +677,31 @@ mod tests {
         let metadata: HoodieCommitMetadata = serde_json::from_value(json).unwrap();
         let count = metadata.iter_replace_file_ids().count();
         assert_eq!(count, 3); // 1 from p1, 2 from p2
+    }
+
+    #[test]
+    fn test_iter_base_file_paths_mor_and_cow() {
+        let json = json!({
+            "partitionToWriteStats": {
+                "p1": [{
+                    "fileId": "fid-0",
+                    "baseFile": "fid-0_0-7-24_20240418173200000.parquet"
+                }],
+                "": [{
+                    "fileId": "fid-1",
+                    "path": "fid-1_0-7-24_20240418173200001.parquet"
+                }]
+            }
+        });
+        let metadata: HoodieCommitMetadata = serde_json::from_value(json).unwrap();
+        let mut paths: Vec<String> = metadata.iter_base_file_paths().collect();
+        paths.sort();
+        assert_eq!(
+            paths,
+            vec![
+                "fid-1_0-7-24_20240418173200001.parquet".to_string(),
+                "p1/fid-0_0-7-24_20240418173200000.parquet".to_string(),
+            ]
+        );
     }
 }

--- a/crates/core/src/metadata/commit.rs
+++ b/crates/core/src/metadata/commit.rs
@@ -756,40 +756,40 @@ mod tests {
     }
 
     #[test]
-    fn test_iter_base_file_paths_from_sample_cow_commit() {
-        let file_path = concat!(
+    fn test_iter_base_file_paths_from_real_commit_fixtures() {
+        // Smoke test against real `.commit` / `.deltacommit` fixtures: verifies the
+        // COW `path` and MOR `baseFile` resolution (and the log-only filter) keep
+        // working when fed actual on-disk metadata, not just hand-rolled JSON.
+        let cow_path = concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/tests/data/timeline/commits_load_schema_from_base_file_cow/.hoodie/20250628002223107.commit"
         );
-        let bytes = std::fs::read(file_path).expect("Failed to read test fixture");
-        let metadata = HoodieCommitMetadata::from_json_bytes(&bytes)
-            .expect("Failed to parse sample COW commit metadata");
-
-        let mut paths: Vec<String> = metadata.iter_base_file_paths().collect();
-        paths.sort();
+        let cow_metadata = HoodieCommitMetadata::from_json_bytes(
+            &std::fs::read(cow_path).expect("Failed to read COW fixture"),
+        )
+        .expect("Failed to parse sample COW commit metadata");
+        let mut cow_paths: Vec<String> = cow_metadata.iter_base_file_paths().collect();
+        cow_paths.sort();
         assert_eq!(
-            paths,
+            cow_paths,
             vec![
                 "city=chennai/03ffd613-fb74-456e-b6bb-115355d9b0ed-0_2-13-37_20250628002223107.parquet".to_string(),
                 "city=san_francisco/b271b5f8-29df-463d-ba4d-feedbe6e09ed-0_0-13-35_20250628002223107.parquet".to_string(),
                 "city=sao_paulo/a3c5da68-55a5-4804-ab8b-57e75252c69f-0_1-13-36_20250628002223107.parquet".to_string(),
             ]
         );
-    }
 
-    #[test]
-    fn test_iter_base_file_paths_from_sample_mor_deltacommit() {
-        let file_path = concat!(
+        let mor_path = concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/tests/data/timeline/commits_load_schema_from_base_file_mor/.hoodie/20250331030645735.deltacommit"
         );
-        let bytes = std::fs::read(file_path).expect("Failed to read test fixture");
-        let metadata = HoodieCommitMetadata::from_json_bytes(&bytes)
-            .expect("Failed to parse sample MOR deltacommit metadata");
-
-        let paths: Vec<String> = metadata.iter_base_file_paths().collect();
+        let mor_metadata = HoodieCommitMetadata::from_json_bytes(
+            &std::fs::read(mor_path).expect("Failed to read MOR fixture"),
+        )
+        .expect("Failed to parse sample MOR deltacommit metadata");
+        let mor_paths: Vec<String> = mor_metadata.iter_base_file_paths().collect();
         assert_eq!(
-            paths,
+            mor_paths,
             vec![
                 "city=san_francisco/d0304c53-6fd2-4b7a-a9d6-5ff632f79224-0_0-13-60_20250331030642808.parquet"
                     .to_string()

--- a/crates/core/src/metadata/commit.rs
+++ b/crates/core/src/metadata/commit.rs
@@ -222,37 +222,32 @@ impl HoodieCommitMetadata {
 
     /// Iterate over relative base-file paths recorded in the commit's write stats.
     ///
-    /// For MOR write stats, returns `<partition>/<baseFile>`.
-    /// For COW write stats, returns the recorded `path` as-is.
-    /// Skips entries whose recorded name does not look like a base file:
-    /// - empty
-    /// - ends with `/` (a directory)
-    /// - file name starts with `.` (Hudi log file convention)
-    /// - has no extension (no `.`)
+    /// Uses dedicated fields from `HoodieWriteStat`:
+    /// - MOR writes use `baseFile` (joined with partition path)
+    /// - COW writes use `path`
+    ///
+    /// Empty values are ignored. For write stats that only carry log-file entries
+    /// (`logFiles` present but no `baseFile`), no base-file path is emitted.
     pub fn iter_base_file_paths(&self) -> impl Iterator<Item = String> + '_ {
-        fn looks_like_base_file(name: &str) -> bool {
-            if name.is_empty() || name.ends_with('/') {
-                return false;
-            }
-            let file_name = name.rsplit('/').next().unwrap_or(name);
-            !file_name.starts_with('.') && file_name.contains('.')
-        }
         self.iter_write_stats().filter_map(|(partition, stat)| {
-            if let Some(base_file) = stat
-                .base_file
-                .as_deref()
-                .filter(|s| looks_like_base_file(s))
-            {
+            if let Some(base_file) = stat.base_file.as_deref().filter(|s| !s.is_empty()) {
                 if partition.is_empty() {
                     Some(base_file.to_string())
                 } else {
                     Some(format!("{partition}/{base_file}"))
                 }
             } else {
-                stat.path
-                    .as_deref()
-                    .filter(|s| looks_like_base_file(s))
-                    .map(|s| s.to_string())
+                // MOR log-only write stats may have `path` set to a log-file path.
+                // Those entries are identifiable by `logFiles` being present while
+                // `baseFile` is absent, and should not contribute base-file samples.
+                if stat.log_files.is_some() {
+                    None
+                } else {
+                    stat.path
+                        .as_deref()
+                        .filter(|s| !s.is_empty())
+                        .map(|s| s.to_string())
+                }
             }
         })
     }
@@ -725,17 +720,18 @@ mod tests {
 
     #[test]
     fn test_iter_base_file_paths_filters_log_files_and_invalid_paths() {
-        // baseFile holding a log file name (Hudi log files start with `.`),
-        // a partition-only path, and an empty string must all be filtered out.
+        // MOR log-only write stats (`logFiles` present, no `baseFile`) should
+        // not emit a base-file path.
         let json = json!({
             "partitionToWriteStats": {
                 "p1": [{
                     "fileId": "fid-0",
-                    "baseFile": ".fid-0_20240418173200000.log.1_0-1-2"
+                    "path": "p1/.fid-0_20240418173200000.log.1_0-1-2",
+                    "logFiles": [".fid-0_20240418173200000.log.1_0-1-2"]
                 }],
                 "p2": [{
                     "fileId": "fid-1",
-                    "path": "p2/"
+                    "path": "p2/fid-1_0-7-24_20240418173200000.parquet"
                 }],
                 "p3": [{
                     "fileId": "fid-2",
@@ -748,10 +744,56 @@ mod tests {
             }
         });
         let metadata: HoodieCommitMetadata = serde_json::from_value(json).unwrap();
+        let mut paths: Vec<String> = metadata.iter_base_file_paths().collect();
+        paths.sort();
+        assert_eq!(
+            paths,
+            vec![
+                "p2/fid-1_0-7-24_20240418173200000.parquet".to_string(),
+                "p4/fid-3_0-7-24_20240418173200000.parquet".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_iter_base_file_paths_from_sample_cow_commit() {
+        let file_path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/data/timeline/commits_load_schema_from_base_file_cow/.hoodie/20250628002223107.commit"
+        );
+        let bytes = std::fs::read(file_path).expect("Failed to read test fixture");
+        let metadata = HoodieCommitMetadata::from_json_bytes(&bytes)
+            .expect("Failed to parse sample COW commit metadata");
+
+        let mut paths: Vec<String> = metadata.iter_base_file_paths().collect();
+        paths.sort();
+        assert_eq!(
+            paths,
+            vec![
+                "city=chennai/03ffd613-fb74-456e-b6bb-115355d9b0ed-0_2-13-37_20250628002223107.parquet".to_string(),
+                "city=san_francisco/b271b5f8-29df-463d-ba4d-feedbe6e09ed-0_0-13-35_20250628002223107.parquet".to_string(),
+                "city=sao_paulo/a3c5da68-55a5-4804-ab8b-57e75252c69f-0_1-13-36_20250628002223107.parquet".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_iter_base_file_paths_from_sample_mor_deltacommit() {
+        let file_path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/data/timeline/commits_load_schema_from_base_file_mor/.hoodie/20250331030645735.deltacommit"
+        );
+        let bytes = std::fs::read(file_path).expect("Failed to read test fixture");
+        let metadata = HoodieCommitMetadata::from_json_bytes(&bytes)
+            .expect("Failed to parse sample MOR deltacommit metadata");
+
         let paths: Vec<String> = metadata.iter_base_file_paths().collect();
         assert_eq!(
             paths,
-            vec!["p4/fid-3_0-7-24_20240418173200000.parquet".to_string()]
+            vec![
+                "city=san_francisco/d0304c53-6fd2-4b7a-a9d6-5ff632f79224-0_0-13-60_20250331030642808.parquet"
+                    .to_string()
+            ]
         );
     }
 }

--- a/crates/core/src/metadata/table/mod.rs
+++ b/crates/core/src/metadata/table/mod.rs
@@ -237,6 +237,7 @@ impl Table {
         let file_pruner = FilePruner::empty();
         let table_schema = Schema::empty();
 
+        // MDT itself uses HFile base files; no estimator applies here.
         let file_slices = self
             .file_system_view
             .get_file_slices_by_storage_listing(
@@ -244,6 +245,7 @@ impl Table {
                 &file_pruner,
                 &table_schema,
                 &timeline_view,
+                None,
             )
             .await?;
 

--- a/crates/core/src/table/builder.rs
+++ b/crates/core/src/table/builder.rs
@@ -121,6 +121,7 @@ impl TableBuilder {
             timeline,
             file_system_view,
             cached_metadata_table: std::sync::Arc::new(tokio::sync::OnceCell::new()),
+            cached_estimator: std::sync::Arc::new(tokio::sync::OnceCell::new()),
         })
     }
 }

--- a/crates/core/src/table/fs_view.rs
+++ b/crates/core/src/table/fs_view.rs
@@ -916,5 +916,4 @@ mod tests {
 
         assert_eq!(file_slices.len(), 1);
     }
-
 }

--- a/crates/core/src/table/fs_view.rs
+++ b/crates/core/src/table/fs_view.rs
@@ -95,6 +95,8 @@ impl FileSystemView {
     /// * `table_schema` - Table schema for statistics extraction
     /// * `timeline_view` - The timeline view providing query timestamp and completion time lookups
     /// * `files_partition_records` - Optional pre-fetched metadata table records
+    /// * `estimator` - Optional estimator used to populate `byte_size` and
+    ///   `num_records` on base-file metadata for both MDT and storage-listing paths
     async fn load_file_groups(
         &self,
         partition_pruner: &PartitionPruner,
@@ -121,7 +123,7 @@ impl FileSystemView {
                 partition_pruner.to_owned(),
             );
             lister
-                .list_file_groups_for_relevant_partitions(timeline_view)
+                .list_file_groups_for_relevant_partitions(timeline_view, estimator)
                 .await?
         };
 
@@ -487,6 +489,48 @@ mod tests {
         for fsl in file_slices.iter() {
             let metadata = fsl.base_file.file_metadata.as_ref().unwrap();
             assert!(metadata.size > 0);
+        }
+    }
+
+    #[tokio::test]
+    async fn fs_view_get_latest_file_slices_with_estimator_populates_estimated_metadata() {
+        let base_url = SampleTable::V6Nonpartitioned.url_to_cow();
+        let hudi_table = Table::new(base_url.path()).await.unwrap();
+        let latest_timestamp = hudi_table.timeline.get_latest_commit_timestamp().unwrap();
+        let fs_view = &hudi_table.file_system_view;
+
+        let timeline_view = hudi_table
+            .timeline
+            .create_view_as_of(&latest_timestamp)
+            .await
+            .unwrap();
+        let partition_pruner = PartitionPruner::empty();
+        let file_pruner = FilePruner::empty();
+        let table_schema = hudi_table.get_schema().await.unwrap();
+        let estimator = hudi_table.get_or_init_estimator(&latest_timestamp).await;
+        assert!(
+            estimator.is_some(),
+            "Expected estimator for parquet sample table"
+        );
+
+        let file_slices = fs_view
+            .get_file_slices(
+                &partition_pruner,
+                &file_pruner,
+                &table_schema,
+                &timeline_view,
+                None,
+                estimator,
+            )
+            .await
+            .unwrap();
+
+        assert!(!file_slices.is_empty());
+        for fsl in file_slices.iter() {
+            let metadata = fsl.base_file.file_metadata.as_ref().unwrap();
+            assert!(metadata.size > 0);
+            assert!(metadata.byte_size > 0);
+            assert!(metadata.num_records > 0);
         }
     }
 

--- a/crates/core/src/table/fs_view.rs
+++ b/crates/core/src/table/fs_view.rs
@@ -104,8 +104,8 @@ impl FileSystemView {
         files_partition_records: Option<&HashMap<String, FilesPartitionRecord>>,
         estimator: Option<&FileStatsEstimator>,
     ) -> Result<()> {
-        let base_file_extension = self.base_file_format();
-        let base_file_extension = base_file_extension.as_ref();
+        let base_file_format = self.base_file_format();
+        let base_file_extension = base_file_format.as_ref();
 
         let file_groups_map = if let Some(records) = files_partition_records {
             file_groups_from_files_partition_records(

--- a/crates/core/src/table/fs_view.rs
+++ b/crates/core/src/table/fs_view.rs
@@ -21,7 +21,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow_schema::Schema;
-use tokio::sync::OnceCell;
 
 use crate::Result;
 use crate::config::HudiConfigs;
@@ -43,12 +42,10 @@ use dashmap::DashMap;
 /// A view of the Hudi table's data files (files stored outside the `.hoodie/` directory) in the file system. It provides APIs to load and
 /// access the file groups and file slices.
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
 pub struct FileSystemView {
     pub(crate) hudi_configs: Arc<HudiConfigs>,
     pub(crate) storage: Arc<Storage>,
     partition_to_file_groups: Arc<DashMap<String, Vec<FileGroup>>>,
-    file_stats_estimator: Arc<OnceCell<FileStatsEstimator>>,
 }
 
 impl FileSystemView {
@@ -56,10 +53,6 @@ impl FileSystemView {
         let s: String = self.hudi_configs.get_or_default(BaseFileFormat).into();
         s.parse::<BaseFileFormatValue>()
             .unwrap_or(BaseFileFormatValue::Parquet)
-    }
-
-    fn supports_footer_stats_estimation(format: &BaseFileFormatValue) -> bool {
-        matches!(format, BaseFileFormatValue::Parquet)
     }
 
     /// Case-insensitive ASCII suffix check that avoids allocating a lowercased copy of `s`.
@@ -80,71 +73,7 @@ impl FileSystemView {
             hudi_configs,
             storage,
             partition_to_file_groups,
-            file_stats_estimator: Arc::new(OnceCell::new()),
         })
-    }
-
-    /// Get or initialize the file stats estimator.
-    pub(crate) async fn get_or_init_estimator(
-        &self,
-        base_file_format: &BaseFileFormatValue,
-        sample_file_path: Option<&str>,
-    ) -> Option<&FileStatsEstimator> {
-        if !Self::supports_footer_stats_estimation(base_file_format) {
-            return None;
-        }
-
-        if let Some(path) = sample_file_path {
-            match self
-                .file_stats_estimator
-                .get_or_try_init(|| FileStatsEstimator::from_parquet_footer(&self.storage, path))
-                .await
-            {
-                Ok(estimator) => Some(estimator),
-                Err(e) => {
-                    log::warn!("Failed to initialize file stats estimator: {e}");
-                    None
-                }
-            }
-        } else {
-            self.file_stats_estimator.get()
-        }
-    }
-
-    /// Find a sample base-file path from metadata table records.
-    ///
-    /// Selects the lexicographically-smallest matching path so the sampled file is
-    /// stable across runs. Stable selection keeps the derived compression ratio and
-    /// the resulting query plan reproducible.
-    pub(crate) fn find_sample_base_file_path_from_records(
-        records: &HashMap<String, FilesPartitionRecord>,
-        base_file_format: &BaseFileFormatValue,
-    ) -> Option<String> {
-        let extension_suffix = format!(".{}", base_file_format.as_ref());
-        let mut best_candidate: Option<String> = None;
-
-        for (key, record) in records {
-            if record.is_all_partitions() {
-                continue;
-            }
-            for file_info in record.files.values() {
-                if file_info.is_deleted
-                    || !Self::ends_with_ignore_ascii_case(&file_info.name, &extension_suffix)
-                {
-                    continue;
-                }
-                let candidate = if key.is_empty() {
-                    file_info.name.clone()
-                } else {
-                    format!("{key}/{}", file_info.name)
-                };
-                if best_candidate.as_ref().is_none_or(|best| candidate < *best) {
-                    best_candidate = Some(candidate);
-                }
-            }
-        }
-
-        best_candidate
     }
 
     /// Load file groups from the appropriate source (storage or metadata table records)
@@ -173,27 +102,17 @@ impl FileSystemView {
         table_schema: &Schema,
         timeline_view: &TimelineView,
         files_partition_records: Option<&HashMap<String, FilesPartitionRecord>>,
+        estimator: Option<&FileStatsEstimator>,
     ) -> Result<()> {
-        let base_file_format = self.base_file_format();
-        let base_file_extension = base_file_format.as_ref();
+        let base_file_extension = self.base_file_format();
+        let base_file_extension = base_file_extension.as_ref();
 
-        // Step 1: Initialize the file stats estimator from MDT records if available.
-        // For Parquet tables, this reads ONE footer to derive compression ratio and
-        // avg row size, allowing the file group builder to populate estimated metadata inline.
-        if let Some(records) = files_partition_records {
-            let sample_path =
-                Self::find_sample_base_file_path_from_records(records, &base_file_format);
-            self.get_or_init_estimator(&base_file_format, sample_path.as_deref())
-                .await;
-        }
-
-        // Step 2: Get file groups from appropriate source
         let file_groups_map = if let Some(records) = files_partition_records {
             file_groups_from_files_partition_records(
                 records,
                 base_file_extension,
                 timeline_view,
-                self.file_stats_estimator.get(),
+                estimator,
             )?
         } else {
             let lister = FileLister::new(
@@ -206,7 +125,7 @@ impl FileSystemView {
                 .await?
         };
 
-        // Step 3: Apply partition pruning (for metadata table path) and stats pruning
+        // Apply partition pruning (for metadata table path) and stats pruning
         for (partition_path, file_groups) in file_groups_map {
             if files_partition_records.is_some()
                 && !partition_pruner.is_empty()
@@ -251,7 +170,10 @@ impl FileSystemView {
         }
 
         let base_file_format = self.base_file_format();
-        if !Self::supports_footer_stats_estimation(&base_file_format) {
+        // Footer-based column-stats pruning only applies to Parquet base files.
+        // (Separate concern from the FileStatsEstimator parquet check, which lives
+        // on Table::get_or_init_estimator.)
+        if !matches!(base_file_format, BaseFileFormatValue::Parquet) {
             return file_groups;
         }
         let base_file_suffix = format!(".{}", base_file_format.as_ref());
@@ -363,6 +285,7 @@ impl FileSystemView {
         table_schema: &Schema,
         timeline_view: &TimelineView,
         metadata_table: Option<&Table>,
+        estimator: Option<&FileStatsEstimator>,
     ) -> Result<Vec<FileSlice>> {
         let files_partition_records = if let Some(mdt) = metadata_table {
             Some(mdt.fetch_files_partition_records(partition_pruner).await?)
@@ -376,6 +299,7 @@ impl FileSystemView {
             table_schema,
             timeline_view,
             files_partition_records.as_ref(),
+            estimator,
         )
         .await?;
 
@@ -399,6 +323,7 @@ impl FileSystemView {
         file_pruner: &FilePruner,
         table_schema: &Schema,
         timeline_view: &TimelineView,
+        estimator: Option<&FileStatsEstimator>,
     ) -> Result<Vec<FileSlice>> {
         // Pass None to force storage listing (avoids recursion for metadata table)
         self.load_file_groups(
@@ -407,6 +332,7 @@ impl FileSystemView {
             table_schema,
             timeline_view,
             None,
+            estimator,
         )
         .await?;
 
@@ -454,6 +380,7 @@ mod tests {
                 &table_schema,
                 &timeline_view,
                 None,
+                None,
             )
             .await
             .unwrap()
@@ -485,10 +412,6 @@ mod tests {
         FileSystemView::new(hudi_configs, Arc::new(HashMap::new()))
             .await
             .unwrap()
-    }
-
-    async fn new_fs_view_with_base_path(base_url: &Url) -> FileSystemView {
-        new_fs_view_with_base_path_and_format(base_url, BaseFileFormatValue::Parquet.as_ref()).await
     }
 
     fn create_files_partition_record(
@@ -525,26 +448,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fs_view_get_or_init_estimator_handles_non_parquet_and_errors() {
-        let temp_dir = tempdir().unwrap();
-        let base_url = Url::from_directory_path(temp_dir.path()).unwrap();
-        let fs_view = new_fs_view_with_base_path(&base_url).await;
-
-        assert!(
-            fs_view
-                .get_or_init_estimator(&BaseFileFormatValue::HFile, Some("any.hfile"))
-                .await
-                .is_none()
-        );
-        assert!(
-            fs_view
-                .get_or_init_estimator(&BaseFileFormatValue::Parquet, Some("missing.parquet"))
-                .await
-                .is_none()
-        );
-    }
-
-    #[tokio::test]
     async fn fs_view_get_latest_file_slices() {
         let base_url = SampleTable::V6Nonpartitioned.url_to_cow();
         let hudi_table = Table::new(base_url.path()).await.unwrap();
@@ -568,6 +471,7 @@ mod tests {
                 &file_pruner,
                 &table_schema,
                 &timeline_view,
+                None,
                 None,
             )
             .await
@@ -683,6 +587,7 @@ mod tests {
                 &table_schema,
                 &timeline_view,
                 Some(&records),
+                None,
             )
             .await
             .unwrap();
@@ -767,6 +672,7 @@ mod tests {
                 &table_schema,
                 &timeline_view,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -808,6 +714,7 @@ mod tests {
                 &file_pruner,
                 &table_schema,
                 &timeline_view,
+                None,
                 None,
             )
             .await
@@ -865,6 +772,7 @@ mod tests {
                 &table_schema,
                 &timeline_view,
                 Some(&records),
+                None,
             )
             .await
             .unwrap();
@@ -972,6 +880,7 @@ mod tests {
                 &table_schema,
                 &timeline_view,
                 Some(metadata_table),
+                None,
             )
             .await
             .unwrap();
@@ -1000,6 +909,7 @@ mod tests {
                 &file_pruner,
                 &table_schema,
                 &timeline_view,
+                None,
             )
             .await
             .unwrap();
@@ -1007,141 +917,4 @@ mod tests {
         assert_eq!(file_slices.len(), 1);
     }
 
-    mod test_find_sample_base_file_path {
-        use super::*;
-        use crate::config::table::BaseFileFormatValue;
-        use crate::metadata::table::records::{
-            FilesPartitionRecord, HoodieMetadataFileInfo, MetadataRecordType,
-        };
-
-        fn create_files_record(
-            key: &str,
-            files: Vec<(&str, i64, bool)>,
-        ) -> (String, FilesPartitionRecord) {
-            let mut files_map = HashMap::new();
-            for (name, size, is_deleted) in files {
-                files_map.insert(
-                    name.to_string(),
-                    HoodieMetadataFileInfo::new(name.to_string(), size, is_deleted),
-                );
-            }
-            (
-                key.to_string(),
-                FilesPartitionRecord {
-                    key: key.to_string(),
-                    record_type: MetadataRecordType::Files,
-                    files: files_map,
-                },
-            )
-        }
-
-        fn create_all_partitions_record(partitions: Vec<&str>) -> (String, FilesPartitionRecord) {
-            let mut files_map = HashMap::new();
-            for p in partitions {
-                files_map.insert(
-                    p.to_string(),
-                    HoodieMetadataFileInfo::new(p.to_string(), 0, false),
-                );
-            }
-            (
-                FilesPartitionRecord::ALL_PARTITIONS_KEY.to_string(),
-                FilesPartitionRecord {
-                    key: FilesPartitionRecord::ALL_PARTITIONS_KEY.to_string(),
-                    record_type: MetadataRecordType::AllPartitions,
-                    files: files_map,
-                },
-            )
-        }
-
-        #[test]
-        fn test_finds_base_file_in_partitioned_and_non_partitioned() {
-            // Partitioned table: key is the partition path
-            let mut records = HashMap::new();
-            let (k, r) = create_files_record(
-                "city=chennai",
-                vec![("abc-0_0-123_20231214.parquet", 1024, false)],
-            );
-            records.insert(k, r);
-            let result = FileSystemView::find_sample_base_file_path_from_records(
-                &records,
-                &BaseFileFormatValue::Parquet,
-            );
-            assert_eq!(
-                result,
-                Some("city=chennai/abc-0_0-123_20231214.parquet".to_string())
-            );
-
-            // Non-partitioned table: key is empty string
-            let mut records = HashMap::new();
-            let (k, r) =
-                create_files_record("", vec![("abc-0_0-123_20231214.parquet", 1024, false)]);
-            records.insert(k, r);
-            let result = FileSystemView::find_sample_base_file_path_from_records(
-                &records,
-                &BaseFileFormatValue::Parquet,
-            );
-            assert_eq!(result, Some("abc-0_0-123_20231214.parquet".to_string()));
-        }
-
-        #[test]
-        fn test_finds_base_file_for_non_parquet_format() {
-            let mut records = HashMap::new();
-            let (k, r) = create_files_record("partition-a", vec![("file-01.hfile", 1024, false)]);
-            records.insert(k, r);
-            let result = FileSystemView::find_sample_base_file_path_from_records(
-                &records,
-                &BaseFileFormatValue::HFile,
-            );
-            assert_eq!(result, Some("partition-a/file-01.hfile".to_string()));
-        }
-
-        #[test]
-        fn test_returns_none_when_no_valid_base_file() {
-            // Empty records
-            let records = HashMap::new();
-            assert!(
-                FileSystemView::find_sample_base_file_path_from_records(
-                    &records,
-                    &BaseFileFormatValue::Parquet
-                )
-                .is_none()
-            );
-
-            // Only __all_partitions__ record
-            let mut records = HashMap::new();
-            let (k, r) = create_all_partitions_record(vec!["partition1"]);
-            records.insert(k, r);
-            assert!(
-                FileSystemView::find_sample_base_file_path_from_records(
-                    &records,
-                    &BaseFileFormatValue::Parquet
-                )
-                .is_none()
-            );
-
-            // Only deleted parquet files
-            let mut records = HashMap::new();
-            let (k, r) = create_files_record("p1", vec![("deleted.parquet", 100, true)]);
-            records.insert(k, r);
-            assert!(
-                FileSystemView::find_sample_base_file_path_from_records(
-                    &records,
-                    &BaseFileFormatValue::Parquet
-                )
-                .is_none()
-            );
-
-            // Only non-parquet files (log files)
-            let mut records = HashMap::new();
-            let (k, r) = create_files_record("p1", vec![(".abc-0_0-123.log.1_0-456", 200, false)]);
-            records.insert(k, r);
-            assert!(
-                FileSystemView::find_sample_base_file_path_from_records(
-                    &records,
-                    &BaseFileFormatValue::Parquet
-                )
-                .is_none()
-            );
-        }
-    }
 }

--- a/crates/core/src/table/listing.rs
+++ b/crates/core/src/table/listing.rs
@@ -25,6 +25,7 @@ use crate::file_group::FileGroup;
 use crate::file_group::base_file::BaseFile;
 use crate::file_group::log_file::LogFile;
 use crate::metadata::LAKE_FORMAT_METADATA_DIRS;
+use crate::statistics::estimator::FileStatsEstimator;
 use crate::storage::{Storage, get_leaf_dirs};
 use crate::table::partition::{
     EMPTY_PARTITION_PATH, PARTITION_METAFIELD_PREFIX, PartitionPruner, is_table_partitioned,
@@ -72,6 +73,7 @@ impl FileLister {
         &self,
         partition_path: &str,
         completion_time_view: &V,
+        estimator: Option<&FileStatsEstimator>,
     ) -> Result<Vec<FileGroup>> {
         let base_file_format: String = self.hudi_configs.get_or_default(BaseFileFormat).into();
 
@@ -98,6 +100,17 @@ impl FileLister {
                 {
                     // file belongs to an uncommitted commit, skip it
                     continue;
+                }
+                if let Some(metadata) = base_file.file_metadata.as_mut() {
+                    // Populate estimated stats for storage-listing paths so
+                    // snapshot/time-travel metadata matches MDT-backed paths.
+                    if metadata.size > 0 {
+                        let (byte_size, num_records) = estimator
+                            .map(|e| e.estimate(metadata.size))
+                            .unwrap_or((0, 0));
+                        metadata.byte_size = byte_size;
+                        metadata.num_records = num_records;
+                    }
                 }
 
                 let file_id = &base_file.file_id;
@@ -185,10 +198,15 @@ impl FileLister {
     pub async fn list_file_groups_for_relevant_partitions<V: CompletionTimeView + Sync>(
         &self,
         completion_time_view: &V,
+        estimator: Option<&FileStatsEstimator>,
     ) -> Result<DashMap<String, Vec<FileGroup>>> {
         if !is_table_partitioned(&self.hudi_configs) {
             let file_groups = self
-                .list_file_groups_for_partition(EMPTY_PARTITION_PATH, completion_time_view)
+                .list_file_groups_for_partition(
+                    EMPTY_PARTITION_PATH,
+                    completion_time_view,
+                    estimator,
+                )
                 .await?;
             let file_groups_map = DashMap::with_capacity(1);
             file_groups_map.insert(EMPTY_PARTITION_PATH.to_string(), file_groups);
@@ -201,7 +219,7 @@ impl FileLister {
         stream::iter(pruned_partition_paths)
             .map(|p| async move {
                 let file_groups = self
-                    .list_file_groups_for_partition(&p, completion_time_view)
+                    .list_file_groups_for_partition(&p, completion_time_view, estimator)
                     .await?;
                 Ok::<_, CoreError>((p, file_groups))
             })

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -235,7 +235,10 @@ impl Table {
             let Ok(parsed) = HoodieCommitMetadata::from_json_map(&metadata) else {
                 continue;
             };
-            if let Some(path) = parsed.iter_base_file_paths().next() {
+            // Pick a stable sample path so estimator-derived stats are reproducible.
+            // `partition_to_write_stats` is a HashMap, so raw iteration order is
+            // non-deterministic across process runs.
+            if let Some(path) = parsed.iter_base_file_paths().min() {
                 return Some(path);
             }
         }

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -1727,6 +1727,25 @@ mod tests {
             "de3550df-e12c-4591-9335-92ff992258a2-0"
         );
         assert!(file_slice_2.log_files.is_empty());
+
+        // FileMetadata is populated for incremental queries (issue #401).
+        // size comes from HoodieWriteStat.fileSizeInBytes; byte_size and num_records
+        // are estimated from the cached FileStatsEstimator (seeded from a sample
+        // base file in commit metadata at or before end_timestamp).
+        let m0 = file_slice_0.base_file.file_metadata.as_ref().unwrap();
+        assert_eq!(m0.size, 440878);
+        assert_eq!(m0.byte_size, 326703);
+        assert_eq!(m0.num_records, 458);
+
+        let m1 = file_slice_1.base_file.file_metadata.as_ref().unwrap();
+        assert_eq!(m1.size, 440616);
+        assert_eq!(m1.byte_size, 326509);
+        assert_eq!(m1.num_records, 458);
+
+        let m2 = file_slice_2.base_file.file_metadata.as_ref().unwrap();
+        assert_eq!(m2.size, 440638);
+        assert_eq!(m2.byte_size, 326525);
+        assert_eq!(m2.num_records, 458);
     }
 
     #[tokio::test]

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -107,6 +107,7 @@ use crate::file_group::file_slice::FileSlice;
 use crate::file_group::reader::FileGroupReader;
 use crate::keygen::is_timestamp_based_keygen;
 use crate::metadata::METADATA_TABLE_PARTITION_FIELD;
+use crate::metadata::commit::HoodieCommitMetadata;
 use crate::metadata::meta_field::MetaField;
 use crate::schema::resolver::{
     resolve_avro_schema, resolve_avro_schema_with_meta_fields, resolve_data_schema, resolve_schema,
@@ -162,6 +163,23 @@ impl Table {
                 self.new_metadata_table().await
             })
             .await
+    }
+
+    /// Sample one base file path active at or before the given timestamp by
+    /// reading the latest completed commit ≤ timestamp and returning the first
+    /// recorded base-file path from its write stats.
+    ///
+    /// Format-agnostic by design: callers that require a specific format must
+    /// validate before invoking. Returns `None` if there is no such commit or
+    /// no recorded base-file path.
+    pub(crate) async fn sample_base_file_path_at_or_before(
+        &self,
+        timestamp: &str,
+    ) -> Option<String> {
+        let commit = self.timeline.get_latest_commit_at_or_before(timestamp).ok()??;
+        let metadata = self.timeline.get_instant_metadata(&commit).await.ok()?;
+        let parsed = HoodieCommitMetadata::from_json_map(&metadata).ok()?;
+        parsed.iter_base_file_paths().next()
     }
 
     /// Create hudi table by base_uri

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -1943,11 +1943,12 @@ mod tests {
         let early_ts = "19700101000000";
         assert!(table.get_or_init_estimator(early_ts).await.is_none());
 
-        // A later request should still be able to initialize and cache the estimator.
+        // A later request should still be able to initialize and cache the estimator,
+        // and the subsequent early-timestamp call must hit the same cached instance.
         let latest_ts = table.timeline.get_latest_commit_timestamp().unwrap();
-        let est_ptr = table.get_or_init_estimator(&latest_ts).await.unwrap() as *const _;
-        let cached_ptr = table.get_or_init_estimator(early_ts).await.unwrap() as *const _;
-        assert_eq!(est_ptr, cached_ptr);
+        let initialized = table.get_or_init_estimator(&latest_ts).await.unwrap();
+        let cached = table.get_or_init_estimator(early_ts).await.unwrap();
+        assert!(std::ptr::eq(initialized, cached));
     }
 
     #[tokio::test]

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -199,7 +199,9 @@ impl Table {
                 ) {
                     return None;
                 }
-                let path = self.sample_base_file_path_at_or_before(sample_at_timestamp).await?;
+                let path = self
+                    .sample_base_file_path_at_or_before(sample_at_timestamp)
+                    .await?;
                 FileStatsEstimator::from_parquet_footer(&self.file_system_view.storage, &path)
                     .await
                     .ok()

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -1910,6 +1910,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_or_init_estimator_returns_none_for_non_parquet_format() {
+        let base_url = SampleTable::V9TxnsSimpleMeta.url_to_cow();
+        let table = Table::new_with_options(
+            base_url.path(),
+            [
+                (BaseFileFormat.as_ref(), BaseFileFormatValue::HFile.as_ref()),
+                (HudiInternalConfig::SkipConfigValidation.as_ref(), "true"),
+            ],
+        )
+        .await
+        .unwrap();
+        let latest_ts = table.timeline.get_latest_commit_timestamp().unwrap();
+        assert!(table.get_or_init_estimator(&latest_ts).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_get_or_init_estimator_retries_after_early_timestamp_without_sample() {
+        let base_url = SampleTable::V6Nonpartitioned.url_to_cow();
+        let table = Table::new(base_url.path()).await.unwrap();
+
+        // No completed commits at or before this timestamp, so no sample file can be found.
+        let early_ts = "19700101000000";
+        assert!(table.get_or_init_estimator(early_ts).await.is_none());
+
+        // A later request should still be able to initialize and cache the estimator.
+        let latest_ts = table.timeline.get_latest_commit_timestamp().unwrap();
+        let est_ptr = table.get_or_init_estimator(&latest_ts).await.unwrap() as *const _;
+        let cached_ptr = table.get_or_init_estimator(early_ts).await.unwrap() as *const _;
+        assert_eq!(est_ptr, cached_ptr);
+    }
+
+    #[tokio::test]
     async fn test_compute_table_stats_with_mdt() {
         use hudi_test::QuickstartTripsTable;
         let table_path = QuickstartTripsTable::V8Trips8I3U1D.path_to_mor_avro();

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -211,7 +211,14 @@ impl Table {
                 FileStatsEstimator::from_parquet_footer(&self.file_system_view.storage, &path).await
             })
             .await
-            .ok()
+            .map(Some)
+            .unwrap_or_else(|e| {
+                log::warn!(
+                    "Failed to initialize file stats estimator from sample base file '{path}' \
+                     (as-of timestamp: '{sample_at_timestamp}'): {e}"
+                );
+                None
+            })
     }
 
     /// Sample one base file path active at or before the given timestamp.
@@ -539,6 +546,8 @@ impl Table {
             None
         };
 
+        // Estimator-backed metadata enrichment is used by both MDT-backed loading
+        // and fallback storage listing.
         let estimator = self.get_or_init_estimator(timestamp).await;
 
         self.file_system_view

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -101,7 +101,7 @@ use crate::Result;
 use crate::config::HudiConfigs;
 use crate::config::read::HudiReadConfig;
 use crate::config::table::HudiTableConfig::PartitionFields;
-use crate::config::table::{HudiTableConfig, TableTypeValue};
+use crate::config::table::{BaseFileFormatValue, HudiTableConfig, TableTypeValue};
 use crate::expr::filter::{Filter, from_str_tuples};
 use crate::file_group::file_slice::FileSlice;
 use crate::file_group::reader::FileGroupReader;
@@ -112,6 +112,7 @@ use crate::metadata::meta_field::MetaField;
 use crate::schema::resolver::{
     resolve_avro_schema, resolve_avro_schema_with_meta_fields, resolve_data_schema, resolve_schema,
 };
+use crate::statistics::estimator::FileStatsEstimator;
 use crate::table::builder::TableBuilder;
 use crate::table::file_pruner::FilePruner;
 use crate::table::fs_view::FileSystemView;
@@ -137,6 +138,10 @@ pub struct Table {
     /// Only populated when metadata table is enabled (v8+ with files partition).
     /// Shared across clones via `Arc` so all scan() calls reuse the same instance.
     cached_metadata_table: Arc<OnceCell<Table>>,
+    /// Cached file stats estimator. Materialized on first call to
+    /// [`Table::get_or_init_estimator`]. `None` after init means "not applicable"
+    /// (non-Parquet base format, no sample path available, or footer read failed).
+    cached_estimator: Arc<OnceCell<Option<FileStatsEstimator>>>,
 }
 
 impl Clone for Table {
@@ -147,6 +152,7 @@ impl Clone for Table {
             timeline: self.timeline.clone(),
             file_system_view: self.file_system_view.clone(),
             cached_metadata_table: self.cached_metadata_table.clone(),
+            cached_estimator: self.cached_estimator.clone(),
         }
     }
 }
@@ -165,21 +171,73 @@ impl Table {
             .await
     }
 
-    /// Sample one base file path active at or before the given timestamp by
-    /// reading the latest completed commit ≤ timestamp and returning the first
-    /// recorded base-file path from its write stats.
+    /// Get or initialize the cached `FileStatsEstimator` for this **data table**.
     ///
-    /// Format-agnostic by design: callers that require a specific format must
-    /// validate before invoking. Returns `None` if there is no such commit or
-    /// no recorded base-file path.
+    /// This is the single point where eligibility for footer-based stats
+    /// estimation is validated. Returns `None` (cached as such) when:
+    /// - The base file format is not Parquet (e.g., HFile metadata tables).
+    /// - No sample base-file path can be derived from commit metadata at or
+    ///   before `sample_at_timestamp`.
+    /// - The parquet footer read fails for the sample path.
+    ///
+    /// The first call materializes the cache; subsequent calls reuse the cached
+    /// `Option<FileStatsEstimator>` regardless of the timestamp passed in.
+    ///
+    /// Not intended for use on metadata tables. MDTs use HFile, which already
+    /// short-circuits via the format check below; this is documented for the
+    /// reader, not enforced via a separate flag.
+    pub(crate) async fn get_or_init_estimator(
+        &self,
+        sample_at_timestamp: &str,
+    ) -> Option<&FileStatsEstimator> {
+        self.cached_estimator
+            .get_or_init(|| async {
+                // SINGLE point of parquet validation for the estimator concern.
+                if !matches!(
+                    self.file_system_view.base_file_format(),
+                    BaseFileFormatValue::Parquet
+                ) {
+                    return None;
+                }
+                let path = self.sample_base_file_path_at_or_before(sample_at_timestamp).await?;
+                FileStatsEstimator::from_parquet_footer(&self.file_system_view.storage, &path)
+                    .await
+                    .ok()
+            })
+            .await
+            .as_ref()
+    }
+
+    /// Sample one base file path active at or before the given timestamp.
+    ///
+    /// Walks completed commits ≤ `timestamp` in reverse (latest-first) and
+    /// returns the first recorded base-file path. This handles MOR tables
+    /// whose latest commit may be a delta commit with only log files —
+    /// in that case we fall back to earlier commits that wrote base files.
+    ///
+    /// Format-agnostic by design: callers that require a specific format
+    /// must validate before invoking. Returns `None` if no commit in range
+    /// has a recorded base-file path.
     pub(crate) async fn sample_base_file_path_at_or_before(
         &self,
         timestamp: &str,
     ) -> Option<String> {
-        let commit = self.timeline.get_latest_commit_at_or_before(timestamp).ok()??;
-        let metadata = self.timeline.get_instant_metadata(&commit).await.ok()?;
-        let parsed = HoodieCommitMetadata::from_json_map(&metadata).ok()?;
-        parsed.iter_base_file_paths().next()
+        let commits = self
+            .timeline
+            .get_completed_commits_at_or_before(timestamp)
+            .ok()?;
+        for commit in commits.iter().rev() {
+            let Ok(metadata) = self.timeline.get_instant_metadata(commit).await else {
+                continue;
+            };
+            let Ok(parsed) = HoodieCommitMetadata::from_json_map(&metadata) else {
+                continue;
+            };
+            if let Some(path) = parsed.iter_base_file_paths().next() {
+                return Some(path);
+            }
+        }
+        None
     }
 
     /// Create hudi table by base_uri
@@ -472,6 +530,8 @@ impl Table {
             None
         };
 
+        let estimator = self.get_or_init_estimator(timestamp).await;
+
         self.file_system_view
             .get_file_slices(
                 &partition_pruner,
@@ -479,6 +539,7 @@ impl Table {
                 &table_schema,
                 &timeline_view,
                 metadata_table,
+                estimator,
             )
             .await
     }
@@ -891,19 +952,15 @@ impl Table {
             .filter(|(name, _)| name.ends_with(&base_file_suffix))
             .map(|(_, size)| size)
             .sum::<u64>();
-        let sample_file_path =
-            FileSystemView::find_sample_base_file_path_from_records(&records, &base_file_format);
 
         if total_on_disk_size == 0 {
             return None;
         }
 
-        // Step 2: Use the cached estimator (or init it now).
-        // Return None if no sample file is found or estimator fails to initialize.
-        let estimator = self
-            .file_system_view
-            .get_or_init_estimator(&base_file_format, sample_file_path.as_deref())
-            .await?;
+        // Step 2: Use the cached estimator (seeded from the latest commit's sample).
+        // Return None if estimator is not available (non-Parquet, no sample, or read failed).
+        let latest_ts = self.timeline.get_latest_commit_timestamp().ok()?;
+        let estimator = self.get_or_init_estimator(&latest_ts).await?;
         let (estimated_total_byte_size, estimated_total_rows) =
             estimator.estimate(total_on_disk_size);
         // Estimator math is non-negative by construction (u64 size * f64 ratio).

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -138,10 +138,10 @@ pub struct Table {
     /// Only populated when metadata table is enabled (v8+ with files partition).
     /// Shared across clones via `Arc` so all scan() calls reuse the same instance.
     cached_metadata_table: Arc<OnceCell<Table>>,
-    /// Cached file stats estimator. Materialized on first call to
-    /// [`Table::get_or_init_estimator`]. `None` after init means "not applicable"
-    /// (non-Parquet base format, no sample path available, or footer read failed).
-    cached_estimator: Arc<OnceCell<Option<FileStatsEstimator>>>,
+    /// Cached file stats estimator. Materialized on first successful call to
+    /// [`Table::get_or_init_estimator`]. Failed or inapplicable attempts do not
+    /// populate the cache, allowing later calls with newer timestamps to retry.
+    cached_estimator: Arc<OnceCell<FileStatsEstimator>>,
 }
 
 impl Clone for Table {
@@ -174,14 +174,14 @@ impl Table {
     /// Get or initialize the cached `FileStatsEstimator` for this **data table**.
     ///
     /// This is the single point where eligibility for footer-based stats
-    /// estimation is validated. Returns `None` (cached as such) when:
+    /// estimation is validated. Returns `None` when:
     /// - The base file format is not Parquet (e.g., HFile metadata tables).
     /// - No sample base-file path can be derived from commit metadata at or
     ///   before `sample_at_timestamp`.
     /// - The parquet footer read fails for the sample path.
     ///
-    /// The first call materializes the cache; subsequent calls reuse the cached
-    /// `Option<FileStatsEstimator>` regardless of the timestamp passed in.
+    /// The cache is only materialized on successful initialization. This avoids
+    /// pinning a "no sample yet" state from an early timestamp.
     ///
     /// Not intended for use on metadata tables. MDTs use HFile, which already
     /// short-circuits via the format check below; this is documented for the
@@ -190,24 +190,28 @@ impl Table {
         &self,
         sample_at_timestamp: &str,
     ) -> Option<&FileStatsEstimator> {
+        if let Some(estimator) = self.cached_estimator.get() {
+            return Some(estimator);
+        }
+
+        // SINGLE point of parquet validation for the estimator concern.
+        if !matches!(
+            self.file_system_view.base_file_format(),
+            BaseFileFormatValue::Parquet
+        ) {
+            return None;
+        }
+
+        let path = self
+            .sample_base_file_path_at_or_before(sample_at_timestamp)
+            .await?;
+
         self.cached_estimator
-            .get_or_init(|| async {
-                // SINGLE point of parquet validation for the estimator concern.
-                if !matches!(
-                    self.file_system_view.base_file_format(),
-                    BaseFileFormatValue::Parquet
-                ) {
-                    return None;
-                }
-                let path = self
-                    .sample_base_file_path_at_or_before(sample_at_timestamp)
-                    .await?;
-                FileStatsEstimator::from_parquet_footer(&self.file_system_view.storage, &path)
-                    .await
-                    .ok()
+            .get_or_try_init(|| async {
+                FileStatsEstimator::from_parquet_footer(&self.file_system_view.storage, &path).await
             })
             .await
-            .as_ref()
+            .ok()
     }
 
     /// Sample one base file path active at or before the given timestamp.
@@ -226,7 +230,7 @@ impl Table {
     ) -> Option<String> {
         let commits = self
             .timeline
-            .get_completed_commits_at_or_before(timestamp)
+            .get_completed_instants_at_or_before(timestamp)
             .ok()?;
         for commit in commits.iter().rev() {
             let Ok(metadata) = self.timeline.get_instant_metadata(commit).await else {

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -619,11 +619,17 @@ impl Table {
         start_timestamp: &str,
         end_timestamp: &str,
     ) -> Result<Vec<FileSlice>> {
-        let mut file_slices: Vec<FileSlice> = Vec::new();
+        // Seed the cached estimator from a sample base file at or before
+        // end_timestamp so the file group builder can populate FileMetadata
+        // (size, byte_size, num_records) on each base file.
+        let estimator = self.get_or_init_estimator(end_timestamp).await;
+
         let file_groups = self
             .timeline
-            .get_file_groups_between(Some(start_timestamp), Some(end_timestamp))
+            .get_file_groups_between(Some(start_timestamp), Some(end_timestamp), estimator)
             .await?;
+
+        let mut file_slices: Vec<FileSlice> = Vec::new();
         for file_group in file_groups {
             if let Some(file_slice) = file_group.get_file_slice_as_of(end_timestamp) {
                 file_slices.push(file_slice.clone());

--- a/crates/core/src/timeline/mod.rs
+++ b/crates/core/src/timeline/mod.rs
@@ -284,9 +284,9 @@ impl Timeline {
         resolve_data_schema_from_commit_metadata(&commit_metadata, self.storage.clone()).await
     }
 
-    /// Get all completed commit instants whose request timestamp is ≤ `timestamp`,
-    /// sorted ascending by timestamp.
-    pub(crate) fn get_completed_commits_at_or_before(
+    /// Get all completed instants (commit/deltacommit/replacecommit) whose
+    /// request timestamp is ≤ `timestamp`, sorted ascending by timestamp.
+    pub(crate) fn get_completed_instants_at_or_before(
         &self,
         timestamp: &str,
     ) -> Result<Vec<Instant>> {
@@ -337,7 +337,7 @@ impl Timeline {
         estimator: Option<&FileStatsEstimator>,
     ) -> Result<HashSet<FileGroup>> {
         use crate::file_group::builder::{
-            FileGroupMerger, file_groups_from_commit_metadata,
+            FileGroupMerger, file_groups_from_commit_metadata_with_estimator,
             replaced_file_groups_from_replace_commit,
         };
 
@@ -367,7 +367,7 @@ impl Timeline {
 
         for commit in commits {
             let commit_metadata = self.get_instant_metadata(&commit).await?;
-            file_groups.merge(file_groups_from_commit_metadata(
+            file_groups.merge(file_groups_from_commit_metadata_with_estimator(
                 &commit_metadata,
                 &completion_time_view,
                 estimator,

--- a/crates/core/src/timeline/mod.rs
+++ b/crates/core/src/timeline/mod.rs
@@ -283,21 +283,19 @@ impl Timeline {
         resolve_data_schema_from_commit_metadata(&commit_metadata, self.storage.clone()).await
     }
 
-    /// Get the latest completed commit instant whose request timestamp is ≤ `timestamp`.
-    ///
-    /// Returns `None` if no such commit exists.
-    pub(crate) fn get_latest_commit_at_or_before(
+    /// Get all completed commit instants whose request timestamp is ≤ `timestamp`,
+    /// sorted ascending by timestamp.
+    pub(crate) fn get_completed_commits_at_or_before(
         &self,
         timestamp: &str,
-    ) -> Result<Option<Instant>> {
+    ) -> Result<Vec<Instant>> {
         let selector = TimelineSelector::completed_actions_in_range(
             DEFAULT_LOADING_ACTIONS,
             self.hudi_configs.clone(),
             None,
             Some(timestamp),
         )?;
-        let mut commits = selector.select(self)?;
-        Ok(commits.pop())
+        selector.select(self)
     }
 
     pub(crate) async fn get_replaced_file_groups_as_of(

--- a/crates/core/src/timeline/mod.rs
+++ b/crates/core/src/timeline/mod.rs
@@ -33,6 +33,7 @@ use crate::file_group::builder::replaced_file_groups_from_replace_commit;
 use crate::schema::resolver::{
     resolve_avro_schema_from_commit_metadata, resolve_data_schema_from_commit_metadata,
 };
+use crate::statistics::estimator::FileStatsEstimator;
 use crate::storage::Storage;
 use crate::timeline::builder::TimelineBuilder;
 use crate::timeline::instant::Action;
@@ -333,6 +334,7 @@ impl Timeline {
         &self,
         start_timestamp: Option<&str>,
         end_timestamp: Option<&str>,
+        estimator: Option<&FileStatsEstimator>,
     ) -> Result<HashSet<FileGroup>> {
         use crate::file_group::builder::{
             FileGroupMerger, file_groups_from_commit_metadata,
@@ -368,6 +370,7 @@ impl Timeline {
             file_groups.merge(file_groups_from_commit_metadata(
                 &commit_metadata,
                 &completion_time_view,
+                estimator,
             )?)?;
 
             if commit.is_replacecommit() {

--- a/crates/core/src/timeline/mod.rs
+++ b/crates/core/src/timeline/mod.rs
@@ -215,7 +215,10 @@ impl Timeline {
         Ok(clustering_instants)
     }
 
-    async fn get_instant_metadata(&self, instant: &Instant) -> Result<Map<String, Value>> {
+    pub(crate) async fn get_instant_metadata(
+        &self,
+        instant: &Instant,
+    ) -> Result<Map<String, Value>> {
         self.active_loader.load_instant_metadata(instant).await
     }
 
@@ -278,6 +281,23 @@ impl Timeline {
     pub async fn get_latest_schema(&self) -> Result<Schema> {
         let commit_metadata = self.get_latest_commit_metadata().await?;
         resolve_data_schema_from_commit_metadata(&commit_metadata, self.storage.clone()).await
+    }
+
+    /// Get the latest completed commit instant whose request timestamp is ≤ `timestamp`.
+    ///
+    /// Returns `None` if no such commit exists.
+    pub(crate) fn get_latest_commit_at_or_before(
+        &self,
+        timestamp: &str,
+    ) -> Result<Option<Instant>> {
+        let selector = TimelineSelector::completed_actions_in_range(
+            DEFAULT_LOADING_ACTIONS,
+            self.hudi_configs.clone(),
+            None,
+            Some(timestamp),
+        )?;
+        let mut commits = selector.select(self)?;
+        Ok(commits.pop())
     }
 
     pub(crate) async fn get_replaced_file_groups_as_of(


### PR DESCRIPTION
## Description

Fixes #401. Replaces #579 (auto-closed during rebase).

- Move cached `FileStatsEstimator` from `FileSystemView` to `Table`; single `OnceCell` shared by both query paths.
- `Table::get_or_init_estimator` is the single gatekeeper for parquet eligibility (data tables only; HFile MDTs short-circuit naturally).
- Seed estimator from a base parquet path discovered in commit metadata; walk back through commits to handle MOR delta-only-latest.
- `file_groups_from_commit_metadata` accepts the estimator and populates `FileMetadata` from `HoodieWriteStat::file_size_in_bytes` like the MDT-records builder.
- Remove `FileSystemView`'s estimator state and helpers; inline the parquet check inside `apply_stats_pruning_from_footers` (separate column-stats concern).
- Result: incremental queries return `FileSlice`s with `size`/`byte_size`/`num_records` populated; storage-listing snapshot path also gains full stats.

## How are the changes test-covered

- [x] Automated tests (unit and/or integration tests)