### PR TITLE
docs(python): add doctests to builder and config APIs, enable --doctest-modules

### DIFF
--- a/python/hudi/_config.py
+++ b/python/hudi/_config.py
@@ -38,6 +38,13 @@ HudiTableConfig = Enum(
 )
 HudiTableConfig.__doc__ = (
     "Configurations for Hudi tables, most of them are persisted in `hoodie.properties`."
+    "\n\n"
+    "Examples:\n"
+    "    >>> from hudi import HudiTableConfig\n"
+    "    >>> HudiTableConfig.BASE_PATH.value\n"
+    "    'hoodie.base.path'\n"
+    "    >>> HudiTableConfig.TABLE_NAME.value\n"
+    "    'hoodie.table.name'\n"
 )
 
 HudiReadConfig = Enum(
@@ -47,7 +54,16 @@ HudiReadConfig = Enum(
     module=__name__,
     qualname="HudiReadConfig",
 )
-HudiReadConfig.__doc__ = "Configurations for reading Hudi tables."
+HudiReadConfig.__doc__ = (
+    "Configurations for reading Hudi tables."
+    "\n\n"
+    "Examples:\n"
+    "    >>> from hudi import HudiReadConfig\n"
+    "    >>> HudiReadConfig.QUERY_TYPE.value\n"
+    "    'hoodie.read.query.type'\n"
+    "    >>> HudiReadConfig.AS_OF_TIMESTAMP.value\n"
+    "    'hoodie.read.as.of.timestamp'\n"
+)
 
 HudiPlanConfig = Enum(
     "HudiPlanConfig",
@@ -56,6 +72,13 @@ HudiPlanConfig = Enum(
     module=__name__,
     qualname="HudiPlanConfig",
 )
-HudiPlanConfig.__doc__ = "Configurations for query planning in Hudi."
+HudiPlanConfig.__doc__ = (
+    "Configurations for query planning in Hudi."
+    "\n\n"
+    "Examples:\n"
+    "    >>> from hudi import HudiPlanConfig\n"
+    "    >>> HudiPlanConfig.LISTING_PARALLELISM.value\n"
+    "    'hoodie.plan.listing.parallelism'\n"
+)
 
 __all__ = ["HudiPlanConfig", "HudiReadConfig", "HudiTableConfig"]

--- a/python/hudi/table/builder.py
+++ b/python/hudi/table/builder.py
@@ -55,6 +55,16 @@ class HudiTableBuilder:
 
         Returns:
             HudiTableBuilder: An instance of the builder.
+
+        Examples:
+            >>> from hudi import HudiTableBuilder
+            >>> builder = HudiTableBuilder.from_base_uri("s3://my-bucket/trips")
+            >>> builder.base_uri
+            's3://my-bucket/trips'
+            >>> builder.hudi_options
+            {}
+            >>> builder.storage_options
+            {}
         """
         builder = cls(base_uri)
         return builder
@@ -75,6 +85,13 @@ class HudiTableBuilder:
 
         Returns:
             HudiTableBuilder: The builder instance.
+
+        Examples:
+            >>> from hudi import HudiTableBuilder
+            >>> builder = HudiTableBuilder.from_base_uri("s3://my-bucket/trips")
+            >>> builder = builder.with_hudi_option("read.timeline.num-instants", "5")
+            >>> builder.hudi_options
+            {'read.timeline.num-instants': '5'}
         """
         self._add_options({_coerce_key(k): v}, "hudi")
         return self
@@ -88,6 +105,16 @@ class HudiTableBuilder:
 
         Returns:
             HudiTableBuilder: The builder instance.
+
+        Examples:
+            >>> from hudi import HudiTableBuilder
+            >>> builder = HudiTableBuilder.from_base_uri("s3://my-bucket/trips")
+            >>> builder = builder.with_hudi_options({
+            ...     "read.timeline.num-instants": "5",
+            ...     "read.use.new.log.record.reader": "true",
+            ... })
+            >>> sorted(builder.hudi_options.items())
+            [('read.timeline.num-instants', '5'), ('read.use.new.log.record.reader', 'true')]
         """
         self._add_options(hudi_options, "hudi")
         return self
@@ -102,6 +129,13 @@ class HudiTableBuilder:
 
         Returns:
             HudiTableBuilder: The builder instance.
+
+        Examples:
+            >>> from hudi import HudiTableBuilder
+            >>> builder = HudiTableBuilder.from_base_uri("s3://my-bucket/trips")
+            >>> builder = builder.with_storage_option("aws.region", "us-east-1")
+            >>> builder.storage_options
+            {'aws.region': 'us-east-1'}
         """
         self._add_options({k: v}, "storage")
         return self
@@ -117,6 +151,13 @@ class HudiTableBuilder:
 
         Returns:
             HudiTableBuilder: The builder instance.
+
+        Examples:
+            >>> from hudi import HudiTableBuilder
+            >>> builder = HudiTableBuilder.from_base_uri("s3://my-bucket/trips")
+            >>> builder = builder.with_storage_options({"aws.region": "us-east-1"})
+            >>> builder.storage_options
+            {'aws.region': 'us-east-1'}
         """
         self._add_options(storage_options, "storage")
         return self
@@ -131,6 +172,13 @@ class HudiTableBuilder:
 
         Returns:
             HudiTableBuilder: The builder instance.
+
+        Examples:
+            >>> from hudi import HudiTableBuilder
+            >>> builder = HudiTableBuilder.from_base_uri("s3://my-bucket/trips")
+            >>> builder = builder.with_option("aws.region", "eu-west-1")
+            >>> builder.options
+            {'aws.region': 'eu-west-1'}
         """
         self._add_options({_coerce_key(k): v})
         return self
@@ -144,6 +192,13 @@ class HudiTableBuilder:
 
         Returns:
             HudiTableBuilder: The builder instance.
+
+        Examples:
+            >>> from hudi import HudiTableBuilder
+            >>> builder = HudiTableBuilder.from_base_uri("s3://my-bucket/trips")
+            >>> builder = builder.with_options({"aws.region": "ap-southeast-1"})
+            >>> builder.options
+            {'aws.region': 'ap-southeast-1'}
         """
         self._add_options(options)
         return self
@@ -154,6 +209,15 @@ class HudiTableBuilder:
 
         Returns:
             HudiTable: The constructed HudiTable object.
+
+        Examples:
+            >>> from hudi import HudiTableBuilder
+            >>> table = (
+            ...     HudiTableBuilder.from_base_uri("s3://my-bucket/trips")
+            ...     .with_hudi_option("read.timeline.num-instants", "5")
+            ...     .with_storage_option("aws.region", "us-east-1")
+            ...     .build()
+            ... )  # doctest: +SKIP
         """
         return build_hudi_table(
             self.base_uri, self.hudi_options, self.storage_options, self.options

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -80,6 +80,7 @@ exclude = "^tests"
 strict = true
 
 [tool.pytest.ini_options]
+addopts = "--doctest-modules"
 testpaths = [
     "tests",
     "hudi",


### PR DESCRIPTION
## Summary

Closes #82.

This PR implements the doctest setup designed by @xushiyan in [the issue](https://github.com/apache/hudi-rs/issues/82).

Sets up Python doctest infrastructure and adds runnable `Examples:` blocks to the public Python API. The blocking dependency (#141 — consolidate testing data modules) was resolved in release 0.5.0.

## Changes

### `python/pyproject.toml`

Add `addopts = "--doctest-modules"` to `[tool.pytest.ini_options]`. The `hudi/` directory was already in `testpaths`; this flag activates doctest discovery so the examples in docstrings are collected and run as part of `pytest`.

### `python/hudi/table/builder.py`

Add `Examples:` blocks to every public `HudiTableBuilder` method (as specified by @xushiyan — "guiding example to show users the most typical use cases of the APIs and actual test cases like other unit tests"):

| Method | What the doctest covers |
|--------|------------------------|
| `from_base_uri` | Creates a builder; asserts `base_uri`, empty `hudi_options`, empty `storage_options` |
| `with_hudi_option` | Adds a single Hudi key; asserts `hudi_options` dict |
| `with_hudi_options` | Adds multiple Hudi keys at once; uses `sorted()` for determinism |
| `with_storage_option` | Adds a single storage key; asserts `storage_options` dict |
| `with_storage_options` | Adds multiple storage keys at once |
| `with_option` | Adds a generic key to `options` |
| `with_options` | Adds multiple generic keys |
| `build` | Shows the full builder chain; uses `# doctest: +SKIP` since a real table path is required |

### `python/hudi/_config.py`

Add `Examples:` blocks to the three config enums, demonstrating how to read the canonical key string from an enum member:

```python
>>> from hudi import HudiTableConfig
>>> HudiTableConfig.BASE_PATH.value
'hoodie.base.path'
```

Key values were verified against the Rust `AsRef<str>` implementations in `crates/core/src/config/{table,read,plan}.rs`.