### PR TITLE
feat: add `arrow-54` feature in hudi-core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ on:
   pull_request:
     branches:
       - main
+      - feature/**
     paths-ignore:
       - '**.md'
       - '.github/ISSUE_TEMPLATE/**'
@@ -76,6 +77,15 @@ jobs:
           name: cov-report-rust-tests-${{ runner.os }}
           path: ./cov-reports
           if-no-files-found: 'error'
+
+  rust-tests-arrow54:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+      - name: Rust unit tests with arrow-54
+        run: make test-rust-arrow54
 
   rust-tests-windows:
     runs-on: windows-2025

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -25,6 +25,7 @@ on:
   pull_request:
     branches:
       - main
+      - feature/**
 
 jobs:
   check-code:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,6 +22,7 @@ on:
     types: [ opened, edited, reopened, synchronize ]
     branches:
       - main
+      - feature/**
 
 permissions:
   contents: read

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ homepage = "https://github.com/apache/hudi-rs"
 repository = "https://github.com/apache/hudi-rs"
 
 [workspace.dependencies]
-# arrow
+# arrow (default)
 arrow = { version = "57" }
 arrow-arith = { version = "57" }
 arrow-array = { version = "57" }
@@ -50,6 +50,21 @@ arrow-schema = { version = "57", features = ["serde"] }
 arrow-select = { version = "57" }
 object_store = { version = "0.12", features = ["aws", "azure", "gcp"] }
 parquet = { version = "57", features = ["async", "object_store"] }
+
+# arrow-54 (for compatibility with projects using arrow 54)
+arrow_v54 = { package = "arrow", version = "~54" }
+arrow-arith_v54 = { package = "arrow-arith", version = "~54" }
+arrow-array_v54 = { package = "arrow-array", version = "~54" }
+arrow-buffer_v54 = { package = "arrow-buffer", version = "~54" }
+arrow-cast_v54 = { package = "arrow-cast", version = "~54" }
+arrow-ipc_v54 = { package = "arrow-ipc", version = "~54" }
+arrow-json_v54 = { package = "arrow-json", version = "~54" }
+arrow-ord_v54 = { package = "arrow-ord", version = "~54" }
+arrow-row_v54 = { package = "arrow-row", version = "~54" }
+arrow-schema_v54 = { package = "arrow-schema", version = "~54", features = ["serde"] }
+arrow-select_v54 = { package = "arrow-select", version = "~54" }
+object_store_v54 = { package = "object_store", version = "~0.11", features = ["aws", "azure", "gcp"] }
+parquet_v54 = { package = "parquet", version = "~54", features = ["async", "object_store"] }
 
 # avro
 apache-avro = { version = "0.21", features = ["derive"] }

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ TARPAULIN_COMMON := --engine llvm --no-dead-code --no-fail-fast \
 
 .PHONY: help
 help: ## Show this help message
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: setup-venv
 setup-venv: ## Setup the virtualenv
@@ -127,6 +127,14 @@ test: test-rust test-python ## Run tests on Rust and Python
 test-rust: ## Run tests on Rust
 	$(info --- Run Rust tests ---)
 	./build-wrapper.sh cargo test --no-fail-fast --all-targets --all-features --workspace
+
+.PHONY: test-rust-arrow54
+test-rust-arrow54: ## Run tests on Rust with arrow-54 feature
+	$(info --- Run Rust tests with arrow-54 ---)
+	./build-wrapper.sh cargo test -p hudi-core --no-fail-fast --lib --tests --no-default-features --features arrow-54
+
+.PHONY: test-arrow54
+test-arrow54: test-rust-arrow54 ## Run tests with arrow-54 feature (Rust only)
 
 .PHONY: test-python
 test-python: ## Run tests on Python

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -28,23 +28,41 @@ homepage.workspace = true
 repository.workspace = true
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(tarpaulin_include)',
+    'cfg(use_arrow_54)',
+] }
 
 [dependencies]
-# arrow
-arrow = { workspace = true }
-arrow-arith = { workspace = true }
-arrow-array = { workspace = true }
-arrow-buffer = { workspace = true }
-arrow-cast = { workspace = true }
-arrow-ipc = { workspace = true }
-arrow-json = { workspace = true }
-arrow-ord = { workspace = true }
-arrow-row = { workspace = true }
-arrow-schema = { workspace = true }
-arrow-select = { workspace = true }
-object_store = { workspace = true }
-parquet = { workspace = true }
+# arrow (default version)
+arrow = { workspace = true, optional = true }
+arrow-arith = { workspace = true, optional = true }
+arrow-array = { workspace = true, optional = true }
+arrow-buffer = { workspace = true, optional = true }
+arrow-cast = { workspace = true, optional = true }
+arrow-ipc = { workspace = true, optional = true }
+arrow-json = { workspace = true, optional = true }
+arrow-ord = { workspace = true, optional = true }
+arrow-row = { workspace = true, optional = true }
+arrow-schema = { workspace = true, optional = true }
+arrow-select = { workspace = true, optional = true }
+object_store = { workspace = true, optional = true }
+parquet = { workspace = true, optional = true }
+
+# arrow-54 (for compatibility with projects using arrow 54)
+arrow_v54 = { workspace = true, optional = true }
+arrow-arith_v54 = { workspace = true, optional = true }
+arrow-array_v54 = { workspace = true, optional = true }
+arrow-buffer_v54 = { workspace = true, optional = true }
+arrow-cast_v54 = { workspace = true, optional = true }
+arrow-ipc_v54 = { workspace = true, optional = true }
+arrow-json_v54 = { workspace = true, optional = true }
+arrow-ord_v54 = { workspace = true, optional = true }
+arrow-row_v54 = { workspace = true, optional = true }
+arrow-schema_v54 = { workspace = true, optional = true }
+arrow-select_v54 = { workspace = true, optional = true }
+object_store_v54 = { workspace = true, optional = true }
+parquet_v54 = { workspace = true, optional = true }
 
 # avro
 apache-avro = { workspace = true }
@@ -88,7 +106,7 @@ datafusion-physical-expr = { workspace = true, optional = true }
 percent-encoding = { workspace = true }
 
 [dev-dependencies]
-hudi-test = { path = "../test" }
+hudi-test = { path = "../test", default-features = false }
 serial_test = { workspace = true }
 tempfile = { workspace = true }
 
@@ -96,6 +114,45 @@ tempfile = { workspace = true }
 result_large_err = "allow"
 
 [features]
+default = ["arrow-default"]
+
+# Arrow version features (mutually exclusive - only enable one)
+arrow-default = [
+    "dep:arrow",
+    "dep:arrow-arith",
+    "dep:arrow-array",
+    "dep:arrow-buffer",
+    "dep:arrow-cast",
+    "dep:arrow-ipc",
+    "dep:arrow-json",
+    "dep:arrow-ord",
+    "dep:arrow-row",
+    "dep:arrow-schema",
+    "dep:arrow-select",
+    "dep:object_store",
+    "dep:parquet",
+    "hudi-test/arrow-default",
+]
+
+# Arrow v54 (for projects that require arrow 54)
+# Usage: default-features = false, features = ["arrow-54"]
+arrow-54 = [
+    "dep:arrow_v54",
+    "dep:arrow-arith_v54",
+    "dep:arrow-array_v54",
+    "dep:arrow-buffer_v54",
+    "dep:arrow-cast_v54",
+    "dep:arrow-ipc_v54",
+    "dep:arrow-json_v54",
+    "dep:arrow-ord_v54",
+    "dep:arrow-row_v54",
+    "dep:arrow-schema_v54",
+    "dep:arrow-select_v54",
+    "dep:object_store_v54",
+    "dep:parquet_v54",
+    "hudi-test/arrow-54",
+]
+
 datafusion = [
     "dep:datafusion",
     "datafusion-expr",

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+fn main() {
+    let arrow_54 = std::env::var("CARGO_FEATURE_ARROW_54").is_ok();
+    let arrow_default = std::env::var("CARGO_FEATURE_ARROW_DEFAULT").is_ok();
+
+    // When both features are enabled (e.g. --all-features), arrow-default wins.
+    if arrow_54 && !arrow_default {
+        println!("cargo::rustc-cfg=use_arrow_54");
+    }
+}

--- a/crates/core/src/avro_to_arrow/schema.rs
+++ b/crates/core/src/avro_to_arrow/schema.rs
@@ -224,7 +224,9 @@ fn default_field_name(dt: &DataType) -> &str {
         | DataType::LargeListView(_) => {
             unimplemented!("View support not implemented")
         }
+        #[cfg(not(use_arrow_54))]
         DataType::Decimal32(_, _) => "decimal",
+        #[cfg(not(use_arrow_54))]
         DataType::Decimal64(_, _) => "decimal",
         DataType::Decimal128(_, _) => "decimal",
         DataType::Decimal256(_, _) => "decimal",

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -46,6 +46,75 @@
 //! }
 //! ```
 
+// Re-export arrow dependencies based on feature flags.
+// build.rs sets `use_arrow_54` only when arrow-54 is enabled WITHOUT arrow-default,
+// so --all-features gracefully falls back to the default arrow version.
+
+#[cfg(not(any(feature = "arrow-default", feature = "arrow-54")))]
+compile_error!("Either 'arrow-default' or 'arrow-54' feature must be enabled.");
+
+#[cfg(all(use_arrow_54, feature = "datafusion"))]
+compile_error!(
+    "Feature 'datafusion' requires 'arrow-default'. \
+     DataFusion depends on object_store 0.12, which is incompatible with arrow-54."
+);
+
+// Arrow v54 re-exports (only when arrow-54 is the sole arrow feature)
+#[cfg(use_arrow_54)]
+pub extern crate arrow_arith_v54 as arrow_arith;
+#[cfg(use_arrow_54)]
+pub extern crate arrow_array_v54 as arrow_array;
+#[cfg(use_arrow_54)]
+pub extern crate arrow_buffer_v54 as arrow_buffer;
+#[cfg(use_arrow_54)]
+pub extern crate arrow_cast_v54 as arrow_cast;
+#[cfg(use_arrow_54)]
+pub extern crate arrow_ipc_v54 as arrow_ipc;
+#[cfg(use_arrow_54)]
+pub extern crate arrow_json_v54 as arrow_json;
+#[cfg(use_arrow_54)]
+pub extern crate arrow_ord_v54 as arrow_ord;
+#[cfg(use_arrow_54)]
+pub extern crate arrow_row_v54 as arrow_row;
+#[cfg(use_arrow_54)]
+pub extern crate arrow_schema_v54 as arrow_schema;
+#[cfg(use_arrow_54)]
+pub extern crate arrow_select_v54 as arrow_select;
+#[cfg(use_arrow_54)]
+pub extern crate arrow_v54 as arrow;
+#[cfg(use_arrow_54)]
+pub extern crate object_store_v54 as object_store;
+#[cfg(use_arrow_54)]
+pub extern crate parquet_v54 as parquet;
+
+// Arrow default re-exports
+#[cfg(not(use_arrow_54))]
+pub extern crate arrow;
+#[cfg(not(use_arrow_54))]
+pub extern crate arrow_arith;
+#[cfg(not(use_arrow_54))]
+pub extern crate arrow_array;
+#[cfg(not(use_arrow_54))]
+pub extern crate arrow_buffer;
+#[cfg(not(use_arrow_54))]
+pub extern crate arrow_cast;
+#[cfg(not(use_arrow_54))]
+pub extern crate arrow_ipc;
+#[cfg(not(use_arrow_54))]
+pub extern crate arrow_json;
+#[cfg(not(use_arrow_54))]
+pub extern crate arrow_ord;
+#[cfg(not(use_arrow_54))]
+pub extern crate arrow_row;
+#[cfg(not(use_arrow_54))]
+pub extern crate arrow_schema;
+#[cfg(not(use_arrow_54))]
+pub extern crate arrow_select;
+#[cfg(not(use_arrow_54))]
+pub extern crate object_store;
+#[cfg(not(use_arrow_54))]
+pub extern crate parquet;
+
 mod avro_to_arrow;
 pub mod config;
 pub mod error;

--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -186,7 +186,11 @@ impl Storage {
         let name = meta.location.filename().ok_or_else(|| {
             InvalidPath(format!("Failed to get file name from: {:?}", meta.location))
         })?;
-        Ok(FileMetadata::new(name.to_string(), meta.size))
+        #[cfg(use_arrow_54)]
+        let size = meta.size as u64;
+        #[cfg(not(use_arrow_54))]
+        let size = meta.size;
+        Ok(FileMetadata::new(name.to_string(), size))
     }
 
     pub async fn get_parquet_file_metadata(&self, relative_path: &str) -> Result<ParquetMetaData> {
@@ -194,6 +198,9 @@ impl Storage {
         let obj_path = ObjPath::from_url_path(obj_url.path())?;
         let obj_store = self.object_store.clone();
         let meta = obj_store.head(&obj_path).await?;
+        #[cfg(use_arrow_54)]
+        let reader = ParquetObjectReader::new(obj_store, meta);
+        #[cfg(not(use_arrow_54))]
         let reader = ParquetObjectReader::new(obj_store, obj_path).with_file_size(meta.size);
         let builder = ParquetRecordBatchStreamBuilder::new(reader).await?;
         Ok(builder.metadata().as_ref().clone())
@@ -248,7 +255,9 @@ impl Storage {
         let obj_store = self.object_store.clone();
         let meta = obj_store.head(&obj_path).await?;
 
-        // read parquet
+        #[cfg(use_arrow_54)]
+        let reader = ParquetObjectReader::new(obj_store, meta);
+        #[cfg(not(use_arrow_54))]
         let reader = ParquetObjectReader::new(obj_store, obj_path).with_file_size(meta.size);
         let builder = ParquetRecordBatchStreamBuilder::new(reader).await?;
         let schema = builder.schema().clone();
@@ -284,6 +293,9 @@ impl Storage {
         let obj_store = self.object_store.clone();
         let meta = obj_store.head(&obj_path).await?;
 
+        #[cfg(use_arrow_54)]
+        let reader = ParquetObjectReader::new(obj_store, meta);
+        #[cfg(not(use_arrow_54))]
         let reader = ParquetObjectReader::new(obj_store, obj_path).with_file_size(meta.size);
         let mut builder = ParquetRecordBatchStreamBuilder::new(reader).await?;
 
@@ -378,7 +390,11 @@ impl Storage {
                 continue;
             }
 
-            file_metadata.push(FileMetadata::new(name.to_string(), obj_meta.size));
+            #[cfg(use_arrow_54)]
+            let size = obj_meta.size as u64;
+            #[cfg(not(use_arrow_54))]
+            let size = obj_meta.size;
+            file_metadata.push(FileMetadata::new(name.to_string(), size));
         }
         Ok(file_metadata)
     }

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -38,7 +38,7 @@
 //! use hudi_core::table::Table;
 //!
 //! pub async fn test() {
-//!     use arrow_schema::Schema;
+//!     use hudi_core::arrow_schema::Schema;
 //!     let base_uri = Url::from_file_path("/tmp/hudi_data").unwrap();
 //!     let hudi_table = Table::new(base_uri.path()).await.unwrap();
 //!     let schema = hudi_table.get_schema().await.unwrap();

--- a/crates/core/tests/statistics_tests.rs
+++ b/crates/core/tests/statistics_tests.rs
@@ -24,17 +24,17 @@
 use std::fs::File;
 use std::sync::Arc;
 
-use arrow_array::{
+use hudi_core::arrow_array::{
     ArrayRef, BooleanArray, Date32Array, Float32Array, Float64Array, Int8Array, Int16Array,
     Int32Array, Int64Array, RecordBatch, StringArray, TimestampMicrosecondArray,
     TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt32Array,
 };
-use arrow_schema::{DataType, Field, Schema, TimeUnit};
-use parquet::arrow::ArrowWriter;
-use parquet::basic::Compression;
-use parquet::file::properties::WriterProperties;
-use parquet::file::reader::FileReader;
-use parquet::file::serialized_reader::SerializedFileReader;
+use hudi_core::arrow_schema::{DataType, Field, Schema, TimeUnit};
+use hudi_core::parquet::arrow::ArrowWriter;
+use hudi_core::parquet::basic::Compression;
+use hudi_core::parquet::file::properties::WriterProperties;
+use hudi_core::parquet::file::reader::FileReader;
+use hudi_core::parquet::file::serialized_reader::SerializedFileReader;
 use tempfile::tempdir;
 
 use hudi_core::statistics::{StatisticsContainer, StatsGranularity};
@@ -44,7 +44,7 @@ fn write_parquet_file(batch: &RecordBatch, path: &std::path::Path) {
     let file = File::create(path).unwrap();
     let props = WriterProperties::builder()
         .set_compression(Compression::SNAPPY)
-        .set_statistics_enabled(parquet::file::properties::EnabledStatistics::Page)
+        .set_statistics_enabled(hudi_core::parquet::file::properties::EnabledStatistics::Page)
         .build();
     let mut writer = ArrowWriter::try_new(file, batch.schema(), Some(props)).unwrap();
     writer.write(batch).unwrap();
@@ -56,7 +56,7 @@ fn write_parquet_file_no_stats(batch: &RecordBatch, path: &std::path::Path) {
     let file = File::create(path).unwrap();
     let props = WriterProperties::builder()
         .set_compression(Compression::SNAPPY)
-        .set_statistics_enabled(parquet::file::properties::EnabledStatistics::None)
+        .set_statistics_enabled(hudi_core::parquet::file::properties::EnabledStatistics::None)
         .build();
     let mut writer = ArrowWriter::try_new(file, batch.schema(), Some(props)).unwrap();
     writer.write(batch).unwrap();
@@ -68,7 +68,7 @@ fn write_parquet_file_multiple_row_groups(batches: &[RecordBatch], path: &std::p
     let file = File::create(path).unwrap();
     let props = WriterProperties::builder()
         .set_compression(Compression::SNAPPY)
-        .set_statistics_enabled(parquet::file::properties::EnabledStatistics::Page)
+        .set_statistics_enabled(hudi_core::parquet::file::properties::EnabledStatistics::Page)
         .set_max_row_group_size(3) // Force smaller row groups
         .build();
     let mut writer = ArrowWriter::try_new(file, batches[0].schema(), Some(props)).unwrap();
@@ -79,7 +79,9 @@ fn write_parquet_file_multiple_row_groups(batches: &[RecordBatch], path: &std::p
 }
 
 /// Helper to read Parquet metadata from a file.
-fn read_parquet_metadata(path: &std::path::Path) -> parquet::file::metadata::ParquetMetaData {
+fn read_parquet_metadata(
+    path: &std::path::Path,
+) -> hudi_core::parquet::file::metadata::ParquetMetaData {
     let file = File::open(path).unwrap();
     let reader = SerializedFileReader::new(file).unwrap();
     reader.metadata().clone()

--- a/crates/core/tests/table_read_tests.rs
+++ b/crates/core/tests/table_read_tests.rs
@@ -21,10 +21,10 @@
 //! This module contains tests for snapshot and time-travel queries,
 //! organized by table version (v6, v8+) and query type.
 
-use arrow::compute::concat_batches;
-use arrow_array::RecordBatch;
 use futures::StreamExt;
 use futures::stream::BoxStream;
+use hudi_core::arrow::compute::concat_batches;
+use hudi_core::arrow_array::RecordBatch;
 use hudi_core::config::read::HudiReadConfig;
 use hudi_core::error::Result;
 use hudi_core::table::{QueryType, ReadOptions, Table};
@@ -644,7 +644,7 @@ mod v8_tables {
                 .column_by_name("rider")
                 .unwrap()
                 .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
+                .downcast_ref::<hudi_core::arrow::array::StringArray>()
                 .unwrap();
             let target_rider = unfiltered_riders.value(0).to_string();
 
@@ -668,7 +668,7 @@ mod v8_tables {
                 .column_by_name("rider")
                 .unwrap()
                 .as_any()
-                .downcast_ref::<arrow::array::StringArray>()
+                .downcast_ref::<hudi_core::arrow::array::StringArray>()
                 .unwrap();
             assert_eq!(riders.value(0), target_rider);
             Ok(())
@@ -891,7 +891,7 @@ mod v8_tables {
 /// Test helper module for v9 tables (1.1 spec)
 mod v9_tables {
     use super::*;
-    use arrow_array::{Int64Array, StringArray};
+    use hudi_core::arrow_array::{Int64Array, StringArray};
 
     fn txn_rows(records: &[RecordBatch]) -> Vec<(String, String, i64)> {
         let mut rows = Vec::new();
@@ -1775,7 +1775,7 @@ mod streaming_queries {
 
     #[tokio::test]
     async fn test_read_snapshot_stream_with_projection_and_filter() -> Result<()> {
-        use arrow::array::Int32Array;
+        use hudi_core::arrow::array::Int32Array;
 
         let base_url = SampleTable::V6Nonpartitioned.url_to_cow();
         let hudi_table = Table::new(base_url.path()).await?;
@@ -1814,7 +1814,7 @@ mod streaming_queries {
 
     #[tokio::test]
     async fn test_read_snapshot_stream_filter_column_not_in_projection() -> Result<()> {
-        use arrow::array::Int32Array;
+        use hudi_core::arrow::array::Int32Array;
 
         let base_url = SampleTable::V6Nonpartitioned.url_to_cow();
         let hudi_table = Table::new(base_url.path()).await?;

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -28,9 +28,13 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-# arrow
-arrow = { workspace = true }
-arrow-array = { workspace = true }
+# arrow (default version)
+arrow = { workspace = true, optional = true }
+arrow-array = { workspace = true, optional = true }
+
+# arrow-54 (for compatibility with projects using arrow 54)
+arrow_v54 = { workspace = true, optional = true }
+arrow-array_v54 = { workspace = true, optional = true }
 
 # datafusion (optional, for verification helpers)
 datafusion = { workspace = true, optional = true }
@@ -48,6 +52,20 @@ tokio = { workspace = true, optional = true }
 tempfile = { workspace = true }
 zip = { workspace = true }
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(use_arrow_54)'] }
+
 [features]
-default = []
+default = ["arrow-default"]
+
+arrow-default = [
+    "dep:arrow",
+    "dep:arrow-array",
+]
+
+arrow-54 = [
+    "dep:arrow_v54",
+    "dep:arrow-array_v54",
+]
+
 datafusion = ["dep:datafusion", "dep:hudi-datafusion", "dep:tokio"]

--- a/crates/test/build.rs
+++ b/crates/test/build.rs
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+fn main() {
+    let arrow_54 = std::env::var("CARGO_FEATURE_ARROW_54").is_ok();
+    let arrow_default = std::env::var("CARGO_FEATURE_ARROW_DEFAULT").is_ok();
+
+    if arrow_54 && !arrow_default {
+        println!("cargo::rustc-cfg=use_arrow_54");
+    }
+}

--- a/crates/test/src/lib.rs
+++ b/crates/test/src/lib.rs
@@ -17,6 +17,12 @@
  * under the License.
  */
 
