### PR TITLE
docs: add AGENTS.md as canonical AI coding agent guide

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,64 +1,49 @@
-# GitHub Copilot Instructions for Apache Hudi-rs
+# GitHub Copilot Instructions — Apache Hudi-rs
 
-## Project Overview
+GitHub Copilot loads **both** this file and [`AGENTS.md`](../AGENTS.md) at the root of the repo;
+they are concatenated, not alternatives. Treat `AGENTS.md` as the source of truth for project
+overview, build commands, coding conventions, testing, PR rules, and the review rubric — this file
+adds Copilot-specific notes only.
 
-Apache Hudi-rs is the native Rust implementation of Apache Hudi, providing Python and C++ API bindings. The project focuses on standardizing core Apache Hudi APIs and broadening Hudi integration in the data ecosystem.
+Path-scoped rules under [`./instructions/`](./instructions) are loaded automatically when files
+match their `applyTo` glob and remain authoritative for those files.
 
-### Key Dependencies & Ecosystem
+## Quick orientation
 
-- **Apache Arrow**: In-memory columnar format (via `arrow-rs` crate)
-- **Apache DataFusion**: Query execution engine integration
-- **Apache Parquet**: Columnar storage format
-- **PyO3**: Python bindings
-- **CXX**: C++ FFI bindings
-- **Tokio**: Async runtime
+- Native Rust implementation of Apache Hudi with Python (PyO3) and C++ (`cxx`) bindings.
+- Workspace: `crates/{core,datafusion,hudi,test}`, plus `python/`, `cpp/`, `benchmark/tpch/`.
+- Toolchain: Rust edition `2024` / MSRV `1.88`; Python `>=3.10`; managed via `uv` and `maturin`.
+- Pre-PR check: `make format check test`.
 
-## Commit Conventions
+## Path-scoped rules (loaded by `applyTo` frontmatter)
 
