### PR TITLE
feat(core): add general config alias support with ordering fields as primary config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ chrono = { version = "0.4" }
 chrono-tz = { version = "0.10" }
 lazy_static = { version = "1" }
 log = { version = "0.4" }
+log-once = { version = "0.4" }
 num-traits = { version = "0.2" }
 once_cell = { version = "1" }
 paste = { version = "1" }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -61,6 +61,7 @@ chrono = { workspace = true }
 chrono-tz = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
+log-once = { workspace = true }
 num-traits = { workspace = true }
 once_cell = { workspace = true }
 paste = { workspace = true }

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -18,8 +18,8 @@
  */
 //! Hudi Configurations.
 use std::any::type_name;
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, LazyLock, Mutex};
 
 use crate::config::error::{ConfigError, Result};
 use crate::storage::error::Result as StorageResult;
@@ -92,11 +92,15 @@ pub trait ConfigParser: AsRef<str> {
         for alias in self.aliases() {
             if let Some(v) = configs.get(alias.key) {
                 if alias.deprecated {
-                    log::warn!(
-                        "Config '{}' is deprecated; use '{}' instead",
-                        alias.key,
-                        self.as_ref()
-                    );
+                    static WARNED: LazyLock<Mutex<HashSet<&'static str>>> =
+                        LazyLock::new(|| Mutex::new(HashSet::new()));
+                    if WARNED.lock().unwrap().insert(alias.key) {
+                        log::warn!(
+                            "Config '{}' is deprecated; use '{}' instead",
+                            alias.key,
+                            self.as_ref()
+                        );
+                    }
                 }
                 return Ok(v.as_str());
             }

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -288,6 +288,59 @@ impl HudiConfigs {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::table::HudiTableConfig;
+
+    #[test]
+    fn test_config_alias_constructors() {
+        let alias = ConfigAlias::new("key");
+        assert_eq!(alias.key, "key");
+        assert!(!alias.deprecated);
+
+        let alias = ConfigAlias::deprecated("old_key");
+        assert_eq!(alias.key, "old_key");
+        assert!(alias.deprecated);
+    }
+
+    #[test]
+    fn test_aliases_default_returns_empty() {
+        assert!(HudiTableConfig::TableName.aliases().is_empty());
+    }
+
+    #[test]
+    fn test_resolve_raw_value_primary_key() {
+        let mut configs = HashMap::new();
+        configs.insert("hoodie.table.name".to_string(), "trips".to_string());
+        let result = HudiTableConfig::TableName.resolve_raw_value(&configs);
+        assert_eq!(result.unwrap(), "trips");
+    }
+
+    #[test]
+    fn test_resolve_raw_value_deprecated_alias() {
+        let mut configs = HashMap::new();
+        configs.insert(
+            "hoodie.table.precombine.field".to_string(),
+            "ts".to_string(),
+        );
+        let result = HudiTableConfig::OrderingFields.resolve_raw_value(&configs);
+        assert_eq!(result.unwrap(), "ts");
+    }
+
+    #[test]
+    fn test_resolve_raw_value_not_found() {
+        let configs = HashMap::new();
+        let result = HudiTableConfig::TableName.resolve_raw_value(&configs);
+        assert!(matches!(result.unwrap_err(), ConfigError::NotFound(_)));
+    }
+
+    #[test]
+    fn test_try_get_returns_err_on_parse_failure() {
+        let hudi_configs = HudiConfigs::new([(
+            HudiTableConfig::PopulatesMetaFields.as_ref(),
+            "not_a_bool",
+        )]);
+        let result = hudi_configs.try_get(HudiTableConfig::PopulatesMetaFields);
+        assert!(result.is_err());
+    }
 
     #[test]
     fn test_new_using_hashmap() {

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -18,8 +18,8 @@
  */
 //! Hudi Configurations.
 use std::any::type_name;
-use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, LazyLock, Mutex};
+use std::collections::HashMap;
+use std::sync::Arc;
 
 use crate::config::error::{ConfigError, Result};
 use crate::storage::error::Result as StorageResult;
@@ -92,15 +92,11 @@ pub trait ConfigParser: AsRef<str> {
         for alias in self.aliases() {
             if let Some(v) = configs.get(alias.key) {
                 if alias.deprecated {
-                    static WARNED: LazyLock<Mutex<HashSet<&'static str>>> =
-                        LazyLock::new(|| Mutex::new(HashSet::new()));
-                    if WARNED.lock().unwrap().insert(alias.key) {
-                        log::warn!(
-                            "Config '{}' is deprecated; use '{}' instead",
-                            alias.key,
-                            self.as_ref()
-                        );
-                    }
+                    log_once::warn_once!(
+                        "Config '{}' is deprecated; use '{}' instead",
+                        alias.key,
+                        self.as_ref()
+                    );
                 }
                 return Ok(v.as_str());
             }
@@ -334,10 +330,8 @@ mod tests {
 
     #[test]
     fn test_try_get_returns_err_on_parse_failure() {
-        let hudi_configs = HudiConfigs::new([(
-            HudiTableConfig::PopulatesMetaFields.as_ref(),
-            "not_a_bool",
-        )]);
+        let hudi_configs =
+            HudiConfigs::new([(HudiTableConfig::PopulatesMetaFields.as_ref(), "not_a_bool")]);
         let result = hudi_configs.try_get(HudiTableConfig::PopulatesMetaFields);
         assert!(result.is_err());
     }

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -40,6 +40,28 @@ pub use read_options::{QueryType, ReadOptions};
 
 pub const HUDI_CONF_DIR: &str = "HUDI_CONF_DIR";
 
+/// An alternative key for a configuration, optionally marked as deprecated.
+pub struct ConfigAlias {
+    pub key: &'static str,
+    pub deprecated: bool,
+}
+
+impl ConfigAlias {
+    pub const fn new(key: &'static str) -> Self {
+        Self {
+            key,
+            deprecated: false,
+        }
+    }
+
+    pub const fn deprecated(key: &'static str) -> Self {
+        Self {
+            key,
+            deprecated: true,
+        }
+    }
+}
+
 /// This defines some common APIs for working with configurations in Hudi.
 pub trait ConfigParser: AsRef<str> {
     /// Configuration value type.
@@ -52,9 +74,34 @@ pub trait ConfigParser: AsRef<str> {
         self.as_ref().to_string()
     }
 
+    /// Returns alternative keys for this configuration.
+    fn aliases(&self) -> &[ConfigAlias] {
+        &[]
+    }
+
     /// To indicate if the configuration is required or not, this helps in validation.
     fn is_required(&self) -> bool {
         false
+    }
+
+    /// Resolve the raw string value from configs, checking the primary key first, then aliases.
+    fn resolve_raw_value<'a>(&self, configs: &'a HashMap<String, String>) -> Result<&'a str> {
+        if let Some(v) = configs.get(self.as_ref()) {
+            return Ok(v.as_str());
+        }
+        for alias in self.aliases() {
+            if let Some(v) = configs.get(alias.key) {
+                if alias.deprecated {
+                    log::warn!(
+                        "Config '{}' is deprecated; use '{}' instead",
+                        alias.key,
+                        self.as_ref()
+                    );
+                }
+                return Ok(v.as_str());
+            }
+        }
+        Err(NotFound(self.key()))
     }
 
     /// Validate the configuration by parsing the given [String] value and check if it is required.

--- a/crates/core/src/config/table.rs
+++ b/crates/core/src/config/table.rs
@@ -260,15 +260,8 @@ impl ConfigParser for HudiTableConfig {
             Self::KeyGeneratorType => get_result.map(|v| HudiConfigValue::String(v.to_string())),
             Self::PartitionFields => get_result
                 .map(|v| HudiConfigValue::List(v.split(',').map(str::to_string).collect())),
-            Self::OrderingFields => get_result.and_then(|v| {
-                if v.contains(',') {
-                    Err(UnsupportedValue(format!(
-                        "Multiple ordering fields '{v}' are not yet supported"
-                    )))
-                } else {
-                    Ok(HudiConfigValue::String(v.to_string()))
-                }
-            }),
+            Self::OrderingFields => get_result
+                .map(|v| HudiConfigValue::List(v.split(',').map(str::to_string).collect())),
             Self::PopulatesMetaFields => get_result
                 .and_then(|v| {
                     bool::from_str(v).map_err(|e| ParseBool(self.key(), v.to_string(), e))
@@ -603,11 +596,11 @@ mod tests {
             (HudiTableConfig::PopulatesMetaFields.as_ref(), "true"),
             (deprecated_key, "ts"),
         ]);
-        let actual: String = hudi_configs
+        let actual: Vec<String> = hudi_configs
             .get(HudiTableConfig::OrderingFields)
             .unwrap()
             .into();
-        assert_eq!(actual, "ts");
+        assert_eq!(actual, vec!["ts"]);
         let actual: String = hudi_configs
             .get_or_default(HudiTableConfig::RecordMergeStrategy)
             .into();
@@ -619,14 +612,15 @@ mod tests {
     }
 
     #[test]
-    fn test_ordering_fields_rejects_multiple() {
+    fn test_ordering_fields_multiple() {
         let hudi_configs = HudiConfigs::new(vec![
             (HudiTableConfig::PopulatesMetaFields.as_ref(), "true"),
             (HudiTableConfig::OrderingFields.as_ref(), "ts,seq"),
         ]);
-        assert!(matches!(
-            hudi_configs.get(HudiTableConfig::OrderingFields).unwrap_err(),
-            ConfigError::UnsupportedValue(_)
-        ));
+        let actual: Vec<String> = hudi_configs
+            .get(HudiTableConfig::OrderingFields)
+            .unwrap()
+            .into();
+        assert_eq!(actual, vec!["ts", "seq"]);
     }
 }

--- a/crates/core/src/config/table.rs
+++ b/crates/core/src/config/table.rs
@@ -88,7 +88,7 @@ pub enum HudiTableConfig {
     /// the record with the larger ordering field value is picked.
     ///
     /// Alias: `hoodie.table.precombine.field` (deprecated).
-    OrderingField,
+    OrderingFields,
 
     /// When enabled, populates all meta fields. When disabled, no meta fields are populated
     /// and incremental queries will not be functional. This is only meant to be used for append only/immutable data for batch processing
@@ -161,7 +161,7 @@ impl AsRef<str> for HudiTableConfig {
             Self::KeyGeneratorClass => "hoodie.table.keygenerator.class",
             Self::KeyGeneratorType => "hoodie.table.keygenerator.type",
             Self::PartitionFields => "hoodie.table.partition.fields",
-            Self::OrderingField => "hoodie.table.ordering.fields",
+            Self::OrderingFields => "hoodie.table.ordering.fields",
             Self::PopulatesMetaFields => "hoodie.populate.meta.fields",
             Self::RecordKeyFields => "hoodie.table.recordkey.fields",
             Self::RecordMergeStrategy => "hoodie.table.record.merge.strategy",
@@ -213,7 +213,7 @@ impl ConfigParser for HudiTableConfig {
 
     fn aliases(&self) -> &[ConfigAlias] {
         match self {
-            Self::OrderingField => {
+            Self::OrderingFields => {
                 const ALIASES: &[ConfigAlias] =
                     &[ConfigAlias::deprecated("hoodie.table.precombine.field")];
                 ALIASES
@@ -260,7 +260,7 @@ impl ConfigParser for HudiTableConfig {
             Self::KeyGeneratorType => get_result.map(|v| HudiConfigValue::String(v.to_string())),
             Self::PartitionFields => get_result
                 .map(|v| HudiConfigValue::List(v.split(',').map(str::to_string).collect())),
-            Self::OrderingField => get_result.map(|v| {
+            Self::OrderingFields => get_result.map(|v| {
                 // Ordering fields may be comma-separated; use the first as the ordering field.
                 let field = v.split(',').next().unwrap_or(v).trim();
                 HudiConfigValue::String(field.to_string())
@@ -320,7 +320,7 @@ impl ConfigParser for HudiTableConfig {
                         );
                     }
 
-                    if HudiTableConfig::OrderingField
+                    if HudiTableConfig::OrderingFields
                         .parse_value(configs)
                         .is_err()
                     {
@@ -555,7 +555,7 @@ mod tests {
     fn test_derive_record_merger_strategy() {
         let hudi_configs = HudiConfigs::new(vec![
             (HudiTableConfig::PopulatesMetaFields, "false"),
-            (HudiTableConfig::OrderingField, "ts"),
+            (HudiTableConfig::OrderingFields, "ts"),
         ]);
         let actual: String = hudi_configs
             .get_or_default(HudiTableConfig::RecordMergeStrategy)
@@ -578,7 +578,7 @@ mod tests {
 
         let hudi_configs = HudiConfigs::new(vec![
             (HudiTableConfig::PopulatesMetaFields, "true"),
-            (HudiTableConfig::OrderingField, "ts"),
+            (HudiTableConfig::OrderingFields, "ts"),
         ]);
         let actual: String = hudi_configs
             .get_or_default(HudiTableConfig::RecordMergeStrategy)
@@ -591,7 +591,7 @@ mod tests {
 
     #[test]
     fn test_precombine_field_deprecated_alias() {
-        let deprecated_key = HudiTableConfig::OrderingField.aliases()[0].key;
+        let deprecated_key = HudiTableConfig::OrderingFields.aliases()[0].key;
         assert_eq!(deprecated_key, "hoodie.table.precombine.field");
 
         // Deprecated alias should still resolve
@@ -600,7 +600,7 @@ mod tests {
             (deprecated_key, "ts"),
         ]);
         let actual: String = hudi_configs
-            .get(HudiTableConfig::OrderingField)
+            .get(HudiTableConfig::OrderingFields)
             .unwrap()
             .into();
         assert_eq!(actual, "ts");
@@ -618,10 +618,10 @@ mod tests {
     fn test_ordering_fields_comma_separated() {
         let hudi_configs = HudiConfigs::new(vec![
             (HudiTableConfig::PopulatesMetaFields.as_ref(), "true"),
-            (HudiTableConfig::OrderingField.as_ref(), "ts,seq"),
+            (HudiTableConfig::OrderingFields.as_ref(), "ts,seq"),
         ]);
         let actual: String = hudi_configs
-            .get(HudiTableConfig::OrderingField)
+            .get(HudiTableConfig::OrderingFields)
             .unwrap()
             .into();
         assert_eq!(actual, "ts", "Should use the first ordering field");

--- a/crates/core/src/config/table.rs
+++ b/crates/core/src/config/table.rs
@@ -88,7 +88,7 @@ pub enum HudiTableConfig {
     /// the record with the larger ordering field value is picked.
     ///
     /// Alias: `hoodie.table.precombine.field` (deprecated).
-    PrecombineField,
+    OrderingField,
 
     /// When enabled, populates all meta fields. When disabled, no meta fields are populated
     /// and incremental queries will not be functional. This is only meant to be used for append only/immutable data for batch processing
@@ -161,7 +161,7 @@ impl AsRef<str> for HudiTableConfig {
             Self::KeyGeneratorClass => "hoodie.table.keygenerator.class",
             Self::KeyGeneratorType => "hoodie.table.keygenerator.type",
             Self::PartitionFields => "hoodie.table.partition.fields",
-            Self::PrecombineField => "hoodie.table.ordering.fields",
+            Self::OrderingField => "hoodie.table.ordering.fields",
             Self::PopulatesMetaFields => "hoodie.populate.meta.fields",
             Self::RecordKeyFields => "hoodie.table.recordkey.fields",
             Self::RecordMergeStrategy => "hoodie.table.record.merge.strategy",
@@ -213,7 +213,7 @@ impl ConfigParser for HudiTableConfig {
 
     fn aliases(&self) -> &[ConfigAlias] {
         match self {
-            Self::PrecombineField => {
+            Self::OrderingField => {
                 const ALIASES: &[ConfigAlias] =
                     &[ConfigAlias::deprecated("hoodie.table.precombine.field")];
                 ALIASES
@@ -260,7 +260,7 @@ impl ConfigParser for HudiTableConfig {
             Self::KeyGeneratorType => get_result.map(|v| HudiConfigValue::String(v.to_string())),
             Self::PartitionFields => get_result
                 .map(|v| HudiConfigValue::List(v.split(',').map(str::to_string).collect())),
-            Self::PrecombineField => get_result.map(|v| {
+            Self::OrderingField => get_result.map(|v| {
                 // Ordering fields may be comma-separated; use the first as the ordering field.
                 let field = v.split(',').next().unwrap_or(v).trim();
                 HudiConfigValue::String(field.to_string())
@@ -320,7 +320,7 @@ impl ConfigParser for HudiTableConfig {
                         );
                     }
 
-                    if HudiTableConfig::PrecombineField
+                    if HudiTableConfig::OrderingField
                         .parse_value(configs)
                         .is_err()
                     {
@@ -555,7 +555,7 @@ mod tests {
     fn test_derive_record_merger_strategy() {
         let hudi_configs = HudiConfigs::new(vec![
             (HudiTableConfig::PopulatesMetaFields, "false"),
-            (HudiTableConfig::PrecombineField, "ts"),
+            (HudiTableConfig::OrderingField, "ts"),
         ]);
         let actual: String = hudi_configs
             .get_or_default(HudiTableConfig::RecordMergeStrategy)
@@ -578,7 +578,7 @@ mod tests {
 
         let hudi_configs = HudiConfigs::new(vec![
             (HudiTableConfig::PopulatesMetaFields, "true"),
-            (HudiTableConfig::PrecombineField, "ts"),
+            (HudiTableConfig::OrderingField, "ts"),
         ]);
         let actual: String = hudi_configs
             .get_or_default(HudiTableConfig::RecordMergeStrategy)
@@ -591,7 +591,7 @@ mod tests {
 
     #[test]
     fn test_precombine_field_deprecated_alias() {
-        let deprecated_key = HudiTableConfig::PrecombineField.aliases()[0].key;
+        let deprecated_key = HudiTableConfig::OrderingField.aliases()[0].key;
         assert_eq!(deprecated_key, "hoodie.table.precombine.field");
 
         // Deprecated alias should still resolve
@@ -600,7 +600,7 @@ mod tests {
             (deprecated_key, "ts"),
         ]);
         let actual: String = hudi_configs
-            .get(HudiTableConfig::PrecombineField)
+            .get(HudiTableConfig::OrderingField)
             .unwrap()
             .into();
         assert_eq!(actual, "ts");
@@ -618,10 +618,10 @@ mod tests {
     fn test_ordering_fields_comma_separated() {
         let hudi_configs = HudiConfigs::new(vec![
             (HudiTableConfig::PopulatesMetaFields.as_ref(), "true"),
-            (HudiTableConfig::PrecombineField.as_ref(), "ts,seq"),
+            (HudiTableConfig::OrderingField.as_ref(), "ts,seq"),
         ]);
         let actual: String = hudi_configs
-            .get(HudiTableConfig::PrecombineField)
+            .get(HudiTableConfig::OrderingField)
             .unwrap()
             .into();
         assert_eq!(actual, "ts", "Should use the first ordering field");

--- a/crates/core/src/config/table.rs
+++ b/crates/core/src/config/table.rs
@@ -25,10 +25,8 @@ use strum_macros::{AsRefStr, EnumIter, IntoStaticStr};
 
 use crate::config::Result;
 use crate::config::error::ConfigError;
-use crate::config::error::ConfigError::{
-    InvalidValue, NotFound, ParseBool, ParseInt, UnsupportedValue,
-};
-use crate::config::{ConfigParser, HudiConfigValue};
+use crate::config::error::ConfigError::{InvalidValue, ParseBool, ParseInt, UnsupportedValue};
+use crate::config::{ConfigAlias, ConfigParser, HudiConfigValue};
 use crate::merge::RecordMergeStrategyValue;
 
 /// Configurations for Hudi tables, most of them are persisted in `hoodie.properties`.
@@ -211,15 +209,23 @@ impl ConfigParser for HudiTableConfig {
         }
     }
 
+    fn aliases(&self) -> &[ConfigAlias] {
+        match self {
+            Self::PrecombineField => {
+                const ALIASES: &[ConfigAlias] =
+                    &[ConfigAlias::new("hoodie.table.ordering.fields")];
+                ALIASES
+            }
+            _ => &[],
+        }
+    }
+
     fn is_required(&self) -> bool {
         matches!(self, Self::TableName | Self::TableType | Self::TableVersion)
     }
 
     fn parse_value(&self, configs: &HashMap<String, String>) -> Result<Self::Output> {
-        let get_result = configs
-            .get(self.as_ref())
-            .map(|v| v.as_str())
-            .ok_or(NotFound(self.key()));
+        let get_result = self.resolve_raw_value(configs);
 
         match self {
             Self::BaseFileFormat => get_result
@@ -308,7 +314,10 @@ impl ConfigParser for HudiTableConfig {
                         );
                     }
 
-                    if !configs.contains_key(HudiTableConfig::PrecombineField.as_ref()) {
+                    if HudiTableConfig::PrecombineField
+                        .parse_value(configs)
+                        .is_err()
+                    {
                         // When precombine field is not available, we treat the table as append-only
                         return HudiConfigValue::String(
                             RecordMergeStrategyValue::AppendOnly.as_ref().to_string(),
@@ -571,6 +580,28 @@ mod tests {
         assert_eq!(
             actual,
             RecordMergeStrategyValue::OverwriteWithLatest.as_ref()
+        );
+    }
+
+    #[test]
+    fn test_ordering_fields_alias_for_precombine() {
+        let ordering_fields_key = HudiTableConfig::PrecombineField.aliases()[0].key;
+        let hudi_configs = HudiConfigs::new(vec![
+            (HudiTableConfig::PopulatesMetaFields.as_ref(), "true"),
+            (ordering_fields_key, "ts"),
+        ]);
+        let actual: String = hudi_configs
+            .get(HudiTableConfig::PrecombineField)
+            .unwrap()
+            .into();
+        assert_eq!(actual, "ts");
+        let actual: String = hudi_configs
+            .get_or_default(HudiTableConfig::RecordMergeStrategy)
+            .into();
+        assert_eq!(
+            actual,
+            RecordMergeStrategyValue::OverwriteWithLatest.as_ref(),
+            "Should derive overwrite-with-latest from v9 ordering fields"
         );
     }
 }

--- a/crates/core/src/config/table.rs
+++ b/crates/core/src/config/table.rs
@@ -260,8 +260,15 @@ impl ConfigParser for HudiTableConfig {
             Self::KeyGeneratorType => get_result.map(|v| HudiConfigValue::String(v.to_string())),
             Self::PartitionFields => get_result
                 .map(|v| HudiConfigValue::List(v.split(',').map(str::to_string).collect())),
-            Self::OrderingFields => get_result
-                .map(|v| HudiConfigValue::List(v.split(',').map(str::to_string).collect())),
+            Self::OrderingFields => get_result.and_then(|v| {
+                let fields: Vec<String> = v.split(',').map(str::to_string).collect();
+                if fields.len() > 1 {
+                    return Err(UnsupportedValue(format!(
+                        "Multiple ordering fields '{v}' are not yet supported"
+                    )));
+                }
+                Ok(HudiConfigValue::List(fields))
+            }),
             Self::PopulatesMetaFields => get_result
                 .and_then(|v| {
                     bool::from_str(v).map_err(|e| ParseBool(self.key(), v.to_string(), e))
@@ -612,15 +619,16 @@ mod tests {
     }
 
     #[test]
-    fn test_ordering_fields_multiple() {
+    fn test_ordering_fields_rejects_multiple() {
         let hudi_configs = HudiConfigs::new(vec![
             (HudiTableConfig::PopulatesMetaFields.as_ref(), "true"),
             (HudiTableConfig::OrderingFields.as_ref(), "ts,seq"),
         ]);
-        let actual: Vec<String> = hudi_configs
-            .get(HudiTableConfig::OrderingFields)
-            .unwrap()
-            .into();
-        assert_eq!(actual, vec!["ts", "seq"]);
+        assert!(matches!(
+            hudi_configs
+                .get(HudiTableConfig::OrderingFields)
+                .unwrap_err(),
+            ConfigError::UnsupportedValue(_)
+        ));
     }
 }

--- a/crates/core/src/config/table.rs
+++ b/crates/core/src/config/table.rs
@@ -84,8 +84,10 @@ pub enum HudiTableConfig {
     /// These fields also include the partition type which is used by custom key generators
     PartitionFields,
 
-    /// Field used in preCombining before actual write. By default, when two records have the same key value,
-    /// the largest value for the precombine field determined by Object.compareTo(..), is picked.
+    /// Fields used for ordering records during merge. When two records have the same key,
+    /// the record with the larger ordering field value is picked.
+    ///
+    /// Alias: `hoodie.table.precombine.field` (deprecated).
     PrecombineField,
 
     /// When enabled, populates all meta fields. When disabled, no meta fields are populated
@@ -159,7 +161,7 @@ impl AsRef<str> for HudiTableConfig {
             Self::KeyGeneratorClass => "hoodie.table.keygenerator.class",
             Self::KeyGeneratorType => "hoodie.table.keygenerator.type",
             Self::PartitionFields => "hoodie.table.partition.fields",
-            Self::PrecombineField => "hoodie.table.precombine.field",
+            Self::PrecombineField => "hoodie.table.ordering.fields",
             Self::PopulatesMetaFields => "hoodie.populate.meta.fields",
             Self::RecordKeyFields => "hoodie.table.recordkey.fields",
             Self::RecordMergeStrategy => "hoodie.table.record.merge.strategy",
@@ -213,7 +215,7 @@ impl ConfigParser for HudiTableConfig {
         match self {
             Self::PrecombineField => {
                 const ALIASES: &[ConfigAlias] =
-                    &[ConfigAlias::new("hoodie.table.ordering.fields")];
+                    &[ConfigAlias::deprecated("hoodie.table.precombine.field")];
                 ALIASES
             }
             _ => &[],
@@ -258,7 +260,11 @@ impl ConfigParser for HudiTableConfig {
             Self::KeyGeneratorType => get_result.map(|v| HudiConfigValue::String(v.to_string())),
             Self::PartitionFields => get_result
                 .map(|v| HudiConfigValue::List(v.split(',').map(str::to_string).collect())),
-            Self::PrecombineField => get_result.map(|v| HudiConfigValue::String(v.to_string())),
+            Self::PrecombineField => get_result.map(|v| {
+                // Ordering fields may be comma-separated; use the first as the ordering field.
+                let field = v.split(',').next().unwrap_or(v).trim();
+                HudiConfigValue::String(field.to_string())
+            }),
             Self::PopulatesMetaFields => get_result
                 .and_then(|v| {
                     bool::from_str(v).map_err(|e| ParseBool(self.key(), v.to_string(), e))
@@ -584,11 +590,14 @@ mod tests {
     }
 
     #[test]
-    fn test_ordering_fields_alias_for_precombine() {
-        let ordering_fields_key = HudiTableConfig::PrecombineField.aliases()[0].key;
+    fn test_precombine_field_deprecated_alias() {
+        let deprecated_key = HudiTableConfig::PrecombineField.aliases()[0].key;
+        assert_eq!(deprecated_key, "hoodie.table.precombine.field");
+
+        // Deprecated alias should still resolve
         let hudi_configs = HudiConfigs::new(vec![
             (HudiTableConfig::PopulatesMetaFields.as_ref(), "true"),
-            (ordering_fields_key, "ts"),
+            (deprecated_key, "ts"),
         ]);
         let actual: String = hudi_configs
             .get(HudiTableConfig::PrecombineField)
@@ -601,7 +610,20 @@ mod tests {
         assert_eq!(
             actual,
             RecordMergeStrategyValue::OverwriteWithLatest.as_ref(),
-            "Should derive overwrite-with-latest from v9 ordering fields"
+            "Should derive overwrite-with-latest from deprecated precombine field"
         );
+    }
+
+    #[test]
+    fn test_ordering_fields_comma_separated() {
+        let hudi_configs = HudiConfigs::new(vec![
+            (HudiTableConfig::PopulatesMetaFields.as_ref(), "true"),
+            (HudiTableConfig::PrecombineField.as_ref(), "ts,seq"),
+        ]);
+        let actual: String = hudi_configs
+            .get(HudiTableConfig::PrecombineField)
+            .unwrap()
+            .into();
+        assert_eq!(actual, "ts", "Should use the first ordering field");
     }
 }

--- a/crates/core/src/config/table.rs
+++ b/crates/core/src/config/table.rs
@@ -260,10 +260,14 @@ impl ConfigParser for HudiTableConfig {
             Self::KeyGeneratorType => get_result.map(|v| HudiConfigValue::String(v.to_string())),
             Self::PartitionFields => get_result
                 .map(|v| HudiConfigValue::List(v.split(',').map(str::to_string).collect())),
-            Self::OrderingFields => get_result.map(|v| {
-                // Ordering fields may be comma-separated; use the first as the ordering field.
-                let field = v.split(',').next().unwrap_or(v).trim();
-                HudiConfigValue::String(field.to_string())
+            Self::OrderingFields => get_result.and_then(|v| {
+                if v.contains(',') {
+                    Err(UnsupportedValue(format!(
+                        "Multiple ordering fields '{v}' are not yet supported"
+                    )))
+                } else {
+                    Ok(HudiConfigValue::String(v.to_string()))
+                }
             }),
             Self::PopulatesMetaFields => get_result
                 .and_then(|v| {
@@ -615,15 +619,14 @@ mod tests {
     }
 
     #[test]
-    fn test_ordering_fields_comma_separated() {
+    fn test_ordering_fields_rejects_multiple() {
         let hudi_configs = HudiConfigs::new(vec![
             (HudiTableConfig::PopulatesMetaFields.as_ref(), "true"),
             (HudiTableConfig::OrderingFields.as_ref(), "ts,seq"),
         ]);
-        let actual: String = hudi_configs
-            .get(HudiTableConfig::OrderingFields)
-            .unwrap()
-            .into();
-        assert_eq!(actual, "ts", "Should use the first ordering field");
+        assert!(matches!(
+            hudi_configs.get(HudiTableConfig::OrderingFields).unwrap_err(),
+            ConfigError::UnsupportedValue(_)
+        ));
     }
 }

--- a/crates/core/src/file_group/log_file/reader.rs
+++ b/crates/core/src/file_group/log_file/reader.rs
@@ -316,7 +316,7 @@ mod tests {
         file_name: &str,
     ) -> Result<LogFileReader<StorageReader>> {
         let dir_url = parse_uri(dir)?;
-        let hudi_configs = Arc::new(HudiConfigs::new([(HudiTableConfig::OrderingField, "ts")]));
+        let hudi_configs = Arc::new(HudiConfigs::new([(HudiTableConfig::OrderingFields, "ts")]));
         let storage = Storage::new_with_base_url(dir_url)?;
         LogFileReader::new(hudi_configs, storage, file_name).await
     }

--- a/crates/core/src/file_group/log_file/reader.rs
+++ b/crates/core/src/file_group/log_file/reader.rs
@@ -316,7 +316,7 @@ mod tests {
         file_name: &str,
     ) -> Result<LogFileReader<StorageReader>> {
         let dir_url = parse_uri(dir)?;
-        let hudi_configs = Arc::new(HudiConfigs::new([(HudiTableConfig::PrecombineField, "ts")]));
+        let hudi_configs = Arc::new(HudiConfigs::new([(HudiTableConfig::OrderingField, "ts")]));
         let storage = Storage::new_with_base_url(dir_url)?;
         LogFileReader::new(hudi_configs, storage, file_name).await
     }

--- a/crates/core/src/file_group/record_batches.rs
+++ b/crates/core/src/file_group/record_batches.rs
@@ -115,7 +115,9 @@ impl RecordBatches {
         &self,
         hudi_configs: Arc<HudiConfigs>,
     ) -> Result<RecordBatch> {
-        let ordering_field: String = hudi_configs.get(HudiTableConfig::OrderingFields)?.into();
+        let ordering_fields: Vec<String> =
+            hudi_configs.get(HudiTableConfig::OrderingFields)?.into();
+        let ordering_field = &ordering_fields[0];
 
         if self.num_delete_rows == 0 {
             return Ok(RecordBatch::new_empty(SchemaRef::from(Schema::empty())));

--- a/crates/core/src/file_group/record_batches.rs
+++ b/crates/core/src/file_group/record_batches.rs
@@ -125,7 +125,7 @@ impl RecordBatches {
 
         let mut delete_batches = Vec::with_capacity(self.delete_batches.len());
         for (batch, instant_time) in &self.delete_batches {
-            let batch = transform_delete_record_batch(batch, instant_time, &ordering_field)?;
+            let batch = transform_delete_record_batch(batch, instant_time, ordering_field)?;
             delete_batches.push(batch);
         }
 

--- a/crates/core/src/file_group/record_batches.rs
+++ b/crates/core/src/file_group/record_batches.rs
@@ -115,7 +115,7 @@ impl RecordBatches {
         &self,
         hudi_configs: Arc<HudiConfigs>,
     ) -> Result<RecordBatch> {
-        let ordering_field: String = hudi_configs.get(HudiTableConfig::PrecombineField)?.into();
+        let ordering_field: String = hudi_configs.get(HudiTableConfig::OrderingField)?.into();
 
         if self.num_delete_rows == 0 {
             return Ok(RecordBatch::new_empty(SchemaRef::from(Schema::empty())));
@@ -506,7 +506,7 @@ mod tests {
     fn test_concat_delete_batches_transformed_empty() {
         let record_batches = RecordBatches::new();
         let hudi_configs = Arc::new(HudiConfigs::new([(
-            HudiTableConfig::PrecombineField.as_ref(),
+            HudiTableConfig::OrderingField.as_ref(),
             "any_ordering_field",
         )]));
 
@@ -533,7 +533,7 @@ mod tests {
         record_batches.push_delete_batch(create_test_delete_batch(3), "20240101000000".to_string());
 
         let hudi_configs = Arc::new(HudiConfigs::new([(
-            HudiTableConfig::PrecombineField.as_ref(),
+            HudiTableConfig::OrderingField.as_ref(),
             ordering_field,
         )]));
 
@@ -569,7 +569,7 @@ mod tests {
         record_batches.push_delete_batch(create_test_delete_batch(1), "20240103000000".to_string());
 
         let hudi_configs = Arc::new(HudiConfigs::new([(
-            HudiTableConfig::PrecombineField.as_ref(),
+            HudiTableConfig::OrderingField.as_ref(),
             ordering_field,
         )]));
 
@@ -613,7 +613,7 @@ mod tests {
         record_batches.push_delete_batch(create_test_delete_batch(2), "20240101000000".to_string());
 
         let hudi_configs = Arc::new(HudiConfigs::new([(
-            HudiTableConfig::PrecombineField.as_ref(),
+            HudiTableConfig::OrderingField.as_ref(),
             ordering_field,
         )]));
 
@@ -635,14 +635,14 @@ mod tests {
         record_batches.push_data_batch(create_test_data_batch(1));
         record_batches.push_delete_batch(create_test_delete_batch(1), "20240101000000".to_string());
 
-        // Create config without PrecombineField
+        // Create config without OrderingField
         let hudi_configs = Arc::new(HudiConfigs::empty());
 
         // This should return an error
         let result = record_batches.concat_delete_batches_transformed(hudi_configs);
         match result {
             Err(CoreError::Config(ConfigError::NotFound(s))) => {
-                assert_eq!(s, HudiTableConfig::PrecombineField.as_ref());
+                assert_eq!(s, HudiTableConfig::OrderingField.as_ref());
             }
             _ => panic!(
                 "Expected ConfigError::NotFound, got {:?}",

--- a/crates/core/src/file_group/record_batches.rs
+++ b/crates/core/src/file_group/record_batches.rs
@@ -115,7 +115,7 @@ impl RecordBatches {
         &self,
         hudi_configs: Arc<HudiConfigs>,
     ) -> Result<RecordBatch> {
-        let ordering_field: String = hudi_configs.get(HudiTableConfig::OrderingField)?.into();
+        let ordering_field: String = hudi_configs.get(HudiTableConfig::OrderingFields)?.into();
 
         if self.num_delete_rows == 0 {
             return Ok(RecordBatch::new_empty(SchemaRef::from(Schema::empty())));
@@ -506,7 +506,7 @@ mod tests {
     fn test_concat_delete_batches_transformed_empty() {
         let record_batches = RecordBatches::new();
         let hudi_configs = Arc::new(HudiConfigs::new([(
-            HudiTableConfig::OrderingField.as_ref(),
+            HudiTableConfig::OrderingFields.as_ref(),
             "any_ordering_field",
         )]));
 
@@ -533,7 +533,7 @@ mod tests {
         record_batches.push_delete_batch(create_test_delete_batch(3), "20240101000000".to_string());
 
         let hudi_configs = Arc::new(HudiConfigs::new([(
-            HudiTableConfig::OrderingField.as_ref(),
+            HudiTableConfig::OrderingFields.as_ref(),
             ordering_field,
         )]));
 
@@ -569,7 +569,7 @@ mod tests {
         record_batches.push_delete_batch(create_test_delete_batch(1), "20240103000000".to_string());
 
         let hudi_configs = Arc::new(HudiConfigs::new([(
-            HudiTableConfig::OrderingField.as_ref(),
+            HudiTableConfig::OrderingFields.as_ref(),
             ordering_field,
         )]));
 
@@ -613,7 +613,7 @@ mod tests {
         record_batches.push_delete_batch(create_test_delete_batch(2), "20240101000000".to_string());
 
         let hudi_configs = Arc::new(HudiConfigs::new([(
-            HudiTableConfig::OrderingField.as_ref(),
+            HudiTableConfig::OrderingFields.as_ref(),
             ordering_field,
         )]));
 
@@ -635,14 +635,14 @@ mod tests {
         record_batches.push_data_batch(create_test_data_batch(1));
         record_batches.push_delete_batch(create_test_delete_batch(1), "20240101000000".to_string());
 
-        // Create config without OrderingField
+        // Create config without OrderingFields
         let hudi_configs = Arc::new(HudiConfigs::empty());
 
         // This should return an error
         let result = record_batches.concat_delete_batches_transformed(hudi_configs);
         match result {
             Err(CoreError::Config(ConfigError::NotFound(s))) => {
-                assert_eq!(s, HudiTableConfig::OrderingField.as_ref());
+                assert_eq!(s, HudiTableConfig::OrderingFields.as_ref());
             }
             _ => panic!(
                 "Expected ConfigError::NotFound, got {:?}",

--- a/crates/core/src/merge/ordering.rs
+++ b/crates/core/src/merge/ordering.rs
@@ -62,7 +62,7 @@ pub fn process_batch_for_max_orderings(
         return Ok(());
     }
 
-    let ordering_field: String = hudi_configs.get(HudiTableConfig::OrderingField)?.into();
+    let ordering_field: String = hudi_configs.get(HudiTableConfig::OrderingFields)?.into();
 
     let keys = extract_record_keys(key_converter, batch)?;
     let event_times =
@@ -340,7 +340,7 @@ mod tests {
     // Helper function to create test HudiConfigs
     fn create_test_hudi_configs() -> Arc<HudiConfigs> {
         Arc::new(HudiConfigs::new([(
-            HudiTableConfig::OrderingField.as_ref(),
+            HudiTableConfig::OrderingFields.as_ref(),
             "an_ordering_field",
         )]))
     }
@@ -570,7 +570,7 @@ mod tests {
         let (key_converter, event_time_converter, commit_time_converter) =
             create_test_converters(schema);
 
-        // Create configs without OrderingField
+        // Create configs without OrderingFields
         let hudi_configs = Arc::new(HudiConfigs::empty());
 
         let mut max_ordering = HashMap::new();

--- a/crates/core/src/merge/ordering.rs
+++ b/crates/core/src/merge/ordering.rs
@@ -62,11 +62,11 @@ pub fn process_batch_for_max_orderings(
         return Ok(());
     }
 
-    let ordering_field: String = hudi_configs.get(HudiTableConfig::OrderingFields)?.into();
+    let ordering_fields: Vec<String> = hudi_configs.get(HudiTableConfig::OrderingFields)?.into();
 
     let keys = extract_record_keys(key_converter, batch)?;
     let event_times =
-        extract_event_time_ordering_values(event_time_converter, batch, &ordering_field)?;
+        extract_event_time_ordering_values(event_time_converter, batch, &ordering_fields[0])?;
     let commit_times = extract_commit_time_ordering_values(commit_time_converter, batch)?;
     for i in 0..batch.num_rows() {
         let key = keys.row(i).owned();

--- a/crates/core/src/merge/ordering.rs
+++ b/crates/core/src/merge/ordering.rs
@@ -62,7 +62,7 @@ pub fn process_batch_for_max_orderings(
         return Ok(());
     }
 
-    let ordering_field: String = hudi_configs.get(HudiTableConfig::PrecombineField)?.into();
+    let ordering_field: String = hudi_configs.get(HudiTableConfig::OrderingField)?.into();
 
     let keys = extract_record_keys(key_converter, batch)?;
     let event_times =
@@ -340,7 +340,7 @@ mod tests {
     // Helper function to create test HudiConfigs
     fn create_test_hudi_configs() -> Arc<HudiConfigs> {
         Arc::new(HudiConfigs::new([(
-            HudiTableConfig::PrecombineField.as_ref(),
+            HudiTableConfig::OrderingField.as_ref(),
             "an_ordering_field",
         )]))
     }
@@ -570,7 +570,7 @@ mod tests {
         let (key_converter, event_time_converter, commit_time_converter) =
             create_test_converters(schema);
 
-        // Create configs without PrecombineField
+        // Create configs without OrderingField
         let hudi_configs = Arc::new(HudiConfigs::empty());
 
         let mut max_ordering = HashMap::new();

--- a/crates/core/src/merge/record_merger.rs
+++ b/crates/core/src/merge/record_merger.rs
@@ -103,23 +103,17 @@ impl RecordMerger {
                 // Use sorting fields to get sorted indices of the data batch (inserts and updates)
                 let ordering_fields: Vec<String> =
                     self.hudi_configs.get(OrderingFields)?.into();
+                let ordering_field = &ordering_fields[0];
                 let key_array = data_batch.get_array(MetaField::RecordKey.as_ref())?;
+                let ordering_array = data_batch.get_array(ordering_field)?;
                 let commit_seqno_array = data_batch.get_array(MetaField::CommitSeqno.as_ref())?;
-                let mut sort_columns = vec![key_array];
-                for field in &ordering_fields {
-                    sort_columns.push(data_batch.get_array(field)?);
-                }
-                sort_columns.push(commit_seqno_array);
-                let desc_indices = lexsort_to_indices(&sort_columns, true);
+                let desc_indices =
+                    lexsort_to_indices(&[key_array, ordering_array, commit_seqno_array], true);
 
-                // Create shared converters for record keys and ordering values.
-                // Event time uses the first ordering field only for data-vs-delete comparison,
-                // since delete records store a single orderingVal.
+                // Create shared converters for record keys and ordering values
                 let key_converter = create_record_key_converter(data_batch.schema())?;
-                let event_time_converter = create_event_time_ordering_converter(
-                    data_batch.schema(),
-                    &ordering_fields[0],
-                )?;
+                let event_time_converter =
+                    create_event_time_ordering_converter(data_batch.schema(), ordering_field)?;
                 let commit_time_converter =
                     create_commit_time_ordering_converter(data_batch.schema())?;
 
@@ -150,7 +144,7 @@ impl RecordMerger {
                 let event_times = extract_event_time_ordering_values(
                     &event_time_converter,
                     &data_batch,
-                    &ordering_fields[0],
+                    ordering_field,
                 )?;
                 let commit_times =
                     extract_commit_time_ordering_values(&commit_time_converter, &data_batch)?;

--- a/crates/core/src/merge/record_merger.rs
+++ b/crates/core/src/merge/record_merger.rs
@@ -101,18 +101,25 @@ impl RecordMerger {
                 }
 
                 // Use sorting fields to get sorted indices of the data batch (inserts and updates)
+                let ordering_fields: Vec<String> =
+                    self.hudi_configs.get(OrderingFields)?.into();
                 let key_array = data_batch.get_array(MetaField::RecordKey.as_ref())?;
-                let ordering_field: String = self.hudi_configs.get(OrderingFields)?.into();
-                let ordering_array = data_batch.get_array(&ordering_field)?;
                 let commit_seqno_array = data_batch.get_array(MetaField::CommitSeqno.as_ref())?;
-                let desc_indices =
-                    lexsort_to_indices(&[key_array, ordering_array, commit_seqno_array], true);
+                let mut sort_columns = vec![key_array];
+                for field in &ordering_fields {
+                    sort_columns.push(data_batch.get_array(field)?);
+                }
+                sort_columns.push(commit_seqno_array);
+                let desc_indices = lexsort_to_indices(&sort_columns, true);
 
-                // Create shared converters for record keys and ordering values
+                // Create shared converters for record keys and ordering values.
+                // Event time uses the first ordering field only for data-vs-delete comparison,
+                // since delete records store a single orderingVal.
                 let key_converter = create_record_key_converter(data_batch.schema())?;
-                let ordering_field: String = self.hudi_configs.get(OrderingFields)?.into();
-                let event_time_converter =
-                    create_event_time_ordering_converter(data_batch.schema(), &ordering_field)?;
+                let event_time_converter = create_event_time_ordering_converter(
+                    data_batch.schema(),
+                    &ordering_fields[0],
+                )?;
                 let commit_time_converter =
                     create_commit_time_ordering_converter(data_batch.schema())?;
 
@@ -143,7 +150,7 @@ impl RecordMerger {
                 let event_times = extract_event_time_ordering_values(
                     &event_time_converter,
                     &data_batch,
-                    &ordering_field,
+                    &ordering_fields[0],
                 )?;
                 let commit_times =
                     extract_commit_time_ordering_values(&commit_time_converter, &data_batch)?;

--- a/crates/core/src/merge/record_merger.rs
+++ b/crates/core/src/merge/record_merger.rs
@@ -21,7 +21,7 @@ use crate::config::HudiConfigs;
 use crate::config::error::ConfigError;
 use crate::config::error::Result as ConfigResult;
 use crate::config::table::HudiTableConfig::{
-    PopulatesMetaFields, OrderingFields, RecordMergeStrategy,
+    OrderingFields, PopulatesMetaFields, RecordMergeStrategy,
 };
 use crate::file_group::record_batches::RecordBatches;
 use crate::merge::RecordMergeStrategyValue;
@@ -101,8 +101,7 @@ impl RecordMerger {
                 }
 
                 // Use sorting fields to get sorted indices of the data batch (inserts and updates)
-                let ordering_fields: Vec<String> =
-                    self.hudi_configs.get(OrderingFields)?.into();
+                let ordering_fields: Vec<String> = self.hudi_configs.get(OrderingFields)?.into();
                 let ordering_field = &ordering_fields[0];
                 let key_array = data_batch.get_array(MetaField::RecordKey.as_ref())?;
                 let ordering_array = data_batch.get_array(ordering_field)?;

--- a/crates/core/src/merge/record_merger.rs
+++ b/crates/core/src/merge/record_merger.rs
@@ -21,7 +21,7 @@ use crate::config::HudiConfigs;
 use crate::config::error::ConfigError;
 use crate::config::error::Result as ConfigResult;
 use crate::config::table::HudiTableConfig::{
-    PopulatesMetaFields, PrecombineField, RecordMergeStrategy,
+    PopulatesMetaFields, OrderingField, RecordMergeStrategy,
 };
 use crate::file_group::record_batches::RecordBatches;
 use crate::merge::RecordMergeStrategyValue;
@@ -64,7 +64,7 @@ impl RecordMerger {
             )));
         }
 
-        let precombine_field = hudi_configs.try_get(PrecombineField)?;
+        let precombine_field = hudi_configs.try_get(OrderingField)?;
         if precombine_field.is_none()
             && merge_strategy == RecordMergeStrategyValue::OverwriteWithLatest
         {
@@ -72,7 +72,7 @@ impl RecordMerger {
                 "When {:?} is {:?}, {:?} must be set.",
                 RecordMergeStrategy,
                 RecordMergeStrategyValue::OverwriteWithLatest,
-                PrecombineField
+                OrderingField
             )));
         }
 
@@ -102,7 +102,7 @@ impl RecordMerger {
 
                 // Use sorting fields to get sorted indices of the data batch (inserts and updates)
                 let key_array = data_batch.get_array(MetaField::RecordKey.as_ref())?;
-                let ordering_field: String = self.hudi_configs.get(PrecombineField)?.into();
+                let ordering_field: String = self.hudi_configs.get(OrderingField)?.into();
                 let ordering_array = data_batch.get_array(&ordering_field)?;
                 let commit_seqno_array = data_batch.get_array(MetaField::CommitSeqno.as_ref())?;
                 let desc_indices =
@@ -110,7 +110,7 @@ impl RecordMerger {
 
                 // Create shared converters for record keys and ordering values
                 let key_converter = create_record_key_converter(data_batch.schema())?;
-                let ordering_field: String = self.hudi_configs.get(PrecombineField)?.into();
+                let ordering_field: String = self.hudi_configs.get(OrderingField)?.into();
                 let event_time_converter =
                     create_event_time_ordering_converter(data_batch.schema(), &ordering_field)?;
                 let commit_time_converter =
@@ -204,7 +204,7 @@ mod tests {
             HudiConfigs::new([
                 (RecordMergeStrategy, strategy.to_string()),
                 (PopulatesMetaFields, populates_meta_fields.to_string()),
-                (PrecombineField, precombine.to_string()),
+                (OrderingField, precombine.to_string()),
             ])
         } else {
             HudiConfigs::new([

--- a/crates/core/src/merge/record_merger.rs
+++ b/crates/core/src/merge/record_merger.rs
@@ -21,7 +21,7 @@ use crate::config::HudiConfigs;
 use crate::config::error::ConfigError;
 use crate::config::error::Result as ConfigResult;
 use crate::config::table::HudiTableConfig::{
-    PopulatesMetaFields, OrderingField, RecordMergeStrategy,
+    PopulatesMetaFields, OrderingFields, RecordMergeStrategy,
 };
 use crate::file_group::record_batches::RecordBatches;
 use crate::merge::RecordMergeStrategyValue;
@@ -64,7 +64,7 @@ impl RecordMerger {
             )));
         }
 
-        let precombine_field = hudi_configs.try_get(OrderingField)?;
+        let precombine_field = hudi_configs.try_get(OrderingFields)?;
         if precombine_field.is_none()
             && merge_strategy == RecordMergeStrategyValue::OverwriteWithLatest
         {
@@ -72,7 +72,7 @@ impl RecordMerger {
                 "When {:?} is {:?}, {:?} must be set.",
                 RecordMergeStrategy,
                 RecordMergeStrategyValue::OverwriteWithLatest,
-                OrderingField
+                OrderingFields
             )));
         }
 
@@ -102,7 +102,7 @@ impl RecordMerger {
 
                 // Use sorting fields to get sorted indices of the data batch (inserts and updates)
                 let key_array = data_batch.get_array(MetaField::RecordKey.as_ref())?;
-                let ordering_field: String = self.hudi_configs.get(OrderingField)?.into();
+                let ordering_field: String = self.hudi_configs.get(OrderingFields)?.into();
                 let ordering_array = data_batch.get_array(&ordering_field)?;
                 let commit_seqno_array = data_batch.get_array(MetaField::CommitSeqno.as_ref())?;
                 let desc_indices =
@@ -110,7 +110,7 @@ impl RecordMerger {
 
                 // Create shared converters for record keys and ordering values
                 let key_converter = create_record_key_converter(data_batch.schema())?;
-                let ordering_field: String = self.hudi_configs.get(OrderingField)?.into();
+                let ordering_field: String = self.hudi_configs.get(OrderingFields)?.into();
                 let event_time_converter =
                     create_event_time_ordering_converter(data_batch.schema(), &ordering_field)?;
                 let commit_time_converter =
@@ -204,7 +204,7 @@ mod tests {
             HudiConfigs::new([
                 (RecordMergeStrategy, strategy.to_string()),
                 (PopulatesMetaFields, populates_meta_fields.to_string()),
-                (OrderingField, precombine.to_string()),
+                (OrderingFields, precombine.to_string()),
             ])
         } else {
             HudiConfigs::new([

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -951,7 +951,7 @@ mod tests {
     use crate::config::table::HudiTableConfig::{
         BaseFileFormat, Checksum, DatabaseName, DropsPartitionFields, IsHiveStylePartitioning,
         IsPartitionPathUrlencoded, KeyGeneratorClass, PartitionFields, PopulatesMetaFields,
-        PrecombineField, RecordKeyFields, TableName, TableType, TableVersion,
+        OrderingField, RecordKeyFields, TableName, TableType, TableVersion,
         TimelineLayoutVersion, TimelineTimezone,
     };
     use crate::config::util::empty_options;
@@ -1227,7 +1227,7 @@ mod tests {
             "non-required config is missing"
         );
         assert!(
-            configs.validate(PrecombineField).is_ok(),
+            configs.validate(OrderingField).is_ok(),
             "non-required config is missing"
         );
         assert!(
@@ -1266,7 +1266,7 @@ mod tests {
         assert!(configs.get(IsPartitionPathUrlencoded).is_err());
         assert!(configs.get(KeyGeneratorClass).is_err());
         assert!(configs.get(PartitionFields).is_err());
-        assert!(configs.get(PrecombineField).is_err());
+        assert!(configs.get(OrderingField).is_err());
         assert!(configs.get(PopulatesMetaFields).is_err());
         assert!(configs.get(RecordKeyFields).is_err());
         assert!(configs.get(TableName).is_err());
@@ -1294,7 +1294,7 @@ mod tests {
         assert!(panic::catch_unwind(|| configs.get_or_default(KeyGeneratorClass)).is_err());
         let actual: Vec<String> = configs.get_or_default(PartitionFields).into();
         assert!(actual.is_empty());
-        assert!(panic::catch_unwind(|| configs.get_or_default(PrecombineField)).is_err());
+        assert!(panic::catch_unwind(|| configs.get_or_default(OrderingField)).is_err());
         let actual: bool = configs.get_or_default(PopulatesMetaFields).into();
         assert!(actual);
         assert!(panic::catch_unwind(|| configs.get_or_default(RecordKeyFields)).is_err());
@@ -1328,7 +1328,7 @@ mod tests {
         assert_eq!(actual, "org.apache.hudi.keygen.SimpleKeyGenerator");
         let actual: Vec<String> = configs.get(PartitionFields).unwrap().into();
         assert_eq!(actual, vec!["city"]);
-        let actual: String = configs.get(PrecombineField).unwrap().into();
+        let actual: String = configs.get(OrderingField).unwrap().into();
         assert_eq!(actual, "ts");
         let actual: bool = configs.get(PopulatesMetaFields).unwrap().into();
         assert!(actual);

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -950,8 +950,8 @@ mod tests {
     use crate::config::table::BaseFileFormatValue;
     use crate::config::table::HudiTableConfig::{
         BaseFileFormat, Checksum, DatabaseName, DropsPartitionFields, IsHiveStylePartitioning,
-        IsPartitionPathUrlencoded, KeyGeneratorClass, PartitionFields, PopulatesMetaFields,
-        OrderingFields, RecordKeyFields, TableName, TableType, TableVersion,
+        IsPartitionPathUrlencoded, KeyGeneratorClass, OrderingFields, PartitionFields,
+        PopulatesMetaFields, RecordKeyFields, TableName, TableType, TableVersion,
         TimelineLayoutVersion, TimelineTimezone,
     };
     use crate::config::util::empty_options;

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -1328,8 +1328,8 @@ mod tests {
         assert_eq!(actual, "org.apache.hudi.keygen.SimpleKeyGenerator");
         let actual: Vec<String> = configs.get(PartitionFields).unwrap().into();
         assert_eq!(actual, vec!["city"]);
-        let actual: String = configs.get(OrderingFields).unwrap().into();
-        assert_eq!(actual, "ts");
+        let actual: Vec<String> = configs.get(OrderingFields).unwrap().into();
+        assert_eq!(actual, vec!["ts"]);
         let actual: bool = configs.get(PopulatesMetaFields).unwrap().into();
         assert!(actual);
         let actual: Vec<String> = configs.get(RecordKeyFields).unwrap().into();

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -951,7 +951,7 @@ mod tests {
     use crate::config::table::HudiTableConfig::{
         BaseFileFormat, Checksum, DatabaseName, DropsPartitionFields, IsHiveStylePartitioning,
         IsPartitionPathUrlencoded, KeyGeneratorClass, PartitionFields, PopulatesMetaFields,
-        OrderingField, RecordKeyFields, TableName, TableType, TableVersion,
+        OrderingFields, RecordKeyFields, TableName, TableType, TableVersion,
         TimelineLayoutVersion, TimelineTimezone,
     };
     use crate::config::util::empty_options;
@@ -1227,7 +1227,7 @@ mod tests {
             "non-required config is missing"
         );
         assert!(
-            configs.validate(OrderingField).is_ok(),
+            configs.validate(OrderingFields).is_ok(),
             "non-required config is missing"
         );
         assert!(
@@ -1266,7 +1266,7 @@ mod tests {
         assert!(configs.get(IsPartitionPathUrlencoded).is_err());
         assert!(configs.get(KeyGeneratorClass).is_err());
         assert!(configs.get(PartitionFields).is_err());
-        assert!(configs.get(OrderingField).is_err());
+        assert!(configs.get(OrderingFields).is_err());
         assert!(configs.get(PopulatesMetaFields).is_err());
         assert!(configs.get(RecordKeyFields).is_err());
         assert!(configs.get(TableName).is_err());
@@ -1294,7 +1294,7 @@ mod tests {
         assert!(panic::catch_unwind(|| configs.get_or_default(KeyGeneratorClass)).is_err());
         let actual: Vec<String> = configs.get_or_default(PartitionFields).into();
         assert!(actual.is_empty());
-        assert!(panic::catch_unwind(|| configs.get_or_default(OrderingField)).is_err());
+        assert!(panic::catch_unwind(|| configs.get_or_default(OrderingFields)).is_err());
         let actual: bool = configs.get_or_default(PopulatesMetaFields).into();
         assert!(actual);
         assert!(panic::catch_unwind(|| configs.get_or_default(RecordKeyFields)).is_err());
@@ -1328,7 +1328,7 @@ mod tests {
         assert_eq!(actual, "org.apache.hudi.keygen.SimpleKeyGenerator");
         let actual: Vec<String> = configs.get(PartitionFields).unwrap().into();
         assert_eq!(actual, vec!["city"]);
-        let actual: String = configs.get(OrderingField).unwrap().into();
+        let actual: String = configs.get(OrderingFields).unwrap().into();
         assert_eq!(actual, "ts");
         let actual: bool = configs.get(PopulatesMetaFields).unwrap().into();
         assert!(actual);


### PR DESCRIPTION
## Description

Add a general `ConfigAlias` mechanism to the `ConfigParser` trait so any Hudi config can declare alternative keys with optional deprecation warnings.

- Add `ConfigAlias` struct with `new()` (active alias) and `deprecated()` constructors
- Add `aliases()` and `resolve_raw_value()` to `ConfigParser` trait with default implementations
- Deprecated alias warnings use warn-once to avoid log spam
- `hoodie.table.ordering.fields` is now the primary key for `PrecombineField`; `hoodie.table.precombine.field` is a deprecated alias
- Comma-separated ordering fields are handled by using the first value
- `RecordMergeStrategy` derivation checks aliases before defaulting to `AppendOnly`

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below