### PR TITLE
refactor(core): move parquet io into base file reader

### DIFF
--- a/crates/core/src/config/table.rs
+++ b/crates/core/src/config/table.rs
@@ -381,8 +381,11 @@ impl BaseFileFormatValue {
 
     /// Returns true when `path` has this format's base-file suffix.
     pub fn matches_extension(&self, path: &str) -> bool {
-        let suffix = format!(".{}", self.as_ref());
-        Self::ends_with_ignore_ascii_case(path, &suffix)
+        let suffix = match self {
+            Self::Parquet => ".parquet",
+            Self::HFile => ".hfile",
+        };
+        Self::ends_with_ignore_ascii_case(path, suffix)
     }
 
     /// Parse the explicit table base-file format config, if present.

--- a/crates/core/src/config/table.rs
+++ b/crates/core/src/config/table.rs
@@ -360,6 +360,63 @@ pub enum BaseFileFormatValue {
     HFile,
 }
 
+impl BaseFileFormatValue {
+    fn ends_with_ignore_ascii_case(s: &str, suffix: &str) -> bool {
+        let s_bytes = s.as_bytes();
+        let suffix_bytes = suffix.as_bytes();
+        s_bytes.len() >= suffix_bytes.len()
+            && s_bytes[s_bytes.len() - suffix_bytes.len()..].eq_ignore_ascii_case(suffix_bytes)
+    }
+
+    /// Detect format from a file extension, returning `None` if unrecognized.
+    pub fn from_extension(path: &str) -> Option<Self> {
+        if Self::ends_with_ignore_ascii_case(path, ".parquet") {
+            Some(Self::Parquet)
+        } else if Self::ends_with_ignore_ascii_case(path, ".hfile") {
+            Some(Self::HFile)
+        } else {
+            None
+        }
+    }
+
+    /// Returns true when `path` has this format's base-file suffix.
+    pub fn matches_extension(&self, path: &str) -> bool {
+        let suffix = format!(".{}", self.as_ref());
+        Self::ends_with_ignore_ascii_case(path, &suffix)
+    }
+
+    /// Parse the explicit table base-file format config, if present.
+    ///
+    /// Missing config returns `Ok(None)` so callers can choose a default or use
+    /// extension-based detection. Invalid or unsupported configured values are
+    /// returned as errors.
+    pub fn from_configs(configs: &crate::config::HudiConfigs) -> Result<Option<Self>, ConfigError> {
+        if !configs.contains(HudiTableConfig::BaseFileFormat.as_ref()) {
+            return Ok(None);
+        }
+
+        let value = configs.get(HudiTableConfig::BaseFileFormat)?;
+        let canonical: String = value.into();
+        Self::from_str(&canonical).map(Some)
+    }
+
+    /// Resolve format from explicit config, then extension, then the Hudi default.
+    pub fn resolve_from_configs(
+        configs: &crate::config::HudiConfigs,
+        file_path: Option<&str>,
+    ) -> Result<Self, ConfigError> {
+        if let Some(configured) = Self::from_configs(configs)? {
+            return Ok(configured);
+        }
+        if let Some(path) = file_path
+            && let Some(format) = Self::from_extension(path)
+        {
+            return Ok(format);
+        }
+        Ok(Self::Parquet)
+    }
+}
+
 impl FromStr for BaseFileFormatValue {
     type Err = ConfigError;
 
@@ -470,6 +527,72 @@ mod tests {
             BaseFileFormatValue::from_str("orc").unwrap_err(),
             UnsupportedValue(_)
         ));
+    }
+
+    #[test]
+    fn base_file_format_from_extension() {
+        assert_eq!(
+            BaseFileFormatValue::from_extension("partition/file.parquet"),
+            Some(BaseFileFormatValue::Parquet)
+        );
+        assert_eq!(
+            BaseFileFormatValue::from_extension("partition/file.PARQUET"),
+            Some(BaseFileFormatValue::Parquet)
+        );
+        assert_eq!(
+            BaseFileFormatValue::from_extension("partition/file.hfile"),
+            Some(BaseFileFormatValue::HFile)
+        );
+        assert_eq!(
+            BaseFileFormatValue::from_extension("partition/file.log"),
+            None
+        );
+    }
+
+    #[test]
+    fn base_file_format_matches_extension() {
+        assert!(BaseFileFormatValue::Parquet.matches_extension("file.PARQUET"));
+        assert!(BaseFileFormatValue::HFile.matches_extension("file.hfile"));
+        assert!(!BaseFileFormatValue::Parquet.matches_extension("file.hfile"));
+    }
+
+    #[test]
+    fn base_file_format_from_configs() {
+        let configs = HudiConfigs::new([(HudiTableConfig::BaseFileFormat, "hfile")]);
+        assert_eq!(
+            BaseFileFormatValue::from_configs(&configs).unwrap(),
+            Some(BaseFileFormatValue::HFile)
+        );
+
+        assert_eq!(
+            BaseFileFormatValue::from_configs(&HudiConfigs::empty()).unwrap(),
+            None
+        );
+
+        let configs = HudiConfigs::new([(HudiTableConfig::BaseFileFormat, "orc")]);
+        assert!(matches!(
+            BaseFileFormatValue::from_configs(&configs).unwrap_err(),
+            UnsupportedValue(_)
+        ));
+    }
+
+    #[test]
+    fn base_file_format_resolve_from_configs() {
+        let configs = HudiConfigs::new([(HudiTableConfig::BaseFileFormat, "parquet")]);
+        assert_eq!(
+            BaseFileFormatValue::resolve_from_configs(&configs, Some("file.hfile")).unwrap(),
+            BaseFileFormatValue::Parquet
+        );
+
+        let configs = HudiConfigs::empty();
+        assert_eq!(
+            BaseFileFormatValue::resolve_from_configs(&configs, Some("file.hfile")).unwrap(),
+            BaseFileFormatValue::HFile
+        );
+        assert_eq!(
+            BaseFileFormatValue::resolve_from_configs(&configs, Some("file.unknown")).unwrap(),
+            BaseFileFormatValue::Parquet
+        );
     }
 
     #[test]

--- a/crates/core/src/file_group/base_file/mod.rs
+++ b/crates/core/src/file_group/base_file/mod.rs
@@ -16,6 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+pub mod parquet;
+pub mod reader;
+
 use crate::Result;
 use crate::error::CoreError;
 use crate::storage::file_metadata::FileMetadata;