-This project uses [Conventional Commits](https://www.conventionalcommits.org). PR titles must follow this format:
+| Glob              | File                                                                                       | Topic                                                              |
+| ----------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
+| `**/*.rs`         | [`instructions/rust.instructions.md`](./instructions/rust.instructions.md)                 | Rust error handling, async, performance, API design, doc comments  |
+| `python/**`       | [`instructions/python.instructions.md`](./instructions/python.instructions.md)             | PyO3 patterns, GIL management, PyArrow conversion, Python tests    |
+| `**/*` (review)   | [`instructions/code-review.instructions.md`](./instructions/code-review.instructions.md)   | Review rubric, severity tags, multi-round behavior, cross-file impact |
 
-```
-<type>(<scope>): <description>
-```
+## PR title format
 
-Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`
+PR titles must follow [Conventional Commits](https://www.conventionalcommits.org)
+(`<type>(<scope>): <description>`). Allowed types per
+[`.commitlintrc.yaml`](../.commitlintrc.yaml):
+`build chore ci docs feat fix perf refactor revert style test`. Examples:
 
-Examples:
 - `feat(core): add support for MOR table reads`
 - `fix(python): handle null partition values correctly`
 - `docs: update API documentation for HudiTable`
 
-## Development Setup
+## Copilot review behavior
 
-See [CONTRIBUTING.md](../CONTRIBUTING.md) for full details.
+- Focus on the latest commits in updated PRs; don't re-raise issues already fixed.
+- Use the severity tags from [`AGENTS.md` → Code review](../AGENTS.md#code-review-rubric)
+  (🔴 / 🟠 / 🟡 / 💬).
+- For `crates/core` public-API changes, check `crates/datafusion`, `python/`, and `cpp/` for
+  downstream impact before approving.
+- Flag `.unwrap()` / `.expect()` / `panic!()` in non-test code as 🔴 Critical.
+- Flag blocking I/O in async functions as 🔴 Critical.
+- Flag hardcoded credentials or secrets as 🔴 Critical.
 
-### Prerequisites
-
-- Rust (see `rust-toolchain.toml`)
-- [uv](https://docs.astral.sh/uv/) - Python package manager
-- Python (see `python/pyproject.toml` for version)
-
-### Quick Start
-
-```bash
-# Setup Python virtual environment
-make setup-venv
-source .venv/bin/activate
-
-# Install for development (builds Rust + Python bindings)
-make develop
-
-# Format and lint
-make format check
-
-# Run all tests
-make test
-```
-
-## Testing
-
-- Unit tests in the same file as the code (`#[cfg(test)]` module)
-- Integration tests in dedicated test modules or test crate
-- Test both success and error paths
-- Use descriptive test names: `test_<function>_<scenario>_<expected_behavior>`
-- Use `#[tokio::test]` for async tests
+For everything else — build commands, coding conventions, testing, security expectations — see
+[`AGENTS.md`](../AGENTS.md).

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Install python linter dependencies
         run: |

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -23,6 +23,8 @@ header:
   paths-ignore:
     - 'LICENSE'
     - 'NOTICE'
+    - 'AGENTS.md'
+    - 'CLAUDE.md'
     - '**/data/**'
     - '.github/PULL_REQUEST_TEMPLATE.md'
     - '.github/copilot-instructions.md'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,190 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+
+# AGENTS.md
+
+Canonical guidance for AI coding agents (ChatGPT/Codex, GitHub Copilot, Cursor, Aider, Zed, etc.)
+working on this repository — the [`agents.md`](https://agents.md) format. Humans should start with
+[`README.md`](./README.md) and [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+
+- [`CLAUDE.md`](./CLAUDE.md) imports this file via `@AGENTS.md` (Claude Code reads `CLAUDE.md`, not
+  `AGENTS.md`).
+- [`.github/copilot-instructions.md`](./.github/copilot-instructions.md) is loaded by GitHub Copilot
+  alongside this file — both are read; it carries Copilot-specific notes.
+- [`.github/instructions/*.instructions.md`](./.github/instructions) hold path-scoped Copilot rules
+  via `applyTo` frontmatter; their content is summarized below so any agent applies the same
+  standards.
+
+## Project at a glance
+
+- Native Rust implementation of [Apache Hudi](https://hudi.apache.org), with Python (PyO3) and C++
+  ([`cxx`](https://cxx.rs)) bindings. Apache 2.0; ASF project.
+- Rust workspace, edition `2024`, MSRV `1.88`. Python `>=3.10`. See [`Cargo.toml`](./Cargo.toml)
+  and [`python/pyproject.toml`](./python/pyproject.toml) for authoritative version pins.
+- Distributed as [`hudi` on crates.io](https://crates.io/crates/hudi) and
+  [`hudi` on PyPI](https://pypi.org/project/hudi/).
+
+## Repository layout
+
+```
+crates/
+  core/         hudi-core — config, expr, file_group, merge, metadata, schema, storage, table, timeline, hfile
+  datafusion/   hudi-datafusion — DataFusion TableProvider (feature: datafusion)
+  hudi/         public umbrella crate; re-exports core + (optional) datafusion
+  test/         shared test fixtures
+python/         PyO3 bindings (module hudi._internal); tests in python/tests
+cpp/            cxx-based C++ bindings; bridge in cpp/src/lib.rs
+benchmark/tpch/ TPC-H benchmark harness (datafusion / spark)
+demo/           docker-compose demos
+.github/
+  workflows/        ci.yml, code.yml, pr.yml, release.yml
+  instructions/     path-scoped Copilot rules (rust, python, code-review)
+```
+
+## Setup & common commands
+
+The [`Makefile`](./Makefile) is the canonical command surface. **Prefer `make <target>`** so agents
+and humans run exactly what CI runs. Cargo / maturin invocations go through
+[`build-wrapper.sh`](./build-wrapper.sh) (sets macOS SDK env vars on macOS 26+).
+
+```bash
+make setup-venv && source .venv/bin/activate
+make develop                 # build workspace + install Python binding via maturin
+make format check test       # the pre-PR loop CI runs
+
+# Targeted runs
+cargo test -p hudi-core                                        # one crate
+cargo test -p hudi-core table::tests::hudi_table_get_schema    # one test
+pytest python/tests/test_table_read.py -s -k "test_read_table_has_correct_schema"
+make coverage-rust                                             # tarpaulin HTML at cov-reports/
+make coverage-check                                            # fails if < 60% (COV_THRESHOLD)
+```
+
+## Coding conventions
+
+Full per-language rules live in [`.github/instructions/`](./.github/instructions). Highlights:
+
+### Rust ([rules](./.github/instructions/rust.instructions.md))
+
+- **No `.unwrap()` / `.expect()` / `panic!()`** in non-test code (treated as 🔴 Critical in review).
+  `unreachable!()` is OK only with a comment justifying the invariant.
+- **Errors carry context** — typed `thiserror` variants or `anyhow::Context`; messages name the
+  offending value (path, key, timestamp). Avoid bare `.map_err(Into::into)`.
+- **No blocking I/O in async** (`std::fs::*`, `std::thread::sleep`). Use Tokio equivalents or
+  `tokio::task::spawn_blocking` for CPU-bound work. Async functions must return `Send` futures (no
+  `Rc` / `RefCell` across `.await`).
+- **Avoid unnecessary `.clone()`** on `RecordBatch`, `Schema`, `Vec<_>`. Prefer `&str`, `&[T]`, or
+  `Cow<'_, str>` in parameter positions when ownership isn't required. Prefer Arrow compute kernels
+  over hand-rolled loops.
+- **Builder pattern** for many-optional types: consume `self`, return `Self`, finalize with
+  `build()` / `build().await`.
+- **Public items must have doc comments**, with examples for non-trivial APIs and explicit notes on
+  panics, errors, and safety.
+- **Inline format args** (Rust 1.88+): `format!("{x}")`, not `format!("{}", x)`.
+- **Don't widen the `cxx` FFI surface** to expose internal Hudi types — keep the bridge narrow.
+
+### Python ([rules](./.github/instructions/python.instructions.md))
+
+- Linted with `ruff` (`E4 E7 E9 F I`, `target-version = py310`); type-checked with `mypy --strict`
+  over `hudi/*.py`. `snake_case`, docstrings on public APIs, type hints in `python/hudi/_internal.pyi`.
+- **PyO3**: convert Rust errors into specific Python exceptions
+  (`PyRuntimeError::new_err(format!("Failed to …: {e}"))`); never let a panic surface to Python.
+  Release the GIL with `py.allow_threads(...)` for blocking I/O. Use `arrow::pyarrow::ToPyArrow`
+  for zero-copy Arrow ↔ PyArrow conversion.
+
+### C++
+
+The FFI surface is generated by [`cxx`](https://cxx.rs); the Rust bridge lives in `cpp/src/lib.rs`.
+Keep it thin — push real logic into `crates/core` and expose narrow shims. Functions may throw
+`rust::Error`; document the error semantics on the C++ side.
+
+## Testing
+
+- Rust unit tests are colocated under `#[cfg(test)] mod tests`. Use `#[tokio::test]` for async.
+  Naming: `test_<function>_<scenario>_<expected>`. Shared fixtures live in `crates/test`.
+- Python tests are in `python/tests/` and run under `pytest`. Cover happy and error paths.
+- New features and bug fixes **must** add tests; for bug fixes, add a regression test that would
+  have caught the bug. Avoid redundant coverage — each test should have a unique purpose.
+- Coverage tracked via [Codecov](https://app.codecov.io/github/apache/hudi-rs)
+  ([`codecov.yml`](./codecov.yml)).
+
+## Pull request conventions
+
+1. **Title** must follow [Conventional Commits](https://www.conventionalcommits.org)
+   (`<type>(<scope>): <description>`). Allowed types per
+   [`.commitlintrc.yaml`](./.commitlintrc.yaml):
+   `build chore ci docs feat fix perf refactor revert style test`. Header ≤ 100 chars; lower-case
+   type; no trailing period; no sentence/start/upper/pascal case in the subject. Examples:
+   - `feat(core): add support for MOR table reads`
+   - `fix(python): handle null partition values correctly`
+2. **Diff size**: keep `max(added, deleted) < 1000 lines` or justify in the PR description.
+3. **Tests required** for new features and bug fixes.
+4. **Comments**: comment non-obvious WHY only (constraints, invariants, workarounds). Don't
+   reference internal plans, phases, or external roadmaps; for unimplemented work prefer
+   "not yet implemented" over TODOs that point at planning docs.
+5. **Cross-binding impact**: changes to `crates/core` public API may cascade to `crates/datafusion`,
+   `python/`, and `cpp/`. Verify all bindings still build and document any breaking changes.
+6. **No secrets** in code, tests, fixtures, or CI logs. Cloud credentials come from environment
+   variables (`AWS_*`, `AZURE_*`, `GOOGLE_*`) or table options.
+7. **Don't bypass `make check` / pre-commit hooks** (`--no-verify`) without justification — fix
+   the underlying issue.
+8. **License headers**: every new source file needs the ASF header
+   ([`.licenserc.yaml`](./.licenserc.yaml) lists ignored paths; CI fails without it).
+
+## Cloud storage & configuration
+
+- Storage backends are routed by URI scheme (`file://`, `s3://`, `az://`, `gs://`) through
+  [`object_store`](https://docs.rs/object_store). Don't hand-roll per-scheme path handling.
+- Table options are typed: `HudiTableConfig`, `HudiReadConfig` (also exported as Python enums).
+  Prefer the typed enum over raw string keys. Singular setters (`with_hudi_option` / `with_option`)
+  accept enum members directly; bulk variants (`with_hudi_options` / `with_options`) currently
+  expect string keys (or `member.value`).
+
+## Code review (rubric)
+
+Full rubric: [`.github/instructions/code-review.instructions.md`](./.github/instructions/code-review.instructions.md). Severity tags to use in comments:
+
+- 🔴 **Critical** — must fix: `.unwrap()/.expect()/panic!()` in lib code, blocking calls in async,
+  hardcoded secrets, breaking public-API changes without docs.
+- 🟠 **Important** — should fix: missing error context, unnecessary clones, missing doc comments
+  on `pub` items, missing tests for new behavior.
+- 🟡 **Suggestion** — iterator chains over imperative loops, `?` over nested `match` on `Result`.
+- 💬 **Question** — clarification.
+
+On updated PRs, focus on the latest commits; do not re-raise issues fixed by follow-up commits.
+For `crates/core` public API changes, also inspect `crates/datafusion`, `python/`, and `cpp/`.
+
+## Pointers
+
+| Document                                              | Purpose                                                            |
+| ----------------------------------------------------- | ------------------------------------------------------------------ |
+| [`README.md`](./README.md)                            | usage examples (Python / Rust / C++) and feature overview          |
+| [`CONTRIBUTING.md`](./CONTRIBUTING.md)                | full human contributor workflow                                    |
+| [`Makefile`](./Makefile)                              | every supported dev/CI command                                     |
+| [`Cargo.toml`](./Cargo.toml)                          | workspace members and dependency pins                              |
+| [`python/pyproject.toml`](./python/pyproject.toml)    | Python build / lint / type-check configuration                     |
+| [`CHANGELOG.md`](./CHANGELOG.md)                      | release history (driven by `cliff.toml` from Conventional Commits) |
+| [Apache Hudi docs](https://hudi.apache.org/docs/overview) | timeline, file groups, MOR/COW, schema evolution               |
+| [Issue tracker](https://github.com/apache/hudi-rs/issues) | bugs, features                                                 |
+| [Slack](https://hudi.apache.org/slack)                | community chat (`#hudi`)                                           |
+
+## Maintenance
+
+When you add or rename a `make` target, change a coding convention, bump the MSRV, or restructure
+the workspace, **update this file in the same PR**. Stale agent guidance produces stale code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,46 +1,20 @@
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
--->
-
 # AGENTS.md
 
-Canonical guidance for AI coding agents (ChatGPT/Codex, GitHub Copilot, Cursor, Aider, Zed, etc.)
-working on this repository — the [`agents.md`](https://agents.md) format. Humans should start with
-[`README.md`](./README.md) and [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+Guidance for AI coding agents working on this repository — the [agents.md](https://agents.md) format.
+Humans should start with [`README.md`](./README.md) and [`CONTRIBUTING.md`](./CONTRIBUTING.md).
 
-- [`CLAUDE.md`](./CLAUDE.md) imports this file via `@AGENTS.md` (Claude Code reads `CLAUDE.md`, not
-  `AGENTS.md`).
+- [`CLAUDE.md`](./CLAUDE.md) imports this file via `@AGENTS.md` (Claude Code reads `CLAUDE.md`).
 - [`.github/copilot-instructions.md`](./.github/copilot-instructions.md) is loaded by GitHub Copilot
-  alongside this file — both are read; it carries Copilot-specific notes.
-- [`.github/instructions/*.instructions.md`](./.github/instructions) hold path-scoped Copilot rules
-  via `applyTo` frontmatter; their content is summarized below so any agent applies the same
-  standards.
+  alongside this file and carries Copilot-specific notes.
+- [`.github/instructions/*.instructions.md`](./.github/instructions) are path-scoped Copilot rules
+  (via `applyTo` frontmatter); their content is summarized below so any agent applies the same standards.
 
-## Project at a glance
+## Project
 
-- Native Rust implementation of [Apache Hudi](https://hudi.apache.org), with Python (PyO3) and C++
-  ([`cxx`](https://cxx.rs)) bindings. Apache 2.0; ASF project.
-- Rust workspace, edition `2024`, MSRV `1.88`. Python `>=3.10`. See [`Cargo.toml`](./Cargo.toml)
-  and [`python/pyproject.toml`](./python/pyproject.toml) for authoritative version pins.
-- Distributed as [`hudi` on crates.io](https://crates.io/crates/hudi) and
-  [`hudi` on PyPI](https://pypi.org/project/hudi/).
-
-## Repository layout
+Native Rust implementation of [Apache Hudi](https://hudi.apache.org) with Python (PyO3) and C++
+([`cxx`](https://cxx.rs)) bindings. Apache 2.0. Rust workspace, edition `2024`, MSRV `1.88`.
+Python `>=3.10`. Distributed as [`hudi`](https://crates.io/crates/hudi) on crates.io and
+[`hudi`](https://pypi.org/project/hudi/) on PyPI.
 
 ```
 crates/
@@ -49,142 +23,116 @@ crates/
   hudi/         public umbrella crate; re-exports core + (optional) datafusion
   test/         shared test fixtures
 python/         PyO3 bindings (module hudi._internal); tests in python/tests
-cpp/            cxx-based C++ bindings; bridge in cpp/src/lib.rs
-benchmark/tpch/ TPC-H benchmark harness (datafusion / spark)
-demo/           docker-compose demos
-.github/
-  workflows/        ci.yml, code.yml, pr.yml, release.yml
-  instructions/     path-scoped Copilot rules (rust, python, code-review)
+cpp/            cxx bindings; bridge in cpp/src/lib.rs
+benchmark/tpch/ TPC-H benchmark harness
+.github/instructions/   path-scoped Copilot rules (rust, python, code-review)
 ```
 
-## Setup & common commands
+## Commands
 
-The [`Makefile`](./Makefile) is the canonical command surface. **Prefer `make <target>`** so agents
-and humans run exactly what CI runs. Cargo / maturin invocations go through
-[`build-wrapper.sh`](./build-wrapper.sh) (sets macOS SDK env vars on macOS 26+).
+The [`Makefile`](./Makefile) is the canonical command surface — **prefer `make <target>`** so agents
+and humans run what CI runs. Cargo / maturin go through [`build-wrapper.sh`](./build-wrapper.sh)
+(macOS 26+ SDK env vars).
 
 ```bash
 make setup-venv && source .venv/bin/activate
 make develop                 # build workspace + install Python binding via maturin
 make format check test       # the pre-PR loop CI runs
 
-# Targeted runs
 cargo test -p hudi-core                                        # one crate
 cargo test -p hudi-core table::tests::hudi_table_get_schema    # one test
-pytest python/tests/test_table_read.py -s -k "test_read_table_has_correct_schema"
+pytest python/tests/test_table_read.py -s -k "<expr>"          # one Python test
 make coverage-rust                                             # tarpaulin HTML at cov-reports/
-make coverage-check                                            # fails if < 60% (COV_THRESHOLD)
 ```
 
-## Coding conventions
+## Conventions
 
-Full per-language rules live in [`.github/instructions/`](./.github/instructions). Highlights:
+### Rust ([details](./.github/instructions/rust.instructions.md))
 
-### Rust ([rules](./.github/instructions/rust.instructions.md))
-
-- **No `.unwrap()` / `.expect()` / `panic!()`** in non-test code (treated as 🔴 Critical in review).
-  `unreachable!()` is OK only with a comment justifying the invariant.
+- **No `.unwrap()` / `.expect()` / `panic!()`** in non-test code (🔴 Critical). `unreachable!()`
+  only with a comment justifying the invariant.
 - **Errors carry context** — typed `thiserror` variants or `anyhow::Context`; messages name the
-  offending value (path, key, timestamp). Avoid bare `.map_err(Into::into)`.
-- **No blocking I/O in async** (`std::fs::*`, `std::thread::sleep`). Use Tokio equivalents or
-  `tokio::task::spawn_blocking` for CPU-bound work. Async functions must return `Send` futures (no
-  `Rc` / `RefCell` across `.await`).
-- **Avoid unnecessary `.clone()`** on `RecordBatch`, `Schema`, `Vec<_>`. Prefer `&str`, `&[T]`, or
-  `Cow<'_, str>` in parameter positions when ownership isn't required. Prefer Arrow compute kernels
-  over hand-rolled loops.
-- **Builder pattern** for many-optional types: consume `self`, return `Self`, finalize with
-  `build()` / `build().await`.
-- **Public items must have doc comments**, with examples for non-trivial APIs and explicit notes on
-  panics, errors, and safety.
+  offending value. Avoid bare `.map_err(Into::into)`.
+- **No blocking I/O in async** (`std::fs::*`, `std::thread::sleep`); use Tokio or
+  `tokio::task::spawn_blocking`. Async functions must return `Send` futures.
+- **Avoid unnecessary `.clone()`** on `RecordBatch` / `Schema` / `Vec<_>`. Prefer `&str`, `&[T]`,
+  `Cow<'_, str>` in parameters. Prefer Arrow compute kernels over hand-rolled loops.
+- **Builder pattern** for many-optional types: consume `self`, return `Self`, finalize with `build()`.
+- **Public items must have doc comments** (examples for non-trivial APIs; note panics, errors, safety).
 - **Inline format args** (Rust 1.88+): `format!("{x}")`, not `format!("{}", x)`.
 - **Don't widen the `cxx` FFI surface** to expose internal Hudi types — keep the bridge narrow.
 
-### Python ([rules](./.github/instructions/python.instructions.md))
+### Python ([details](./.github/instructions/python.instructions.md))
 
-- Linted with `ruff` (`E4 E7 E9 F I`, `target-version = py310`); type-checked with `mypy --strict`
-  over `hudi/*.py`. `snake_case`, docstrings on public APIs, type hints in `python/hudi/_internal.pyi`.
-- **PyO3**: convert Rust errors into specific Python exceptions
+- `ruff` (`E4 E7 E9 F I`, target `py310`) + `mypy --strict` over `hudi/*.py`. `snake_case`,
+  docstrings on public APIs, type hints in `python/hudi/_internal.pyi`.
+- **PyO3**: convert Rust errors to specific Python exceptions
   (`PyRuntimeError::new_err(format!("Failed to …: {e}"))`); never let a panic surface to Python.
   Release the GIL with `py.allow_threads(...)` for blocking I/O. Use `arrow::pyarrow::ToPyArrow`
-  for zero-copy Arrow ↔ PyArrow conversion.
+  for zero-copy Arrow ↔ PyArrow.
 
 ### C++
 
-The FFI surface is generated by [`cxx`](https://cxx.rs); the Rust bridge lives in `cpp/src/lib.rs`.
-Keep it thin — push real logic into `crates/core` and expose narrow shims. Functions may throw
+`cxx` bridge in `cpp/src/lib.rs` — keep thin; push logic into `crates/core`. Functions may throw
 `rust::Error`; document the error semantics on the C++ side.
 
 ## Testing
 
-- Rust unit tests are colocated under `#[cfg(test)] mod tests`. Use `#[tokio::test]` for async.
-  Naming: `test_<function>_<scenario>_<expected>`. Shared fixtures live in `crates/test`.
-- Python tests are in `python/tests/` and run under `pytest`. Cover happy and error paths.
-- New features and bug fixes **must** add tests; for bug fixes, add a regression test that would
-  have caught the bug. Avoid redundant coverage — each test should have a unique purpose.
-- Coverage tracked via [Codecov](https://app.codecov.io/github/apache/hudi-rs)
-  ([`codecov.yml`](./codecov.yml)).
+Rust unit tests are colocated under `#[cfg(test)] mod tests`; use `#[tokio::test]` for async.
+Naming: `test_<function>_<scenario>_<expected>`. Shared fixtures in `crates/test`. Python tests in
+`python/tests/`. Cover happy and error paths. New features and bug fixes **must** add tests; for
+bug fixes, add a regression test that would have caught the bug. Avoid redundant coverage — each
+test should have a unique purpose. Coverage tracked via [Codecov](https://app.codecov.io/github/apache/hudi-rs).
 
-## Pull request conventions
+## Pull requests
 
-1. **Title** must follow [Conventional Commits](https://www.conventionalcommits.org)
+1. **Title**: [Conventional Commits](https://www.conventionalcommits.org)
    (`<type>(<scope>): <description>`). Allowed types per
    [`.commitlintrc.yaml`](./.commitlintrc.yaml):
    `build chore ci docs feat fix perf refactor revert style test`. Header ≤ 100 chars; lower-case
-   type; no trailing period; no sentence/start/upper/pascal case in the subject. Examples:
-   - `feat(core): add support for MOR table reads`
-   - `fix(python): handle null partition values correctly`
-2. **Diff size**: keep `max(added, deleted) < 1000 lines` or justify in the PR description.
+   type; no trailing period; no sentence/start/upper/pascal case in the subject.
+   Example: `feat(core): add support for MOR table reads`.
+2. **Diff size**: `max(added, deleted) < 1000 lines` or justify in the description.
 3. **Tests required** for new features and bug fixes.
 4. **Comments**: comment non-obvious WHY only (constraints, invariants, workarounds). Don't
-   reference internal plans, phases, or external roadmaps; for unimplemented work prefer
-   "not yet implemented" over TODOs that point at planning docs.
+   reference internal plans or external roadmaps; for unimplemented work prefer "not yet implemented".
 5. **Cross-binding impact**: changes to `crates/core` public API may cascade to `crates/datafusion`,
-   `python/`, and `cpp/`. Verify all bindings still build and document any breaking changes.
-6. **No secrets** in code, tests, fixtures, or CI logs. Cloud credentials come from environment
-   variables (`AWS_*`, `AZURE_*`, `GOOGLE_*`) or table options.
-7. **Don't bypass `make check` / pre-commit hooks** (`--no-verify`) without justification — fix
-   the underlying issue.
-8. **License headers**: every new source file needs the ASF header
-   ([`.licenserc.yaml`](./.licenserc.yaml) lists ignored paths; CI fails without it).
+   `python/`, and `cpp/`. Verify all bindings still build; document breaking changes.
+6. **No secrets**. Cloud credentials come from env vars (`AWS_*`, `AZURE_*`, `GOOGLE_*`) or table
+   options. Don't bypass `make check` / pre-commit hooks (`--no-verify`) without justification.
 
-## Cloud storage & configuration
+## Cloud storage & config
 
-- Storage backends are routed by URI scheme (`file://`, `s3://`, `az://`, `gs://`) through
-  [`object_store`](https://docs.rs/object_store). Don't hand-roll per-scheme path handling.
-- Table options are typed: `HudiTableConfig`, `HudiReadConfig` (also exported as Python enums).
-  Prefer the typed enum over raw string keys. Singular setters (`with_hudi_option` / `with_option`)
-  accept enum members directly; bulk variants (`with_hudi_options` / `with_options`) currently
-  expect string keys (or `member.value`).
+Storage backends route by URI scheme (`file://`, `s3://`, `az://`, `gs://`) through
+[`object_store`](https://docs.rs/object_store) — don't hand-roll per-scheme paths. Table options
+are typed: `HudiTableConfig`, `HudiReadConfig` (also Python enums). Prefer enum members over raw
+string keys; bulk variants (`with_hudi_options` / `with_options`) currently expect string keys.
 
-## Code review (rubric)
+## Code review rubric
 
-Full rubric: [`.github/instructions/code-review.instructions.md`](./.github/instructions/code-review.instructions.md). Severity tags to use in comments:
+Full rubric: [`.github/instructions/code-review.instructions.md`](./.github/instructions/code-review.instructions.md).
+Severity tags:
 
-- 🔴 **Critical** — must fix: `.unwrap()/.expect()/panic!()` in lib code, blocking calls in async,
-  hardcoded secrets, breaking public-API changes without docs.
-- 🟠 **Important** — should fix: missing error context, unnecessary clones, missing doc comments
-  on `pub` items, missing tests for new behavior.
-- 🟡 **Suggestion** — iterator chains over imperative loops, `?` over nested `match` on `Result`.
+- 🔴 **Critical** — `.unwrap()/.expect()/panic!()` in lib code, blocking calls in async, hardcoded
+  secrets, breaking public-API changes without docs.
+- 🟠 **Important** — missing error context, unnecessary clones, missing doc comments on `pub`,
+  missing tests for new behavior.
+- 🟡 **Suggestion** — iterator chains over loops, `?` over nested `match` on `Result`.
 - 💬 **Question** — clarification.
 
-On updated PRs, focus on the latest commits; do not re-raise issues fixed by follow-up commits.
-For `crates/core` public API changes, also inspect `crates/datafusion`, `python/`, and `cpp/`.
+On updated PRs, focus on the latest commits; do not re-raise issues already fixed. For
+`crates/core` public-API changes, also inspect `crates/datafusion`, `python/`, and `cpp/`.
 
 ## Pointers
 
-| Document                                              | Purpose                                                            |
-| ----------------------------------------------------- | ------------------------------------------------------------------ |
-| [`README.md`](./README.md)                            | usage examples (Python / Rust / C++) and feature overview          |
-| [`CONTRIBUTING.md`](./CONTRIBUTING.md)                | full human contributor workflow                                    |
-| [`Makefile`](./Makefile)                              | every supported dev/CI command                                     |
-| [`Cargo.toml`](./Cargo.toml)                          | workspace members and dependency pins                              |
-| [`python/pyproject.toml`](./python/pyproject.toml)    | Python build / lint / type-check configuration                     |
-| [`CHANGELOG.md`](./CHANGELOG.md)                      | release history (driven by `cliff.toml` from Conventional Commits) |
-| [Apache Hudi docs](https://hudi.apache.org/docs/overview) | timeline, file groups, MOR/COW, schema evolution               |
-| [Issue tracker](https://github.com/apache/hudi-rs/issues) | bugs, features                                                 |
-| [Slack](https://hudi.apache.org/slack)                | community chat (`#hudi`)                                           |
+- [`README.md`](./README.md) — usage examples
+- [`CONTRIBUTING.md`](./CONTRIBUTING.md) — full contributor workflow
+- [`Makefile`](./Makefile) — every supported dev/CI command
+- [`Cargo.toml`](./Cargo.toml), [`python/pyproject.toml`](./python/pyproject.toml) — version pins
+- [`CHANGELOG.md`](./CHANGELOG.md) — release history (driven by `cliff.toml`)
+- [Apache Hudi docs](https://hudi.apache.org/docs/overview), [issue tracker](https://github.com/apache/hudi-rs/issues), [Slack](https://hudi.apache.org/slack)
 
 ## Maintenance
 
-When you add or rename a `make` target, change a coding convention, bump the MSRV, or restructure
-the workspace, **update this file in the same PR**. Stale agent guidance produces stale code.
+When you change a `make` target, a coding convention, the MSRV, or the workspace layout, **update
+this file in the same PR**. Stale agent guidance produces stale code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+
+# CLAUDE.md
+
+The canonical agent guidance for this repository lives in [`AGENTS.md`](./AGENTS.md). This file
+imports it via Claude Code's `@`-import syntax so the two stay in lockstep. Add Claude Code-specific
+notes (plan-mode tips, skill references, etc.) under the `## Claude Code` heading below — they are
+appended after the imported content.
+
+@AGENTS.md
+
+## Claude Code
+
+_No Claude-specific instructions yet. Add them here when patterns emerge that don't apply to other
+agents (e.g. preferred plan-mode usage, skills to invoke for certain workflows, hook expectations)._

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,32 +1,6 @@
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
--->
-
 # CLAUDE.md
 
-The canonical agent guidance for this repository lives in [`AGENTS.md`](./AGENTS.md). This file
-imports it via Claude Code's `@`-import syntax so the two stay in lockstep. Add Claude Code-specific
-notes (plan-mode tips, skill references, etc.) under the `## Claude Code` heading below — they are
-appended after the imported content.
+Imports the canonical agent guidance. Add Claude-specific notes (plan-mode tips, skill references,
+hook expectations) below the import as they emerge.
 
 @AGENTS.md
-
-## Claude Code
-
-_No Claude-specific instructions yet. Add them here when patterns emerge that don't apply to other
-agents (e.g. preferred plan-mode usage, skills to invoke for certain workflows, hook expectations)._

--- a/python/hudi/_internal.pyi
+++ b/python/hudi/_internal.pyi
@@ -22,6 +22,7 @@ import pyarrow  # type: ignore
 __version__: str
 
 def _config_keys() -> Dict[str, List[Tuple[str, str]]]: ...
+
 @dataclass(init=False)
 class HudiFileGroupReader:
     """
@@ -384,6 +385,7 @@ def build_hudi_table(
         HudiTable: An instance of hudi table.
     """
     ...
+
 @dataclass(init=False)
 class HudiDataFusionDataSource:
     def __init__(

--- a/python/hudi/_internal.pyi
+++ b/python/hudi/_internal.pyi
@@ -384,6 +384,7 @@ def build_hudi_table(
         HudiTable: An instance of hudi table.
     """
     ...
+
 @dataclass(init=False)
 class HudiDataFusionDataSource:
     def __init__(

--- a/python/hudi/_internal.pyi
+++ b/python/hudi/_internal.pyi
@@ -384,7 +384,6 @@ def build_hudi_table(
         HudiTable: An instance of hudi table.
     """
     ...
-
 @dataclass(init=False)
 class HudiDataFusionDataSource:
     def __init__(


### PR DESCRIPTION
## Description

Adopt the [agents.md](https://agents.md) spec to provide a single canonical instruction surface for AI coding agents (ChatGPT/Codex, Cursor, Aider, GitHub Copilot Coding Agent, etc.) and align Claude Code and GitHub Copilot to share it.

- New root `AGENTS.md` is the source of truth for project layout, Makefile-driven setup/test/coverage commands, per-language conventions (Rust/Python/C++), PR rules, and review rubric. Tightened to 138 lines and ASF-header-free (the file is agent tooling config, added to `.licenserc.yaml` paths-ignore alongside the existing `.github/copilot-instructions.md` entry) so token overhead per session stays minimal for AGENTS.md-aware agents that don't strip HTML comments.
- New `CLAUDE.md` (6 lines) uses Anthropic's documented `@AGENTS.md` import directive so Claude Code shares the same guidance without duplication.
- `.github/copilot-instructions.md` is refreshed as a thin companion that GitHub Copilot loads alongside `AGENTS.md` (per current Copilot docs, both files are read); existing path-scoped `.github/instructions/*.instructions.md` rules are preserved.
- Drive-by: bump `.github/workflows/code.yml` Python from 3.9 to 3.10 to match `python/pyproject.toml` `requires-python = ">=3.10"`.

## How are the changes test-covered

- [x] N/A — documentation + one-line CI version alignment. Verified all relative links resolve, `@AGENTS.md` import is in place, and `paths-ignore` covers the new files.