+// Arrow v54 re-exports (aliased to match the standard crate names)
+#[cfg(use_arrow_54)]
+extern crate arrow_array_v54 as arrow_array;
+#[cfg(use_arrow_54)]
+extern crate arrow_v54 as arrow;
+
 use arrow_array::{BooleanArray, Float64Array, Int32Array, RecordBatch, StringArray};
 use std::fs;
 use std::io::Cursor;


### PR DESCRIPTION
## Description

- Add mutually exclusive `arrow-default` / `arrow-54` feature flags to `hudi-core` and `hudi-test`
- Arrow v54 deps defined as workspace aliases (e.g. `arrow_v54`); re-exported via `pub extern crate` in `lib.rs` under standard names
- `build.rs` sets `use_arrow_54` cfg only when `arrow-54` is the sole arrow feature, so `--all-features` gracefully falls back to arrow-default
- `#[cfg(use_arrow_54)]` gates handle `ParquetObjectReader`, `ObjectMeta.size`, and `DataType` API differences
- Guard `arrow-54` + `datafusion` with `compile_error!` (DataFusion requires `object_store` 0.12)
- Fix doctest to use `hudi_core::arrow_schema` re-export for arrow-54 compatibility
- Integration tests import arrow types through `hudi_core::` re-exports for version compatibility
- Add `make test-rust-arrow54` target and CI job (`rust-tests-arrow54`)

## How are the changes test-covered

- [x] Automated tests (unit and/or integration tests)
- [x] Manual tests
  - [x] `cargo check/test` passes for `arrow-default`, `arrow-54`, and `--all-features`
  - [x] `cargo clippy --all-features --workspace` passes
  - [x] Doctests pass under both `arrow-default` and `arrow-54`
  - [x] `arrow-54,datafusion` correctly rejected at compile time