--- a/crates/core/src/file_group/base_file/parquet.rs
+++ b/crates/core/src/file_group/base_file/parquet.rs
@@ -1,0 +1,309 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+//! Parquet implementation of [`BaseFileReader`].
+
+use std::sync::Arc;
+
+use arrow::compute::concat_batches;
+use arrow::record_batch::RecordBatch;
+use futures::StreamExt;
+use futures::future::BoxFuture;
+use object_store::path::Path as ObjPath;
+use parquet::arrow::async_reader::ParquetObjectReader;
+use parquet::arrow::{ParquetRecordBatchStreamBuilder, parquet_to_arrow_schema};
+use parquet::file::metadata::ParquetMetaData;
+
+use super::reader::{BaseFileReadOptions, BaseFileReader, BaseFileStream};
+use crate::statistics::StatisticsContainer;
+use crate::storage::Storage;
+use crate::storage::error::{Result, StorageError};
+use crate::storage::file_metadata::FileMetadata;
+use crate::storage::util::join_url_segments;
+
+/// Parquet implementation of [`BaseFileReader`].
+///
+/// Reads Parquet files directly via `object_store` and the `parquet` crate.
+pub struct ParquetBaseFileReader {
+    storage: Arc<Storage>,
+}
+
+impl ParquetBaseFileReader {
+    pub fn new(storage: Arc<Storage>) -> Self {
+        Self { storage }
+    }
+
+    async fn object_path_and_size(&self, relative_path: &str) -> Result<(ObjPath, u64)> {
+        let obj_url = join_url_segments(&self.storage.base_url, &[relative_path])?;
+        let obj_path = ObjPath::from_url_path(obj_url.path())?;
+        let meta = self.storage.object_store.head(&obj_path).await?;
+        Ok((obj_path, meta.size))
+    }
+
+    async fn open_builder_with_size(
+        &self,
+        obj_path: ObjPath,
+        file_size: u64,
+    ) -> Result<ParquetRecordBatchStreamBuilder<ParquetObjectReader>> {
+        let reader = ParquetObjectReader::new(self.storage.object_store.clone(), obj_path)
+            .with_file_size(file_size);
+        Ok(ParquetRecordBatchStreamBuilder::new(reader).await?)
+    }
+
+    async fn open_builder(
+        &self,
+        relative_path: &str,
+    ) -> Result<ParquetRecordBatchStreamBuilder<ParquetObjectReader>> {
+        let (obj_path, file_size) = self.object_path_and_size(relative_path).await?;
+        self.open_builder_with_size(obj_path, file_size).await
+    }
+
+    fn apply_options(
+        mut builder: ParquetRecordBatchStreamBuilder<ParquetObjectReader>,
+        options: &BaseFileReadOptions,
+    ) -> Result<ParquetRecordBatchStreamBuilder<ParquetObjectReader>> {
+        if let Some(batch_size) = options.batch_size {
+            builder = builder.with_batch_size(batch_size);
+        }
+
+        // Handle projection: convert column names to indices using builder's schema.
+        if let Some(ref column_names) = options.projection {
+            let arrow_schema = builder.schema();
+            let projection: Vec<usize> = column_names
+                .iter()
+                .map(|name| {
+                    arrow_schema.index_of(name).map_err(|_| {
+                        let available = arrow_schema
+                            .fields()
+                            .iter()
+                            .map(|f| f.name().as_str())
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        StorageError::InvalidColumn(format!(
+                            "Column '{name}' not found in parquet file schema. Available columns: [{available}]"
+                        ))
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+
+            let projection_mask = parquet::arrow::ProjectionMask::roots(
+                builder.parquet_schema(),
+                projection.iter().copied(),
+            );
+            builder = builder.with_projection(projection_mask);
+        }
+
+        Ok(builder)
+    }
+
+    /// Read the raw Parquet footer metadata.
+    ///
+    /// Exposed for callers that need format-specific details such as row group
+    /// compressed sizes for statistics estimation.
+    pub async fn get_parquet_metadata(&self, relative_path: &str) -> Result<ParquetMetaData> {
+        let builder = self.open_builder(relative_path).await?;
+        Ok(builder.metadata().as_ref().clone())
+    }
+
+    /// Get the Arrow schema from a Parquet file's footer.
+    pub async fn get_schema(&self, relative_path: &str) -> Result<arrow_schema::Schema> {
+        let parquet_meta = self.get_parquet_metadata(relative_path).await?;
+        Ok(parquet_to_arrow_schema(
+            parquet_meta.file_metadata().schema_descr(),
+            None,
+        )?)
+    }
+}
+
+impl BaseFileReader for ParquetBaseFileReader {
+    fn read_data<'a>(
+        &'a self,
+        relative_path: &'a str,
+        options: BaseFileReadOptions,
+    ) -> BoxFuture<'a, Result<RecordBatch>> {
+        Box::pin(async move {
+            let builder = self.open_builder(relative_path).await?;
+            let builder = Self::apply_options(builder, &options)?;
+            let schema = builder.schema().clone();
+            let mut stream = builder.build()?;
+
+            let mut batches = Vec::new();
+            while let Some(batch) = stream.next().await {
+                batches.push(batch?);
+            }
+
+            if batches.is_empty() {
+                return Ok(RecordBatch::new_empty(schema));
+            }
+
+            let schema = batches[0].schema();
+            Ok(concat_batches(&schema, &batches)?)
+        })
+    }
+
+    fn read_stream<'a>(
+        &'a self,
+        relative_path: &'a str,
+        options: BaseFileReadOptions,
+    ) -> BoxFuture<'a, Result<BaseFileStream>> {
+        Box::pin(async move {
+            let builder = self.open_builder(relative_path).await?;
+            let builder = Self::apply_options(builder, &options)?;
+            let schema = builder.schema().clone();
+            let stream = builder.build()?;
+            let mapped_stream = stream
+                .map(|result| result.map_err(StorageError::from))
+                .boxed();
+
+            Ok(BaseFileStream::new(schema, mapped_stream))
+        })
+    }
+
+    fn get_metadata_and_stats<'a>(
+        &'a self,
+        relative_path: &'a str,
+        table_schema: &'a arrow_schema::Schema,
+    ) -> BoxFuture<'a, Result<(FileMetadata, StatisticsContainer)>> {
+        Box::pin(async move {
+            let (obj_path, file_size) = self.object_path_and_size(relative_path).await?;
+            let builder = self.open_builder_with_size(obj_path, file_size).await?;
+            let parquet_meta = builder.metadata().as_ref();
+
+            let name = std::path::Path::new(relative_path)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or(relative_path)
+                .to_string();
+
+            let num_records = parquet_meta.file_metadata().num_rows().max(0);
+            let byte_size: i64 = parquet_meta
+                .row_groups()
+                .iter()
+                .map(|rg| rg.total_byte_size())
+                .sum::<i64>()
+                .max(0);
+
+            let file_metadata = FileMetadata {
+                name,
+                size: file_size,
+                byte_size,
+                num_records,
+            };
+
+            let col_stats = StatisticsContainer::from_parquet_metadata(parquet_meta, table_schema);
+
+            Ok((file_metadata, col_stats))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::canonicalize;
+    use std::path::Path;
+    use url::Url;
+
+    fn test_storage() -> Arc<Storage> {
+        let base_url =
+            Url::from_directory_path(canonicalize(Path::new("tests/data")).unwrap()).unwrap();
+        Storage::new_with_base_url(base_url).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_read_data_returns_all_rows() {
+        let reader = ParquetBaseFileReader::new(test_storage());
+        let batch = reader
+            .read_data("a.parquet", BaseFileReadOptions::new())
+            .await
+            .unwrap();
+        assert_eq!(batch.num_rows(), 5);
+        assert!(batch.num_columns() > 1);
+    }
+
+    #[tokio::test]
+    async fn test_read_data_with_projection() {
+        let reader = ParquetBaseFileReader::new(test_storage());
+
+        let full = reader
+            .read_data("a.parquet", BaseFileReadOptions::new())
+            .await
+            .unwrap();
+
+        let first_col = full.schema().field(0).name().clone();
+        let opts = BaseFileReadOptions::new().with_projection([&first_col]);
+        let projected = reader.read_data("a.parquet", opts).await.unwrap();
+
+        assert_eq!(projected.num_columns(), 1);
+        assert_eq!(projected.schema().field(0).name(), &first_col);
+        assert_eq!(projected.num_rows(), full.num_rows());
+    }
+
+    #[tokio::test]
+    async fn test_read_stream_matches_read_data() {
+        let reader = ParquetBaseFileReader::new(test_storage());
+
+        let eager = reader
+            .read_data("a.parquet", BaseFileReadOptions::new())
+            .await
+            .unwrap();
+
+        let opts = BaseFileReadOptions::new().with_batch_size(2);
+        let mut stream = reader.read_stream("a.parquet", opts).await.unwrap();
+
+        let mut batches = Vec::new();
+        while let Some(batch) = stream.next().await {
+            batches.push(batch.unwrap());
+        }
+
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, eager.num_rows());
+        assert_eq!(batches[0].schema(), eager.schema());
+    }
+
+    #[tokio::test]
+    async fn test_get_metadata_and_stats() {
+        let reader = ParquetBaseFileReader::new(test_storage());
+
+        let schema = reader.get_schema("a.parquet").await.unwrap();
+        let (metadata, stats) = reader
+            .get_metadata_and_stats("a.parquet", &schema)
+            .await
+            .unwrap();
+
+        assert_eq!(metadata.name, "a.parquet");
+        assert!(metadata.size > 0);
+        assert_eq!(metadata.num_records, 5);
+        assert!(!stats.columns.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_get_schema() {
+        let reader = ParquetBaseFileReader::new(test_storage());
+        let schema = reader.get_schema("a.parquet").await.unwrap();
+        assert!(!schema.fields().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_get_parquet_metadata() {
+        let reader = ParquetBaseFileReader::new(test_storage());
+        let meta = reader.get_parquet_metadata("a.parquet").await.unwrap();
+        assert_eq!(meta.file_metadata().num_rows(), 5);
+        assert!(!meta.row_groups().is_empty());
+    }
+}

--- a/crates/core/src/file_group/base_file/parquet.rs
+++ b/crates/core/src/file_group/base_file/parquet.rs
@@ -20,8 +20,6 @@
 
 use std::sync::Arc;
 
-use arrow::compute::concat_batches;
-use arrow::record_batch::RecordBatch;
 use futures::StreamExt;
 use futures::future::BoxFuture;
 use object_store::path::Path as ObjPath;
@@ -122,7 +120,8 @@ impl ParquetBaseFileReader {
 
     /// Get the Arrow schema from a Parquet file's footer.
     pub async fn get_schema(&self, relative_path: &str) -> Result<arrow_schema::Schema> {
-        let parquet_meta = self.get_parquet_metadata(relative_path).await?;
+        let builder = self.open_builder(relative_path).await?;
+        let parquet_meta = builder.metadata();
         Ok(parquet_to_arrow_schema(
             parquet_meta.file_metadata().schema_descr(),
             None,
@@ -131,31 +130,6 @@ impl ParquetBaseFileReader {
 }
 
 impl BaseFileReader for ParquetBaseFileReader {
-    fn read_data<'a>(
-        &'a self,
-        relative_path: &'a str,
-        options: BaseFileReadOptions,
-    ) -> BoxFuture<'a, Result<RecordBatch>> {
-        Box::pin(async move {
-            let builder = self.open_builder(relative_path).await?;
-            let builder = Self::apply_options(builder, &options)?;
-            let schema = builder.schema().clone();
-            let mut stream = builder.build()?;
-
-            let mut batches = Vec::new();
-            while let Some(batch) = stream.next().await {
-                batches.push(batch?);
-            }
-
-            if batches.is_empty() {
-                return Ok(RecordBatch::new_empty(schema));
-            }
-
-            let schema = batches[0].schema();
-            Ok(concat_batches(&schema, &batches)?)
-        })
-    }
-
     fn read_stream<'a>(
         &'a self,
         relative_path: &'a str,
@@ -164,8 +138,8 @@ impl BaseFileReader for ParquetBaseFileReader {
         Box::pin(async move {
             let builder = self.open_builder(relative_path).await?;
             let builder = Self::apply_options(builder, &options)?;
-            let schema = builder.schema().clone();
             let stream = builder.build()?;
+            let schema = stream.schema().clone();
             let mapped_stream = stream
                 .map(|result| result.map_err(StorageError::from))
                 .boxed();
@@ -229,7 +203,7 @@ mod tests {
     async fn test_read_data_returns_all_rows() {
         let reader = ParquetBaseFileReader::new(test_storage());
         let batch = reader
-            .read_data("a.parquet", BaseFileReadOptions::new())
+            .read_data("a.parquet", BaseFileReadOptions::default())
             .await
             .unwrap();
         assert_eq!(batch.num_rows(), 5);
@@ -241,12 +215,12 @@ mod tests {
         let reader = ParquetBaseFileReader::new(test_storage());
 
         let full = reader
-            .read_data("a.parquet", BaseFileReadOptions::new())
+            .read_data("a.parquet", BaseFileReadOptions::default())
             .await
             .unwrap();
 
         let first_col = full.schema().field(0).name().clone();
-        let opts = BaseFileReadOptions::new().with_projection([&first_col]);
+        let opts = BaseFileReadOptions::default().with_projection([&first_col]);
         let projected = reader.read_data("a.parquet", opts).await.unwrap();
 
         assert_eq!(projected.num_columns(), 1);
@@ -259,11 +233,11 @@ mod tests {
         let reader = ParquetBaseFileReader::new(test_storage());
 
         let eager = reader
-            .read_data("a.parquet", BaseFileReadOptions::new())
+            .read_data("a.parquet", BaseFileReadOptions::default())
             .await
             .unwrap();
 
-        let opts = BaseFileReadOptions::new().with_batch_size(2);
+        let opts = BaseFileReadOptions::default().with_batch_size(2);
         let mut stream = reader.read_stream("a.parquet", opts).await.unwrap();
 
         let mut batches = Vec::new();

--- a/crates/core/src/file_group/base_file/reader.rs
+++ b/crates/core/src/file_group/base_file/reader.rs
@@ -25,8 +25,6 @@ use arrow_schema::SchemaRef;
 use futures::future::BoxFuture;
 use futures::stream::BoxStream;
 
-use crate::Result as CoreResult;
-use crate::config::HudiConfigs;
 use crate::config::table::BaseFileFormatValue;
 use crate::statistics::StatisticsContainer;
 use crate::storage::Storage;
@@ -138,26 +136,12 @@ pub fn create_base_file_reader(
     }
 }
 
-/// Resolve the base-file format from table config, falling back to file
-/// extension detection if the config is absent.
-pub fn resolve_base_file_format(
-    hudi_configs: &HudiConfigs,
-    file_path: Option<&str>,
-) -> CoreResult<BaseFileFormatValue> {
-    Ok(BaseFileFormatValue::resolve_from_configs(
-        hudi_configs,
-        file_path,
-    )?)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::fs::canonicalize;
     use std::path::Path;
     use url::Url;
-
-    use crate::config::table::HudiTableConfig;
 
     fn test_storage() -> Arc<Storage> {
         let base_url =
@@ -181,44 +165,5 @@ mod tests {
             Ok(_) => panic!("HFile should not create a generic base-file reader"),
             Err(err) => panic!("Expected unsupported HFile error, got {err}"),
         }
-    }
-
-    #[test]
-    fn test_resolve_base_file_format_from_config() {
-        let configs = HudiConfigs::new([(HudiTableConfig::BaseFileFormat, "parquet")]);
-        assert_eq!(
-            resolve_base_file_format(&configs, None).unwrap(),
-            BaseFileFormatValue::Parquet
-        );
-    }
-
-    #[test]
-    fn test_resolve_base_file_format_extension_fallback() {
-        let configs = HudiConfigs::empty();
-        assert_eq!(
-            resolve_base_file_format(&configs, Some("data/file.hfile")).unwrap(),
-            BaseFileFormatValue::HFile
-        );
-        assert_eq!(
-            resolve_base_file_format(&configs, Some("data/file.parquet")).unwrap(),
-            BaseFileFormatValue::Parquet
-        );
-    }
-
-    #[test]
-    fn test_resolve_base_file_format_defaults_to_parquet() {
-        let configs = HudiConfigs::empty();
-        assert_eq!(
-            resolve_base_file_format(&configs, None).unwrap(),
-            BaseFileFormatValue::Parquet
-        );
-    }
-
-    #[test]
-    fn test_resolve_base_file_format_rejects_invalid_config() {
-        let configs = HudiConfigs::new([(HudiTableConfig::BaseFileFormat, "orc")]);
-        let err = resolve_base_file_format(&configs, Some("data/file.parquet"))
-            .expect_err("invalid explicit config must not fall back to extension");
-        assert!(err.to_string().contains("orc"));
     }
 }

--- a/crates/core/src/file_group/base_file/reader.rs
+++ b/crates/core/src/file_group/base_file/reader.rs
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+//! Hudi base-file reader abstraction for format-polymorphic reads.
+
+use std::sync::Arc;
+
+use arrow::record_batch::RecordBatch;
+use arrow_schema::SchemaRef;
+use futures::future::BoxFuture;
+use futures::stream::BoxStream;
+
+use crate::Result as CoreResult;
+use crate::config::HudiConfigs;
+use crate::config::table::BaseFileFormatValue;
+use crate::statistics::StatisticsContainer;
+use crate::storage::Storage;
+use crate::storage::error::{Result, StorageError};
+use crate::storage::file_metadata::FileMetadata;
+
+/// Options for reading a base file.
+#[derive(Clone, Debug, Default)]
+pub struct BaseFileReadOptions {
+    /// Target batch size (number of rows per batch) for streaming reads.
+    pub batch_size: Option<usize>,
+    /// Column projection by names.
+    pub projection: Option<Vec<String>>,
+}
+
+impl BaseFileReadOptions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = Some(batch_size);
+        self
+    }
+
+    /// Sets column projection by column names.
+    pub fn with_projection<I, S>(mut self, columns: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.projection = Some(columns.into_iter().map(|s| s.into()).collect());
+        self
+    }
+}
+
+/// A stream of record batches from a base file with its schema.
+pub struct BaseFileStream {
+    schema: SchemaRef,
+    stream: BoxStream<'static, Result<RecordBatch>>,
+}
+
+impl BaseFileStream {
+    pub fn new(schema: SchemaRef, stream: BoxStream<'static, Result<RecordBatch>>) -> Self {
+        Self { schema, stream }
+    }
+
+    /// Returns the Arrow schema of the base file.
+    pub fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    /// Consumes self and returns the inner stream.
+    pub fn into_stream(self) -> BoxStream<'static, Result<RecordBatch>> {
+        self.stream
+    }
+}
+
+impl futures::Stream for BaseFileStream {
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.stream.as_mut().poll_next(cx)
+    }
+}
+
+/// Trait for reading base files in a format-agnostic way.
+pub trait BaseFileReader: Send + Sync {
+    /// Read all data from a base file, returning a single concatenated RecordBatch.
+    fn read_data<'a>(
+        &'a self,
+        relative_path: &'a str,
+        options: BaseFileReadOptions,
+    ) -> BoxFuture<'a, Result<RecordBatch>>;
+
+    /// Read data from a base file as a stream of RecordBatches.
+    fn read_stream<'a>(
+        &'a self,
+        relative_path: &'a str,
+        options: BaseFileReadOptions,
+    ) -> BoxFuture<'a, Result<BaseFileStream>>;
+
+    /// Get file metadata and column statistics from a base file.
+    fn get_metadata_and_stats<'a>(
+        &'a self,
+        relative_path: &'a str,
+        table_schema: &'a arrow_schema::Schema,
+    ) -> BoxFuture<'a, Result<(FileMetadata, StatisticsContainer)>>;
+}
+
+/// Create a [`BaseFileReader`] for a regular table base-file format.
+///
+/// Metadata-table HFile data uses a dedicated reader path instead of the
+/// generic base-file reader abstraction.
+pub fn create_base_file_reader(
+    storage: &Arc<Storage>,
+    format: &BaseFileFormatValue,
+) -> Result<Arc<dyn BaseFileReader>> {
+    match format {
+        BaseFileFormatValue::Parquet => Ok(Arc::new(super::parquet::ParquetBaseFileReader::new(
+            storage.clone(),
+        ))),
+        BaseFileFormatValue::HFile => Err(StorageError::UnsupportedBaseFileFormat(
+            "hfile is only supported through the metadata-table HFile reader".to_string(),
+        )),
+    }
+}
+
+/// Resolve the base-file format from table config, falling back to file
+/// extension detection if the config is absent.
+pub fn resolve_base_file_format(
+    hudi_configs: &HudiConfigs,
+    file_path: Option<&str>,
+) -> CoreResult<BaseFileFormatValue> {
+    Ok(BaseFileFormatValue::resolve_from_configs(
+        hudi_configs,
+        file_path,
+    )?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::canonicalize;
+    use std::path::Path;
+    use url::Url;
+
+    use crate::config::table::HudiTableConfig;
+
+    fn test_storage() -> Arc<Storage> {
+        let base_url =
+            Url::from_directory_path(canonicalize(Path::new("tests/data")).unwrap()).unwrap();
+        Storage::new_with_base_url(base_url).unwrap()
+    }
+
+    #[test]
+    fn test_create_base_file_reader_parquet() {
+        let storage = test_storage();
+        let reader = create_base_file_reader(&storage, &BaseFileFormatValue::Parquet);
+        assert!(reader.is_ok());
+    }
+
+    #[test]
+    fn test_create_base_file_reader_hfile_is_unsupported() {
+        let storage = test_storage();
+        let reader = create_base_file_reader(&storage, &BaseFileFormatValue::HFile);
+        match reader {
+            Err(StorageError::UnsupportedBaseFileFormat(_)) => {}
+            Ok(_) => panic!("HFile should not create a generic base-file reader"),
+            Err(err) => panic!("Expected unsupported HFile error, got {err}"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_base_file_format_from_config() {
+        let configs = HudiConfigs::new([(HudiTableConfig::BaseFileFormat, "parquet")]);
+        assert_eq!(
+            resolve_base_file_format(&configs, None).unwrap(),
+            BaseFileFormatValue::Parquet
+        );
+    }
+
+    #[test]
+    fn test_resolve_base_file_format_extension_fallback() {
+        let configs = HudiConfigs::empty();
+        assert_eq!(
+            resolve_base_file_format(&configs, Some("data/file.hfile")).unwrap(),
+            BaseFileFormatValue::HFile
+        );
+        assert_eq!(
+            resolve_base_file_format(&configs, Some("data/file.parquet")).unwrap(),
+            BaseFileFormatValue::Parquet
+        );
+    }
+
+    #[test]
+    fn test_resolve_base_file_format_defaults_to_parquet() {
+        let configs = HudiConfigs::empty();
+        assert_eq!(
+            resolve_base_file_format(&configs, None).unwrap(),
+            BaseFileFormatValue::Parquet
+        );
+    }
+
+    #[test]
+    fn test_resolve_base_file_format_rejects_invalid_config() {
+        let configs = HudiConfigs::new([(HudiTableConfig::BaseFileFormat, "orc")]);
+        let err = resolve_base_file_format(&configs, Some("data/file.parquet"))
+            .expect_err("invalid explicit config must not fall back to extension");
+        assert!(err.to_string().contains("orc"));
+    }
+}

--- a/crates/core/src/file_group/base_file/reader.rs
+++ b/crates/core/src/file_group/base_file/reader.rs
@@ -20,8 +20,10 @@
 
 use std::sync::Arc;
 
+use arrow::compute::concat_batches;
 use arrow::record_batch::RecordBatch;
 use arrow_schema::SchemaRef;
+use futures::StreamExt;
 use futures::future::BoxFuture;
 use futures::stream::BoxStream;
 
@@ -41,10 +43,6 @@ pub struct BaseFileReadOptions {
 }
 
 impl BaseFileReadOptions {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = Some(batch_size);
         self
@@ -101,7 +99,24 @@ pub trait BaseFileReader: Send + Sync {
         &'a self,
         relative_path: &'a str,
         options: BaseFileReadOptions,
-    ) -> BoxFuture<'a, Result<RecordBatch>>;
+    ) -> BoxFuture<'a, Result<RecordBatch>> {
+        Box::pin(async move {
+            let base_stream = self.read_stream(relative_path, options).await?;
+            let schema = base_stream.schema().clone();
+            let mut stream = base_stream.into_stream();
+
+            let mut batches = Vec::new();
+            while let Some(batch) = stream.next().await {
+                batches.push(batch?);
+            }
+
+            if batches.is_empty() {
+                return Ok(RecordBatch::new_empty(schema));
+            }
+
+            Ok(concat_batches(&schema, &batches)?)
+        })
+    }
 
     /// Read data from a base file as a stream of RecordBatches.
     fn read_stream<'a>(

--- a/crates/core/src/file_group/reader.rs
+++ b/crates/core/src/file_group/reader.rs
@@ -145,24 +145,22 @@ impl FileGroupReader {
         }
     }
 
-    /// Returns the base file reader for a given path. When the table config
-    /// explicitly sets the format, returns the cached reader. Otherwise falls
-    /// back to extension-based detection.
+    /// Returns the base file reader for a given path. Path extension detection
+    /// keeps no-config readers from using the default Parquet reader for HFile
+    /// paths, while the resolved Parquet path still reuses the cached reader.
     fn reader_for_path(&self, relative_path: &str) -> Result<Arc<dyn BaseFileReader>> {
-        if self
-            .hudi_configs
-            .contains(HudiTableConfig::BaseFileFormat.as_ref())
-        {
-            if let Some(reader) = &self.base_file_reader {
-                return Ok(reader.clone());
-            }
-            let format = base_file_reader::resolve_base_file_format(&self.hudi_configs, None)?;
-            return base_file_reader::create_base_file_reader(&self.storage, &format)
-                .map_err(|e| ReadFileSliceError(format!("{e}")));
-        }
-
         let format =
             base_file_reader::resolve_base_file_format(&self.hudi_configs, Some(relative_path))?;
+
+        if let Some(reader) = &self.base_file_reader
+            && (self
+                .hudi_configs
+                .contains(HudiTableConfig::BaseFileFormat.as_ref())
+                || matches!(format, BaseFileFormatValue::Parquet))
+        {
+            return Ok(reader.clone());
+        }
+
         base_file_reader::create_base_file_reader(&self.storage, &format)
             .map_err(|e| ReadFileSliceError(format!("{e}")))
     }
@@ -1052,6 +1050,35 @@ mod tests {
             error_msg.contains("Unsupported base file format")
                 && error_msg.contains("hfile is only supported"),
             "Expected explicit unsupported HFile reader error, got: {error_msg}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_reader_for_path_reuses_cached_default_parquet_reader() -> Result<()> {
+        let base_uri = get_base_uri_with_valid_props_minimum();
+        let reader = create_test_reader(&base_uri)?;
+        let cached_reader = reader
+            .base_file_reader
+            .as_ref()
+            .expect("default Parquet reader should be cached");
+
+        let resolved_reader = reader.reader_for_path(TEST_SAMPLE_BASE_FILE)?;
+
+        assert!(
+            Arc::ptr_eq(cached_reader, &resolved_reader),
+            "no-config Parquet path should reuse the cached base-file reader"
+        );
+
+        let hfile_error = match reader.reader_for_path("fileid_0-0-1_20240418173551906.hfile") {
+            Ok(_) => panic!("no-config HFile path should still use extension detection"),
+            Err(err) => err.to_string(),
+        };
+        assert!(
+            hfile_error.contains("Unsupported base file format")
+                && hfile_error.contains("hfile is only supported"),
+            "Expected no-config HFile path to report unsupported reader, got: {hfile_error}"
         );
 
         Ok(())

--- a/crates/core/src/file_group/reader.rs
+++ b/crates/core/src/file_group/reader.rs
@@ -19,7 +19,7 @@
 use crate::Result;
 use crate::config::HudiConfigs;
 use crate::config::read::HudiReadConfig;
-use crate::config::table::HudiTableConfig;
+use crate::config::table::{BaseFileFormatValue, HudiTableConfig};
 use crate::error::CoreError;
 use crate::error::CoreError::ReadFileSliceError;
 use crate::expr::filter::{
@@ -37,6 +37,7 @@ use crate::metadata::merger::FilesPartitionMerger;
 use crate::metadata::meta_field::MetaField;
 use crate::metadata::table_record::FilesPartitionRecord;
 use crate::storage::Storage;
+use crate::storage::error::StorageError;
 use crate::table::ReadOptions;
 use crate::table::builder::OptionResolver;
 use crate::timeline::selector::InstantRange;
@@ -88,7 +89,7 @@ impl FileGroupReader {
         let hudi_configs = Arc::new(HudiConfigs::new(final_opts));
         let storage = Storage::new(Arc::new(storage_opts), hudi_configs.clone())?;
         let format = base_file_reader::resolve_base_file_format(&hudi_configs, None)?;
-        let base_file_reader = base_file_reader::create_base_file_reader(&storage, &format).ok();
+        let base_file_reader = Self::create_optional_base_file_reader(&storage, &format)?;
 
         Ok(Self {
             hudi_configs,
@@ -116,7 +117,7 @@ impl FileGroupReader {
         let hudi_configs = Arc::new(HudiConfigs::new(resolver.hudi_options));
         let storage = Storage::new(Arc::new(resolver.storage_options), hudi_configs.clone())?;
         let format = base_file_reader::resolve_base_file_format(&hudi_configs, None)?;
-        let base_file_reader = base_file_reader::create_base_file_reader(&storage, &format).ok();
+        let base_file_reader = Self::create_optional_base_file_reader(&storage, &format)?;
 
         Ok(Self {
             hudi_configs,
@@ -129,6 +130,21 @@ impl FileGroupReader {
         options.with_defaults_from(&self.hudi_configs)
     }
 
+    fn create_optional_base_file_reader(
+        storage: &Arc<Storage>,
+        format: &BaseFileFormatValue,
+    ) -> Result<Option<Arc<dyn BaseFileReader>>> {
+        match base_file_reader::create_base_file_reader(storage, format) {
+            Ok(reader) => Ok(Some(reader)),
+            Err(StorageError::UnsupportedBaseFileFormat(_))
+                if matches!(format, BaseFileFormatValue::HFile) =>
+            {
+                Ok(None)
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+
     /// Returns the base file reader for a given path. When the table config
     /// explicitly sets the format, returns the cached reader. Otherwise falls
     /// back to extension-based detection.
@@ -137,9 +153,12 @@ impl FileGroupReader {
             .hudi_configs
             .contains(HudiTableConfig::BaseFileFormat.as_ref())
         {
-            return self.base_file_reader.clone().ok_or_else(|| {
-                ReadFileSliceError(format!("No base file reader available for {relative_path}"))
-            });
+            if let Some(reader) = &self.base_file_reader {
+                return Ok(reader.clone());
+            }
+            let format = base_file_reader::resolve_base_file_format(&self.hudi_configs, None)?;
+            return base_file_reader::create_base_file_reader(&self.storage, &format)
+                .map_err(|e| ReadFileSliceError(format!("{e}")));
         }
 
         let format =
@@ -1000,6 +1019,39 @@ mod tests {
         assert!(
             error_msg.contains("not found") || error_msg.contains("Failed to read path"),
             "Should contain appropriate error message, got: {error_msg}"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_hfile_base_file_read_reports_unsupported_reader() -> Result<()> {
+        let base_uri = get_base_uri_with_valid_props_minimum();
+        let hudi_configs = Arc::new(HudiConfigs::new([
+            (HudiTableConfig::BasePath, base_uri.as_str()),
+            (
+                HudiTableConfig::BaseFileFormat,
+                BaseFileFormatValue::HFile.as_ref(),
+            ),
+        ]));
+        let reader =
+            FileGroupReader::new_with_overrides(hudi_configs, HashMap::new(), HashMap::new())?;
+
+        let result = reader
+            .read_file_slice_from_paths(
+                "fileid_0-0-1_20240418173551906.hfile",
+                Vec::<&str>::new(),
+                &ReadOptions::new(),
+            )
+            .await;
+
+        let error_msg = result
+            .expect_err("Expected unsupported HFile reader error")
+            .to_string();
+        assert!(
+            error_msg.contains("Unsupported base file format")
+                && error_msg.contains("hfile is only supported"),
+            "Expected explicit unsupported HFile reader error, got: {error_msg}"
         );
 
         Ok(())

--- a/crates/core/src/file_group/reader.rs
+++ b/crates/core/src/file_group/reader.rs
@@ -26,7 +26,7 @@ use crate::expr::filter::{
     Filter, SchemableFilter, filters_to_row_mask, validate_fields_against_schemas,
 };
 use crate::file_group::base_file::reader::{
-    self as base_file_reader, BaseFileReadOptions, BaseFileReader,
+    BaseFileReadOptions, BaseFileReader, create_base_file_reader,
 };
 use crate::file_group::file_slice::FileSlice;
 use crate::file_group::log_file::scanner::{LogFileScanner, ScanResult};
@@ -56,6 +56,7 @@ use std::sync::Arc;
 pub struct FileGroupReader {
     hudi_configs: Arc<HudiConfigs>,
     storage: Arc<Storage>,
+    base_file_format: BaseFileFormatValue,
     base_file_reader: Option<Arc<dyn BaseFileReader>>,
 }
 
@@ -64,6 +65,7 @@ impl std::fmt::Debug for FileGroupReader {
         f.debug_struct("FileGroupReader")
             .field("hudi_configs", &self.hudi_configs)
             .field("storage", &self.storage)
+            .field("base_file_format", &self.base_file_format)
             .finish_non_exhaustive()
     }
 }
@@ -94,6 +96,7 @@ impl FileGroupReader {
         Ok(Self {
             hudi_configs,
             storage,
+            base_file_format: format,
             base_file_reader,
         })
     }
@@ -122,6 +125,7 @@ impl FileGroupReader {
         Ok(Self {
             hudi_configs,
             storage,
+            base_file_format: format,
             base_file_reader,
         })
     }
@@ -134,7 +138,7 @@ impl FileGroupReader {
         storage: &Arc<Storage>,
         format: &BaseFileFormatValue,
     ) -> Result<Option<Arc<dyn BaseFileReader>>> {
-        match base_file_reader::create_base_file_reader(storage, format) {
+        match create_base_file_reader(storage, format) {
             Ok(reader) => Ok(Some(reader)),
             Err(StorageError::UnsupportedBaseFileFormat(_))
                 if matches!(format, BaseFileFormatValue::HFile) =>
@@ -145,23 +149,19 @@ impl FileGroupReader {
         }
     }
 
-    /// Returns the base file reader for a given path. Path extension detection
-    /// keeps no-config readers from using the default Parquet reader for HFile
-    /// paths, while the resolved Parquet path still reuses the cached reader.
+    /// Returns the base-file reader for a path, reusing the cached reader when
+    /// the path resolves to the same format selected at construction time.
     fn reader_for_path(&self, relative_path: &str) -> Result<Arc<dyn BaseFileReader>> {
         let format =
             BaseFileFormatValue::resolve_from_configs(&self.hudi_configs, Some(relative_path))?;
 
-        if let Some(reader) = &self.base_file_reader
-            && (self
-                .hudi_configs
-                .contains(HudiTableConfig::BaseFileFormat.as_ref())
-                || matches!(format, BaseFileFormatValue::Parquet))
+        if format == self.base_file_format
+            && let Some(reader) = &self.base_file_reader
         {
             return Ok(reader.clone());
         }
 
-        base_file_reader::create_base_file_reader(&self.storage, &format)
+        create_base_file_reader(&self.storage, &format)
             .map_err(|e| ReadFileSliceError(format!("{e}")))
     }
 
@@ -171,7 +171,7 @@ impl FileGroupReader {
     async fn read_base_file_eager(&self, relative_path: &str) -> Result<RecordBatch> {
         let reader = self.reader_for_path(relative_path)?;
         let records: RecordBatch = reader
-            .read_data(relative_path, BaseFileReadOptions::new())
+            .read_data(relative_path, BaseFileReadOptions::default())
             .map_err(|e| ReadFileSliceError(format!("Failed to read path {relative_path}: {e:?}")))
             .await?;
         apply_commit_time_filter(&self.hudi_configs, records)
@@ -393,7 +393,7 @@ impl FileGroupReader {
             .get_or_default(HudiReadConfig::StreamBatchSize)
             .into();
         let batch_size = options.batch_size()?.unwrap_or(default_batch_size);
-        let mut read_options = BaseFileReadOptions::new().with_batch_size(batch_size);
+        let mut read_options = BaseFileReadOptions::default().with_batch_size(batch_size);
 
         // If projection is set, widen the base file read to also include any columns
         // we need post-read but the user didn't request:

--- a/crates/core/src/file_group/reader.rs
+++ b/crates/core/src/file_group/reader.rs
@@ -25,6 +25,9 @@ use crate::error::CoreError::ReadFileSliceError;
 use crate::expr::filter::{
     Filter, SchemableFilter, filters_to_row_mask, validate_fields_against_schemas,
 };
+use crate::file_group::base_file::reader::{
+    self as base_file_reader, BaseFileReadOptions, BaseFileReader,
+};
 use crate::file_group::file_slice::FileSlice;
 use crate::file_group::log_file::scanner::{LogFileScanner, ScanResult};
 use crate::file_group::record_batches::RecordBatches;
@@ -33,7 +36,7 @@ use crate::merge::record_merger::RecordMerger;
 use crate::metadata::merger::FilesPartitionMerger;
 use crate::metadata::meta_field::MetaField;
 use crate::metadata::table_record::FilesPartitionRecord;
-use crate::storage::{ParquetReadOptions, Storage};
+use crate::storage::Storage;
 use crate::table::ReadOptions;
 use crate::table::builder::OptionResolver;
 use crate::timeline::selector::InstantRange;
@@ -48,10 +51,20 @@ use std::convert::TryFrom;
 use std::sync::Arc;
 
 /// The reader that handles all read operations against a file group.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct FileGroupReader {
     hudi_configs: Arc<HudiConfigs>,
     storage: Arc<Storage>,
+    base_file_reader: Option<Arc<dyn BaseFileReader>>,
+}
+
+impl std::fmt::Debug for FileGroupReader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FileGroupReader")
+            .field("hudi_configs", &self.hudi_configs)
+            .field("storage", &self.storage)
+            .finish_non_exhaustive()
+    }
 }
 
 impl FileGroupReader {
@@ -74,10 +87,13 @@ impl FileGroupReader {
         final_opts.extend(extra_hudi_opts);
         let hudi_configs = Arc::new(HudiConfigs::new(final_opts));
         let storage = Storage::new(Arc::new(storage_opts), hudi_configs.clone())?;
+        let format = base_file_reader::resolve_base_file_format(&hudi_configs, None)?;
+        let base_file_reader = base_file_reader::create_base_file_reader(&storage, &format).ok();
 
         Ok(Self {
             hudi_configs,
             storage,
+            base_file_reader,
         })
     }
 
@@ -99,10 +115,13 @@ impl FileGroupReader {
         resolver.resolve_options().await?;
         let hudi_configs = Arc::new(HudiConfigs::new(resolver.hudi_options));
         let storage = Storage::new(Arc::new(resolver.storage_options), hudi_configs.clone())?;
+        let format = base_file_reader::resolve_base_file_format(&hudi_configs, None)?;
+        let base_file_reader = base_file_reader::create_base_file_reader(&storage, &format).ok();
 
         Ok(Self {
             hudi_configs,
             storage,
+            base_file_reader,
         })
     }
 
@@ -110,13 +129,32 @@ impl FileGroupReader {
         options.with_defaults_from(&self.hudi_configs)
     }
 
+    /// Returns the base file reader for a given path. When the table config
+    /// explicitly sets the format, returns the cached reader. Otherwise falls
+    /// back to extension-based detection.
+    fn reader_for_path(&self, relative_path: &str) -> Result<Arc<dyn BaseFileReader>> {
+        if self
+            .hudi_configs
+            .contains(HudiTableConfig::BaseFileFormat.as_ref())
+        {
+            return self.base_file_reader.clone().ok_or_else(|| {
+                ReadFileSliceError(format!("No base file reader available for {relative_path}"))
+            });
+        }
+
+        let format =
+            base_file_reader::resolve_base_file_format(&self.hudi_configs, Some(relative_path))?;
+        base_file_reader::create_base_file_reader(&self.storage, &format)
+            .map_err(|e| ReadFileSliceError(format!("{e}")))
+    }
+
     /// Internal: read base file + apply commit-time filter, no [`ReadOptions`] applied.
     /// Used by the merge path so options aren't applied prematurely before merging
     /// with log files.
     async fn read_base_file_eager(&self, relative_path: &str) -> Result<RecordBatch> {
-        let records: RecordBatch = self
-            .storage
-            .get_parquet_file_data(relative_path)
+        let reader = self.reader_for_path(relative_path)?;
+        let records: RecordBatch = reader
+            .read_data(relative_path, BaseFileReadOptions::new())
             .map_err(|e| ReadFileSliceError(format!("Failed to read path {relative_path}: {e:?}")))
             .await?;
         apply_commit_time_filter(&self.hudi_configs, records)
@@ -325,7 +363,7 @@ impl FileGroupReader {
     ///
     /// Supports the following [ReadOptions]:
     /// - `batch_size`: Controls the number of rows per batch
-    /// - `projection`: Pushes column selection to the parquet reader level
+    /// - `projection`: Pushes column selection to the base-file reader level
     /// - `filters`: Applied as a row-level mask after reading each batch (in addition to
     ///   any pruning that already happened upstream)
     async fn read_base_file_stream(
@@ -338,9 +376,9 @@ impl FileGroupReader {
             .get_or_default(HudiReadConfig::StreamBatchSize)
             .into();
         let batch_size = options.batch_size()?.unwrap_or(default_batch_size);
-        let mut parquet_options = ParquetReadOptions::new().with_batch_size(batch_size);
+        let mut read_options = BaseFileReadOptions::new().with_batch_size(batch_size);
 
-        // If projection is set, widen the parquet read to also include any columns
+        // If projection is set, widen the base file read to also include any columns
         // we need post-read but the user didn't request:
         //   - filter fields, so the row-level mask can evaluate them
         //   - `_hoodie_commit_time`, when commit-time filtering is active
@@ -396,7 +434,7 @@ impl FileGroupReader {
             combined
         });
         if let Some(ref cols) = read_projection {
-            parquet_options = parquet_options.with_projection(cols.clone());
+            read_options = read_options.with_projection(cols.clone());
         }
 
         let hudi_configs = self.hudi_configs.clone();
@@ -407,14 +445,14 @@ impl FileGroupReader {
         // rather than silent no-ops in `filters_to_row_mask`.
         let validated = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
-        let parquet_stream = self
-            .storage
-            .get_parquet_file_stream(&path, parquet_options)
+        let reader = self.reader_for_path(&path)?;
+        let base_stream = reader
+            .read_stream(&path, read_options)
             .map_err(|e| ReadFileSliceError(format!("Failed to read path {path}: {e:?}")))
             .await?;
 
         // Apply filtering: commit time → structured filters → final projection.
-        let stream = parquet_stream.into_stream().filter_map(move |result| {
+        let stream = base_stream.into_stream().filter_map(move |result| {
             let hudi_configs = hudi_configs.clone();
             let filters = filters.clone();
             let final_projection = final_projection.clone();

--- a/crates/core/src/file_group/reader.rs
+++ b/crates/core/src/file_group/reader.rs
@@ -88,7 +88,7 @@ impl FileGroupReader {
         final_opts.extend(extra_hudi_opts);
         let hudi_configs = Arc::new(HudiConfigs::new(final_opts));
         let storage = Storage::new(Arc::new(storage_opts), hudi_configs.clone())?;
-        let format = base_file_reader::resolve_base_file_format(&hudi_configs, None)?;
+        let format = BaseFileFormatValue::resolve_from_configs(&hudi_configs, None)?;
         let base_file_reader = Self::create_optional_base_file_reader(&storage, &format)?;
 
         Ok(Self {
@@ -116,7 +116,7 @@ impl FileGroupReader {
         resolver.resolve_options().await?;
         let hudi_configs = Arc::new(HudiConfigs::new(resolver.hudi_options));
         let storage = Storage::new(Arc::new(resolver.storage_options), hudi_configs.clone())?;
-        let format = base_file_reader::resolve_base_file_format(&hudi_configs, None)?;
+        let format = BaseFileFormatValue::resolve_from_configs(&hudi_configs, None)?;
         let base_file_reader = Self::create_optional_base_file_reader(&storage, &format)?;
 
         Ok(Self {
@@ -150,7 +150,7 @@ impl FileGroupReader {
     /// paths, while the resolved Parquet path still reuses the cached reader.
     fn reader_for_path(&self, relative_path: &str) -> Result<Arc<dyn BaseFileReader>> {
         let format =
-            base_file_reader::resolve_base_file_format(&self.hudi_configs, Some(relative_path))?;
+            BaseFileFormatValue::resolve_from_configs(&self.hudi_configs, Some(relative_path))?;
 
         if let Some(reader) = &self.base_file_reader
             && (self

--- a/crates/core/src/schema/resolver.rs
+++ b/crates/core/src/schema/resolver.rs
@@ -17,8 +17,10 @@
  * under the License.
  */
 use crate::avro_to_arrow::to_arrow_schema;
+use crate::config::table::BaseFileFormatValue;
 use crate::config::table::HudiTableConfig;
 use crate::error::{CoreError, Result};
+use crate::file_group::base_file::parquet::ParquetBaseFileReader;
 use crate::metadata::commit::HoodieCommitMetadata;
 use crate::schema::{prepend_meta_fields, prepend_meta_fields_to_avro_schema_str};
 use crate::storage::Storage;
@@ -142,9 +144,11 @@ async fn resolve_schema_from_base_file(
 
     // Try to get the base file path from either 'path' or 'baseFile' field
     if let Some(path) = &first_stat.path
-        && path.ends_with(".parquet")
+        && BaseFileFormatValue::from_extension(path) == Some(BaseFileFormatValue::Parquet)
     {
-        return Ok(storage.get_file_schema(path).await?);
+        return Ok(ParquetBaseFileReader::new(storage.clone())
+            .get_schema(path)
+            .await?);
     }
 
     // Handle deltacommit case with baseFile
@@ -159,7 +163,11 @@ async fn resolve_schema_from_base_file(
                 "Failed to resolve the latest schema: invalid file path".to_string(),
             )
         })?;
-        return Ok(storage.get_file_schema(path).await?);
+        if BaseFileFormatValue::from_extension(path) == Some(BaseFileFormatValue::Parquet) {
+            return Ok(ParquetBaseFileReader::new(storage.clone())
+                .get_schema(path)
+                .await?);
+        }
     }
 
     Err(CoreError::CommitMetadata(

--- a/crates/core/src/statistics/estimator.rs
+++ b/crates/core/src/statistics/estimator.rs
@@ -18,7 +18,9 @@
  */
 
 use crate::Result;
+use crate::file_group::base_file::parquet::ParquetBaseFileReader;
 use crate::storage::Storage;
+use std::sync::Arc;
 
 /// Cached ratios derived from a single base file sample.
 /// Used to estimate `byte_size` and `num_records` for all files.
@@ -42,10 +44,12 @@ impl FileStatsEstimator {
 
     /// Build an estimator by reading a single Parquet footer.
     pub(crate) async fn from_parquet_footer(
-        storage: &Storage,
+        storage: &Arc<Storage>,
         relative_path: &str,
     ) -> Result<Self> {
-        let parquet_meta = storage.get_parquet_file_metadata(relative_path).await?;
+        let parquet_meta = ParquetBaseFileReader::new(storage.clone())
+            .get_parquet_metadata(relative_path)
+            .await?;
         let on_disk: i64 = parquet_meta
             .row_groups()
             .iter()

--- a/crates/core/src/storage/error.rs
+++ b/crates/core/src/storage/error.rs
@@ -34,6 +34,9 @@ pub enum StorageError {
     #[error("Invalid column: {0}")]
     InvalidColumn(String),
 
+    #[error("Unsupported base file format: {0}")]
+    UnsupportedBaseFileFormat(String),
+
     #[error(transparent)]
     ObjectStoreError(#[from] object_store::Error),
 

--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -22,26 +22,17 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use arrow::compute::concat_batches;
-use arrow::record_batch::RecordBatch;
-use arrow_schema::SchemaRef;
 use async_recursion::async_recursion;
 use bytes::Bytes;
-use futures::StreamExt;
-use futures::stream::BoxStream;
 use object_store::path::Path as ObjPath;
 use object_store::{ObjectStore, parse_url_opts};
-use parquet::arrow::async_reader::ParquetObjectReader;
-use parquet::arrow::{ParquetRecordBatchStreamBuilder, parquet_to_arrow_schema};
-use parquet::file::metadata::ParquetMetaData;
 use url::Url;
 
 use crate::config::HudiConfigs;
 use crate::config::table::HudiTableConfig;
-use crate::statistics::StatisticsContainer;
 
-use crate::storage::error::StorageError::{Creation, InvalidPath};
-use crate::storage::error::{Result, StorageError};
+use crate::storage::error::Result;
+use crate::storage::error::StorageError::{self, Creation, InvalidPath};
 use crate::storage::file_metadata::FileMetadata;
 use crate::storage::reader::StorageReader;
 use crate::storage::util::join_url_segments;
@@ -50,75 +41,6 @@ pub mod error;
 pub mod file_metadata;
 pub mod reader;
 pub mod util;
-
-/// Options for reading Parquet files with streaming.
-#[derive(Clone, Debug, Default)]
-pub struct ParquetReadOptions {
-    /// Target batch size (number of rows per batch).
-    pub batch_size: Option<usize>,
-    /// Column projection by names.
-    pub projection: Option<Vec<String>>,
-}
-
-impl ParquetReadOptions {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
-        self.batch_size = Some(batch_size);
-        self
-    }
-
-    /// Sets column projection by column names.
-    pub fn with_projection<I, S>(mut self, columns: I) -> Self
-    where
-        I: IntoIterator<Item = S>,
-        S: Into<String>,
-    {
-        self.projection = Some(columns.into_iter().map(|s| s.into()).collect());
-        self
-    }
-}
-
-/// A stream of record batches from a Parquet file with its schema.
-///
-/// # Implementation Note
-///
-/// This struct uses a `BoxStream` internally, which requires a heap allocation per file.
-/// For high-performance scenarios with many small files, this adds minimal overhead since:
-/// - Batch processing amortizes the allocation cost (each batch may contain thousands of rows)
-/// - The streaming benefit (lazy evaluation, reduced memory) outweighs the Box allocation cost
-/// - For typical parquet files (>10MB), the Box overhead (~40-80 bytes) is negligible
-pub struct ParquetFileStream {
-    schema: SchemaRef,
-    stream: BoxStream<'static, std::result::Result<RecordBatch, parquet::errors::ParquetError>>,
-}
-
-impl ParquetFileStream {
-    /// Returns the Arrow schema of the Parquet file.
-    pub fn schema(&self) -> &SchemaRef {
-        &self.schema
-    }
-
-    /// Consumes self and returns the inner stream.
-    pub fn into_stream(
-        self,
-    ) -> BoxStream<'static, std::result::Result<RecordBatch, parquet::errors::ParquetError>> {
-        self.stream
-    }
-}
-
-impl futures::Stream for ParquetFileStream {
-    type Item = std::result::Result<RecordBatch, parquet::errors::ParquetError>;
-
-    fn poll_next(
-        mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<Self::Item>> {
-        self.stream.as_mut().poll_next(cx)
-    }
-}
 
 #[allow(dead_code)]
 #[derive(Clone, Debug)]
@@ -193,83 +115,6 @@ impl Storage {
         Ok(FileMetadata::new(name.to_string(), meta.size))
     }
 
-    /// Get the Arrow schema from a base file.
-    ///
-    /// Currently supports Parquet only; other formats (e.g., Lance) can be added.
-    pub async fn get_file_schema(&self, relative_path: &str) -> Result<arrow_schema::Schema> {
-        let parquet_meta = self.get_parquet_file_metadata(relative_path).await?;
-        Ok(parquet_to_arrow_schema(
-            parquet_meta.file_metadata().schema_descr(),
-            None,
-        )?)
-    }
-
-    /// Read a Parquet file's footer and return the raw metadata.
-    ///
-    /// Internal API for callers that need raw row group details (estimator
-    /// sampling). Most callers should use [`Self::get_file_schema`] or
-    /// [`Self::get_file_metadata_and_stats`] instead.
-    pub(crate) async fn get_parquet_file_metadata(
-        &self,
-        relative_path: &str,
-    ) -> Result<ParquetMetaData> {
-        let obj_url = join_url_segments(&self.base_url, &[relative_path])?;
-        let obj_path = ObjPath::from_url_path(obj_url.path())?;
-        let obj_store = self.object_store.clone();
-        let meta = obj_store.head(&obj_path).await?;
-        let reader = ParquetObjectReader::new(obj_store, obj_path).with_file_size(meta.size);
-        let builder = ParquetRecordBatchStreamBuilder::new(reader).await?;
-        Ok(builder.metadata().as_ref().clone())
-    }
-
-    /// Get file metadata and column statistics from a base file.
-    ///
-    /// Reads the Parquet footer in a single HEAD + range request and returns:
-    /// - [`FileMetadata`]: `size` (on-disk from HEAD), `byte_size` (uncompressed
-    ///   from row groups), `num_records` (exact from footer).
-    /// - [`StatisticsContainer`]: per-column min/max from row group stats.
-    ///
-    /// Currently supports Parquet only; other base file formats can be added.
-    pub async fn get_file_metadata_and_stats(
-        &self,
-        relative_path: &str,
-        table_schema: &arrow_schema::Schema,
-    ) -> Result<(FileMetadata, StatisticsContainer)> {
-        let obj_url = join_url_segments(&self.base_url, &[relative_path])?;
-        let obj_path = ObjPath::from_url_path(obj_url.path())?;
-        let obj_store = self.object_store.clone();
-        let meta = obj_store.head(&obj_path).await?;
-        let file_size = meta.size as u64;
-        let reader = ParquetObjectReader::new(obj_store, obj_path).with_file_size(meta.size);
-        let builder = ParquetRecordBatchStreamBuilder::new(reader).await?;
-        let parquet_meta = builder.metadata().as_ref();
-
-        let name = std::path::Path::new(relative_path)
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or(relative_path)
-            .to_string();
-
-        let num_records = parquet_meta.file_metadata().num_rows().max(0);
-        let byte_size: i64 = parquet_meta
-            .row_groups()
-            .iter()
-            .map(|rg| rg.total_byte_size())
-            .sum::<i64>()
-            .max(0);
-
-        let file_metadata = FileMetadata {
-            name,
-            size: file_size,
-            byte_size,
-            num_records,
-        };
-
-        let col_stats = StatisticsContainer::from_parquet_metadata(parquet_meta, table_schema);
-
-        Ok((file_metadata, col_stats))
-    }
-
     pub async fn get_file_data(&self, relative_path: &str) -> Result<Bytes> {
         let obj_url = join_url_segments(&self.base_url, &[relative_path])?;
         let obj_path = ObjPath::from_url_path(obj_url.path())?;
@@ -283,91 +128,6 @@ impl Storage {
         let result = self.object_store.get(&obj_path).await?;
         let bytes = result.bytes().await?;
         Ok(bytes)
-    }
-
-    pub async fn get_parquet_file_data(&self, relative_path: &str) -> Result<RecordBatch> {
-        let obj_url = join_url_segments(&self.base_url, &[relative_path])?;
-        let obj_path = ObjPath::from_url_path(obj_url.path())?;
-        let obj_store = self.object_store.clone();
-        let meta = obj_store.head(&obj_path).await?;
-
-        // read parquet
-        let reader = ParquetObjectReader::new(obj_store, obj_path).with_file_size(meta.size);
-        let builder = ParquetRecordBatchStreamBuilder::new(reader).await?;
-        let schema = builder.schema().clone();
-        let mut stream = builder.build()?;
-        let mut batches = Vec::new();
-
-        while let Some(r) = stream.next().await {
-            batches.push(r?)
-        }
-
-        if batches.is_empty() {
-            return Ok(RecordBatch::new_empty(schema.clone()));
-        }
-
-        Ok(concat_batches(&schema, &batches)?)
-    }
-
-    /// Get a streaming reader for a Parquet file.
-    ///
-    /// Returns a [ParquetFileStream] that yields record batches as they are read,
-    /// without loading all data into memory at once.
-    ///
-    /// # Arguments
-    /// * `relative_path` - The relative path to the Parquet file.
-    /// * `options` - Options for reading the Parquet file (batch size, projection).
-    pub async fn get_parquet_file_stream(
-        &self,
-        relative_path: &str,
-        options: ParquetReadOptions,
-    ) -> Result<ParquetFileStream> {
-        let obj_url = join_url_segments(&self.base_url, &[relative_path])?;
-        let obj_path = ObjPath::from_url_path(obj_url.path())?;
-        let obj_store = self.object_store.clone();
-        let meta = obj_store.head(&obj_path).await?;
-
-        let reader = ParquetObjectReader::new(obj_store, obj_path).with_file_size(meta.size);
-        let mut builder = ParquetRecordBatchStreamBuilder::new(reader).await?;
-
-        if let Some(batch_size) = options.batch_size {
-            builder = builder.with_batch_size(batch_size);
-        }
-
-        // Handle projection: convert column names to indices using builder's schema
-        if let Some(ref column_names) = options.projection {
-            let arrow_schema = builder.schema();
-            let projection: Vec<usize> = column_names
-                .iter()
-                .map(|name| {
-                    arrow_schema.index_of(name).map_err(|_| {
-                        let available = arrow_schema
-                            .fields()
-                            .iter()
-                            .map(|f| f.name().as_str())
-                            .collect::<Vec<_>>()
-                            .join(", ");
-                        StorageError::InvalidColumn(format!(
-                            "Column '{name}' not found in parquet file schema. Available columns: [{available}]"
-                        ))
-                    })
-                })
-                .collect::<Result<Vec<_>>>()?;
-
-            let projection_mask = parquet::arrow::ProjectionMask::roots(
-                builder.parquet_schema(),
-                projection.iter().copied(),
-            );
-            builder = builder.with_projection(projection_mask);
-        }
-
-        let schema = builder.schema().clone();
-        let stream = builder.build()?;
-
-        Ok(ParquetFileStream {
-            schema,
-            stream: Box::pin(stream),
-        })
     }
 
     pub async fn get_storage_reader(&self, relative_path: &str) -> Result<StorageReader> {
@@ -628,14 +388,5 @@ mod tests {
             .unwrap();
         assert_eq!(file_metadata.name, "a.parquet");
         assert_eq!(file_metadata.size, 866);
-    }
-
-    #[tokio::test]
-    async fn storage_get_parquet_file_data() {
-        let base_url =
-            Url::from_directory_path(canonicalize(Path::new("tests/data")).unwrap()).unwrap();
-        let storage = Storage::new_with_base_url(base_url).unwrap();
-        let file_data = storage.get_parquet_file_data("a.parquet").await.unwrap();
-        assert_eq!(file_data.num_rows(), 5);
     }
 }

--- a/crates/core/src/table/fs_view.rs
+++ b/crates/core/src/table/fs_view.rs
@@ -27,6 +27,8 @@ use crate::config::HudiConfigs;
 use crate::config::table::BaseFileFormatValue;
 use crate::config::table::HudiTableConfig::BaseFileFormat;
 use crate::file_group::FileGroup;
+use crate::file_group::base_file::parquet::ParquetBaseFileReader;
+use crate::file_group::base_file::reader::BaseFileReader;
 use crate::file_group::builder::file_groups_from_files_partition_records;
 use crate::file_group::file_slice::FileSlice;
 use crate::metadata::table::records::FilesPartitionRecord;
@@ -53,14 +55,6 @@ impl FileSystemView {
         let s: String = self.hudi_configs.get_or_default(BaseFileFormat).into();
         s.parse::<BaseFileFormatValue>()
             .unwrap_or(BaseFileFormatValue::Parquet)
-    }
-
-    /// Case-insensitive ASCII suffix check that avoids allocating a lowercased copy of `s`.
-    fn ends_with_ignore_ascii_case(s: &str, suffix: &str) -> bool {
-        let s_bytes = s.as_bytes();
-        let suffix_bytes = suffix.as_bytes();
-        s_bytes.len() >= suffix_bytes.len()
-            && s_bytes[s_bytes.len() - suffix_bytes.len()..].eq_ignore_ascii_case(suffix_bytes)
     }
 
     pub async fn new(
@@ -178,7 +172,6 @@ impl FileSystemView {
         if !matches!(base_file_format, BaseFileFormatValue::Parquet) {
             return file_groups;
         }
-        let base_file_suffix = format!(".{}", base_file_format.as_ref());
 
         let mut retained = Vec::with_capacity(file_groups.len());
 
@@ -195,16 +188,16 @@ impl FileSystemView {
                     }
                 };
 
-                // Case-insensitive check for configured base file extension.
-                if !Self::ends_with_ignore_ascii_case(&relative_path, &base_file_suffix) {
+                if !base_file_format.matches_extension(&relative_path) {
                     retained.push(fg);
                     continue;
                 }
 
-                let (file_metadata, col_stats) = match self
-                    .storage
-                    .get_file_metadata_and_stats(&relative_path, table_schema)
-                    .await
+                let (file_metadata, col_stats) = match ParquetBaseFileReader::new(
+                    self.storage.clone(),
+                )
+                .get_metadata_and_stats(&relative_path, table_schema)
+                .await
                 {
                     Ok(result) => result,
                     Err(e) => {

--- a/crates/core/src/table/fs_view.rs
+++ b/crates/core/src/table/fs_view.rs
@@ -173,6 +173,7 @@ impl FileSystemView {
             return file_groups;
         }
 
+        let parquet_reader = ParquetBaseFileReader::new(self.storage.clone());
         let mut retained = Vec::with_capacity(file_groups.len());
 
         for mut fg in file_groups {
@@ -193,11 +194,9 @@ impl FileSystemView {
                     continue;
                 }
 
-                let (file_metadata, col_stats) = match ParquetBaseFileReader::new(
-                    self.storage.clone(),
-                )
-                .get_metadata_and_stats(&relative_path, table_schema)
-                .await
+                let (file_metadata, col_stats) = match parquet_reader
+                    .get_metadata_and_stats(&relative_path, table_schema)
+                    .await
                 {
                     Ok(result) => result,
                     Err(e) => {


### PR DESCRIPTION
## Description

Refactors base-file reads by moving Parquet-specific I/O out of `Storage` into a new `BaseFileReader` abstraction and `ParquetBaseFileReader`.
`Storage` now stays focused on object-store access, while schema resolution, footer stats, file-group streaming, and stats estimation call the Parquet reader explicitly.
The dispatch helpers on `BaseFileFormatValue` support config-first and extension fallback for Parquet and HFile, with HFile kept on the metadata-table reader path.

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below

Automated checks: `make check-rust`; `./build-wrapper.sh cargo test -p hudi-core`.
