### PR TITLE
feat(core): add the merge-on-read reader context, resolver, and entry point

### DIFF
--- a/crates/core/src/file_group/mod.rs
+++ b/crates/core/src/file_group/mod.rs
@@ -25,6 +25,7 @@ pub mod builder;
 pub mod file_slice;
 pub mod log_file;
 pub mod reader;
+pub(crate) mod reader_v2;
 pub mod record_batches;
 
 use crate::Result;

--- a/crates/core/src/file_group/reader.rs
+++ b/crates/core/src/file_group/reader.rs
@@ -177,7 +177,9 @@ impl FileGroupReader {
         apply_commit_time_filter(&self.hudi_configs, records)
     }
 
-    fn create_instant_range_for_log_file_scan(&self) -> Result<InstantRange> {
+    /// Visible to the crate so the merge-on-read context resolver can assert it
+    /// derives the same range; see `reader_v2::resolver`.
+    pub(crate) fn create_instant_range_for_log_file_scan(&self) -> Result<InstantRange> {
         let timezone = self
             .hudi_configs
             .get_or_default(HudiTableConfig::TimelineTimezone)

--- a/crates/core/src/file_group/reader_v2/mod.rs
+++ b/crates/core/src/file_group/reader_v2/mod.rs
@@ -28,5 +28,6 @@
 //! is what the allow below silences. Remove it once the reader wires in.
 #![allow(dead_code)]
 
+pub(crate) mod reader;
 pub(crate) mod reader_context;
 pub(crate) mod resolver;

--- a/crates/core/src/file_group/reader_v2/mod.rs
+++ b/crates/core/src/file_group/reader_v2/mod.rs
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//! Context types for the merge-on-read file group reader.
+//!
+//! This module holds the inputs the MOR reader needs and the resolver that
+//! derives them from a table's configs. Nothing consumes it yet — the reader
+//! itself lands in later changes, and the existing read path is untouched
+//! until it does.
+//!
+//! Everything here is therefore unreachable from the crate's call graph, which
+//! is what the allow below silences. Remove it once the reader wires in.
+#![allow(dead_code)]
+
+pub(crate) mod reader_context;
+pub(crate) mod resolver;

--- a/crates/core/src/file_group/reader_v2/mod.rs
+++ b/crates/core/src/file_group/reader_v2/mod.rs
@@ -24,9 +24,11 @@
 //! itself lands in later changes, and the existing read path is untouched
 //! until it does.
 //!
-//! Everything here is therefore unreachable from the crate's call graph, which
-//! is what the allow below silences. Remove it once the reader wires in.
-#![allow(dead_code)]
+//! Everything here is therefore unreachable from the crate's call graph. Each
+//! item that needs it carries its own `allow(dead_code)`, rather than a blanket
+//! allow on the module: a module-wide one would also silence an item that is
+//! dead by mistake, and this module has a lot of growing left to do. Drop the
+//! per-item allows as the reader wires in.
 
 pub(crate) mod reader;
 pub(crate) mod reader_context;

--- a/crates/core/src/file_group/reader_v2/reader.rs
+++ b/crates/core/src/file_group/reader_v2/reader.rs
@@ -38,11 +38,13 @@ use arrow_array::RecordBatch;
 /// Serves both table types: a merge-on-read slice merges its log records onto
 /// the base file, and a copy-on-write slice is the same read with no log files
 /// to merge.
+#[allow(dead_code)]
 pub(crate) struct FileGroupReader {
     context: ReaderContext,
     parameters: ReaderParameters,
 }
 
+#[allow(dead_code)]
 impl FileGroupReader {
     pub(crate) fn new(context: ReaderContext, parameters: ReaderParameters) -> Self {
         Self {
@@ -110,13 +112,20 @@ mod tests {
         );
     }
 
-    /// Constructing is deliberately separate from reading: later changes fill in
-    /// the engine behind `read`, and callers wiring up a reader should not have
-    /// to handle a failure until they actually ask for rows.
+    /// The reader hands back what it was built with, rather than re-deriving or
+    /// defaulting it. Uses non-default parameters so that substituting defaults
+    /// somewhere in construction would fail this rather than pass unnoticed.
     #[test]
-    fn construction_succeeds_even_though_reading_does_not() {
-        let reader = FileGroupReader::new(context(), ReaderParameters::default());
+    fn holds_the_context_and_parameters_it_was_built_with() {
+        let parameters = ReaderParameters {
+            emit_delete: true,
+            sort_output: true,
+            allow_inflight_instants: true,
+        };
+
+        let reader = FileGroupReader::new(context(), parameters);
 
         assert_eq!(reader.context().table_path, "file:///tmp/t");
+        assert_eq!(*reader.parameters(), parameters);
     }
 }

--- a/crates/core/src/file_group/reader_v2/reader.rs
+++ b/crates/core/src/file_group/reader_v2/reader.rs
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//! The file group reader.
+//!
+//! Only the entry point exists so far. It is here ahead of the engine so that
+//! the shape callers will use is settled, and so the gap is something tests can
+//! point at rather than an absence.
+//!
+//! Shares a name with [`crate::file_group::reader::FileGroupReader`], which
+//! reads file groups today. This one replaces it once the engine behind it is
+//! written, so it carries the name it will keep; until then, reach for either
+//! by module path. Nothing outside this module uses this one yet.
+
+use crate::Result;
+use crate::error::CoreError;
+use crate::file_group::reader_v2::reader_context::{ReaderContext, ReaderParameters};
+use arrow_array::RecordBatch;
+
+/// Reads one file slice.
+///
+/// Serves both table types: a merge-on-read slice merges its log records onto
+/// the base file, and a copy-on-write slice is the same read with no log files
+/// to merge.
+pub(crate) struct FileGroupReader {
+    context: ReaderContext,
+    parameters: ReaderParameters,
+}
+
+impl FileGroupReader {
+    pub(crate) fn new(context: ReaderContext, parameters: ReaderParameters) -> Self {
+        Self {
+            context,
+            parameters,
+        }
+    }
+
+    /// What the reader was resolved to read.
+    pub(crate) fn context(&self) -> &ReaderContext {
+        &self.context
+    }
+
+    /// Flags controlling what this reader emits.
+    pub(crate) fn parameters(&self) -> &ReaderParameters {
+        &self.parameters
+    }
+
+    /// Read the file slice and return the merged rows.
+    ///
+    /// # Errors
+    /// Always, for now: the merge engine has not been written. Failing is the
+    /// point — an empty batch would be indistinguishable from a file slice that
+    /// genuinely has no rows, and would let an unfinished reader look like it
+    /// worked.
+    pub(crate) async fn read(&self) -> Result<RecordBatch> {
+        Err(CoreError::Unsupported(
+            "The merge-on-read file group reader is not yet implemented. \
+             Its context resolves, but no merge engine is wired up behind it."
+                .to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::HudiConfigs;
+    use crate::config::read::HudiReadConfig;
+    use crate::config::table::HudiTableConfig;
+    use crate::file_group::reader_v2::reader_context::ReaderParameters;
+    use crate::file_group::reader_v2::resolver::resolve_reader_context;
+
+    fn context() -> ReaderContext {
+        let configs = HudiConfigs::new([
+            (HudiTableConfig::BasePath.as_ref(), "file:///tmp/t"),
+            (HudiReadConfig::EndTimestamp.as_ref(), "20240101000000000"),
+            (HudiTableConfig::OrderingFields.as_ref(), "ts"),
+        ]);
+        resolve_reader_context(&configs, true).unwrap()
+    }
+
+    /// The context resolves, but there is no engine behind it yet. Reading must
+    /// say so plainly — returning an empty batch would look like a table with no
+    /// rows, which is indistinguishable from a real answer.
+    #[tokio::test]
+    async fn read_reports_that_the_engine_is_not_implemented() {
+        let reader = FileGroupReader::new(context(), ReaderParameters::default());
+
+        let err = reader.read().await.unwrap_err();
+
+        assert!(
+            err.to_string().contains("not yet implemented"),
+            "error should say the engine is missing, got: {err}"
+        );
+    }
+
+    /// Constructing is deliberately separate from reading: later changes fill in
+    /// the engine behind `read`, and callers wiring up a reader should not have
+    /// to handle a failure until they actually ask for rows.
+    #[test]
+    fn construction_succeeds_even_though_reading_does_not() {
+        let reader = FileGroupReader::new(context(), ReaderParameters::default());
+
+        assert_eq!(reader.context().table_path, "file:///tmp/t");
+    }
+}

--- a/crates/core/src/file_group/reader_v2/reader_context.rs
+++ b/crates/core/src/file_group/reader_v2/reader_context.rs
@@ -27,9 +27,15 @@ use std::collections::HashMap;
 ///
 /// The string forms match the merge modes the Hudi Java reader uses, so the
 /// values survive a round trip through engine integrations unchanged.
+#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum MergeMode {
     /// Latest commit wins.
+    ///
+    /// Nothing selects this yet. A table with no ordering field derives
+    /// `append_only`, which the resolver rejects rather than mapping — see
+    /// `resolver::resolve_merge_mode`. Settling that question is what makes
+    /// this reachable, since commit-time ordering is what such a table wants.
     CommitTimeOrdering,
     /// Highest ordering-field value wins.
     EventTimeOrdering,
@@ -46,6 +52,7 @@ impl AsRef<str> for MergeMode {
 
 /// Everything the MOR reader needs that is derived from table state rather
 /// than from the file slice itself.
+#[allow(dead_code)]
 #[derive(Clone, Debug)]
 pub(crate) struct ReaderContext {
     /// Table base path, as configured.
@@ -72,6 +79,7 @@ pub(crate) struct ReaderContext {
 }
 
 /// Flags controlling what the reader emits, independent of table state.
+#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) struct ReaderParameters {
     /// Emit delete records to the caller instead of only applying them.

--- a/crates/core/src/file_group/reader_v2/reader_context.rs
+++ b/crates/core/src/file_group/reader_v2/reader_context.rs
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//! Inputs the merge-on-read file group reader needs for one file slice.
+
+use crate::config::table::BaseFileFormatValue;
+use crate::timeline::selector::InstantRange;
+use std::collections::HashMap;
+
+/// How the reader picks a winner among versions of the same record key.
+///
+/// The string forms match the merge modes the Hudi Java reader uses, so the
+/// values survive a round trip through engine integrations unchanged.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum MergeMode {
+    /// Latest commit wins.
+    CommitTimeOrdering,
+    /// Highest ordering-field value wins.
+    EventTimeOrdering,
+}
+
+impl AsRef<str> for MergeMode {
+    fn as_ref(&self) -> &str {
+        match self {
+            MergeMode::CommitTimeOrdering => "COMMIT_TIME_ORDERING",
+            MergeMode::EventTimeOrdering => "EVENT_TIME_ORDERING",
+        }
+    }
+}
+
+/// Everything the MOR reader needs that is derived from table state rather
+/// than from the file slice itself.
+#[derive(Clone, Debug)]
+pub(crate) struct ReaderContext {
+    /// Table base path, as configured.
+    pub table_path: String,
+    /// Timestamp the read is pinned to. Log blocks at or before this instant
+    /// are visible; later ones are not.
+    pub latest_commit_time: String,
+    /// How to pick a winner among versions of the same record key.
+    pub merge_mode: MergeMode,
+    /// Format of the base file backing the slice.
+    pub base_file_format: BaseFileFormatValue,
+    /// Whether the slice has log files to merge. `false` reduces the read to a
+    /// plain base-file scan.
+    pub has_log_files: bool,
+    /// Window bounding which instants the log scan admits.
+    pub instant_range: InstantRange,
+    /// The table's own properties, keyed by their `hoodie.*` config names.
+    pub table_config: HashMap<String, String>,
+    /// Per-read overrides, keyed by their `hoodie.read.*` config names.
+    pub hoodie_reader_config: HashMap<String, String>,
+    /// Whether to merge log records onto base rows by record position rather
+    /// than by record key.
+    pub should_merge_use_record_position: bool,
+}
+
+/// Flags controlling what the reader emits, independent of table state.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ReaderParameters {
+    /// Emit delete records to the caller instead of only applying them.
+    pub emit_delete: bool,
+    /// Sort the merged output.
+    pub sort_output: bool,
+    /// Admit log blocks from instants that have not completed.
+    pub allow_inflight_instants: bool,
+}

--- a/crates/core/src/file_group/reader_v2/resolver.rs
+++ b/crates/core/src/file_group/reader_v2/resolver.rs
@@ -146,7 +146,9 @@ fn resolve_merge_mode(hudi_configs: &HudiConfigs) -> Result<MergeMode> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::file_group::reader::FileGroupReader;
     use crate::file_group::reader_v2::reader_context::ReaderParameters;
+    use std::sync::Arc;
 
     /// Configs with just enough set for the resolver to succeed. Includes an
     /// ordering field so the table derives `overwrite_with_latest` rather than
@@ -175,6 +177,41 @@ mod tests {
                 .filter(|(k, _)| k != key)
                 .collect::<Vec<_>>(),
         )
+    }
+
+    /// [`resolve_instant_range`] deliberately reproduces the bounds the legacy
+    /// file group reader computes, so that a read through either path admits
+    /// the same log blocks. Nothing but this test enforces that: the two live
+    /// in different modules and neither calls the other, so an edit to one
+    /// would otherwise drift silently.
+    ///
+    /// Compares the `Debug` rendering rather than the fields because
+    /// `InstantRange`'s fields are private — which also means a field added to
+    /// the struct is covered here for free, instead of being silently skipped
+    /// by an explicit field-by-field comparison.
+    #[test]
+    fn instant_range_matches_the_legacy_reader() {
+        let mut options = minimal_configs();
+        options.push((
+            HudiReadConfig::StartTimestamp.as_ref().to_string(),
+            "20230101000000000".to_string(),
+        ));
+        let configs = HudiConfigs::new(options);
+
+        let legacy = FileGroupReader::new_with_overrides(
+            Arc::new(configs.clone()),
+            HashMap::new(),
+            HashMap::new(),
+        )
+        .unwrap()
+        .create_instant_range_for_log_file_scan()
+        .unwrap();
+
+        let resolved = resolve_reader_context(&configs, true)
+            .unwrap()
+            .instant_range;
+
+        assert_eq!(format!("{legacy:?}"), format!("{resolved:?}"));
     }
 
     #[test]

--- a/crates/core/src/file_group/reader_v2/resolver.rs
+++ b/crates/core/src/file_group/reader_v2/resolver.rs
@@ -1,0 +1,360 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//! Derives a [`ReaderContext`] from a table's resolved configs.
+
+use crate::Result;
+use crate::config::HudiConfigs;
+use crate::config::error::ConfigError;
+use crate::config::read::HudiReadConfig;
+use crate::config::table::{BaseFileFormatValue, HudiTableConfig};
+use crate::error::CoreError;
+use crate::file_group::reader_v2::reader_context::{MergeMode, ReaderContext};
+use crate::merge::RecordMergeStrategyValue;
+use crate::timeline::selector::InstantRange;
+use std::collections::HashMap;
+use std::str::FromStr;
+
+/// Resolve the MOR reader context from `hudi_configs`, which the caller has
+/// already merged read options into.
+pub(crate) fn resolve_reader_context(
+    hudi_configs: &HudiConfigs,
+    has_log_files: bool,
+) -> Result<ReaderContext> {
+    let table_path: String = hudi_configs.get(HudiTableConfig::BasePath)?.into();
+
+    // Resolved by `Table::prepare_reader_options` for table-level reads. A
+    // `FileGroupReader` built straight from a base URI never loads the timeline,
+    // so the caller must supply it; defaulting here would silently widen the read.
+    let latest_commit_time: String = hudi_configs
+        .try_get(HudiReadConfig::EndTimestamp)?
+        .ok_or_else(|| ConfigError::NotFound(HudiReadConfig::EndTimestamp.as_ref().to_string()))?
+        .into();
+
+    let merge_mode = resolve_merge_mode(hudi_configs)?;
+    let base_file_format = BaseFileFormatValue::resolve_from_configs(hudi_configs, None)?;
+    let instant_range = resolve_instant_range(hudi_configs)?;
+    let (table_config, hoodie_reader_config) = partition_configs(hudi_configs);
+
+    Ok(ReaderContext {
+        table_path,
+        latest_commit_time,
+        merge_mode,
+        base_file_format,
+        has_log_files,
+        instant_range,
+        table_config,
+        hoodie_reader_config,
+        // Log blocks carry record positions, but no code reads them yet.
+        // Merging by key is what the legacy reader does, so that is what a v2
+        // read must do until the position-based merge lands.
+        should_merge_use_record_position: false,
+    })
+}
+
+/// Prefix identifying a per-read config; everything else is a table property.
+const READ_CONFIG_PREFIX: &str = "hoodie.read.";
+
+/// Split the merged config bag back into table properties and per-read
+/// overrides, so the merge code can tell one from the other.
+fn partition_configs(
+    hudi_configs: &HudiConfigs,
+) -> (HashMap<String, String>, HashMap<String, String>) {
+    let mut table_config = HashMap::new();
+    let mut reader_config = HashMap::new();
+
+    for (key, value) in hudi_configs.as_options() {
+        if key.starts_with(READ_CONFIG_PREFIX) {
+            reader_config.insert(key, value);
+        } else {
+            table_config.insert(key, value);
+        }
+    }
+
+    (table_config, reader_config)
+}
+
+/// Build the window bounding which instants the log scan admits.
+///
+/// Mirrors the bounds the legacy file group reader applies, so a v2 read sees
+/// the same log blocks: exclusive at the start, inclusive at the pinned commit.
+fn resolve_instant_range(hudi_configs: &HudiConfigs) -> Result<InstantRange> {
+    let timezone: String = hudi_configs
+        .get_or_default(HudiTableConfig::TimelineTimezone)
+        .into();
+    let start_timestamp = hudi_configs
+        .try_get(HudiReadConfig::StartTimestamp)?
+        .map(|v| -> String { v.into() });
+    let end_timestamp = hudi_configs
+        .try_get(HudiReadConfig::EndTimestamp)?
+        .map(|v| -> String { v.into() });
+
+    Ok(InstantRange::new(
+        timezone,
+        start_timestamp,
+        end_timestamp,
+        false,
+        true,
+    ))
+}
+
+/// Map the table's record merge strategy onto a MOR [`MergeMode`].
+///
+/// | `hoodie.table.record.merge.strategy` | [`MergeMode`]           |
+/// |-------------------------------------|-------------------------|
+/// | `overwrite_with_latest`             | `EventTimeOrdering`     |
+/// | `append_only`                       | unsupported — see below |
+///
+/// `append_only` has no MOR counterpart: the reader always merges by record
+/// key, so there is no mode that reproduces "keep every version". The table
+/// config derives `append_only` whenever meta fields are disabled or no
+/// ordering field is set, which makes it reachable for ordinary tables — so
+/// this returns an error rather than picking a mode that would change which
+/// rows a query returns.
+fn resolve_merge_mode(hudi_configs: &HudiConfigs) -> Result<MergeMode> {
+    let strategy: String = hudi_configs
+        .get_or_default(HudiTableConfig::RecordMergeStrategy)
+        .into();
+
+    match RecordMergeStrategyValue::from_str(&strategy)? {
+        RecordMergeStrategyValue::OverwriteWithLatest => Ok(MergeMode::EventTimeOrdering),
+        RecordMergeStrategyValue::AppendOnly => Err(CoreError::Unsupported(format!(
+            "Record merge strategy '{}' has no merge-on-read equivalent. \
+             The merge-on-read reader merges by record key, which does not \
+             preserve every record version.",
+            RecordMergeStrategyValue::AppendOnly.as_ref(),
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::file_group::reader_v2::reader_context::ReaderParameters;
+
+    /// Configs with just enough set for the resolver to succeed. Includes an
+    /// ordering field so the table derives `overwrite_with_latest` rather than
+    /// the append-only fallback exercised in its own tests below.
+    fn minimal_configs() -> Vec<(String, String)> {
+        vec![
+            (
+                HudiTableConfig::BasePath.as_ref().to_string(),
+                "file:///tmp/t".to_string(),
+            ),
+            (
+                HudiReadConfig::EndTimestamp.as_ref().to_string(),
+                "20240101000000000".to_string(),
+            ),
+            (
+                HudiTableConfig::OrderingFields.as_ref().to_string(),
+                "ts".to_string(),
+            ),
+        ]
+    }
+
+    fn configs_without(key: &str) -> HudiConfigs {
+        HudiConfigs::new(
+            minimal_configs()
+                .into_iter()
+                .filter(|(k, _)| k != key)
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    #[test]
+    fn resolves_table_path_from_base_path_config() {
+        let configs = HudiConfigs::new(minimal_configs());
+
+        let ctx = resolve_reader_context(&configs, false).unwrap();
+
+        assert_eq!(ctx.table_path, "file:///tmp/t");
+    }
+
+    #[test]
+    fn resolves_latest_commit_time_from_end_timestamp() {
+        let configs = HudiConfigs::new(minimal_configs());
+
+        let ctx = resolve_reader_context(&configs, false).unwrap();
+
+        assert_eq!(ctx.latest_commit_time, "20240101000000000");
+    }
+
+    /// `latest_commit_time` gates which log blocks are visible, so a missing
+    /// value must fail loudly rather than silently reading everything.
+    #[test]
+    fn errors_when_end_timestamp_is_absent() {
+        let configs = configs_without(HudiReadConfig::EndTimestamp.as_ref());
+
+        let err = resolve_reader_context(&configs, false).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains(HudiReadConfig::EndTimestamp.as_ref()),
+            "error should name the missing key, got: {err}"
+        );
+    }
+
+    #[test]
+    fn resolves_has_log_files_from_the_caller() {
+        let configs = HudiConfigs::new(minimal_configs());
+
+        assert!(
+            resolve_reader_context(&configs, true)
+                .unwrap()
+                .has_log_files
+        );
+        assert!(
+            !resolve_reader_context(&configs, false)
+                .unwrap()
+                .has_log_files
+        );
+    }
+
+    #[test]
+    fn defaults_base_file_format_to_parquet() {
+        let configs = HudiConfigs::new(minimal_configs());
+
+        let ctx = resolve_reader_context(&configs, true).unwrap();
+
+        assert_eq!(ctx.base_file_format, BaseFileFormatValue::Parquet);
+    }
+
+    /// The log scan is bounded by the same window the legacy reader uses, so a
+    /// v2 read sees exactly the log blocks a legacy read would.
+    #[test]
+    fn bounds_instant_range_by_the_read_window() {
+        let mut options = minimal_configs();
+        options.push((
+            HudiReadConfig::StartTimestamp.as_ref().to_string(),
+            "20230101000000000".to_string(),
+        ));
+        let configs = HudiConfigs::new(options);
+
+        let ctx = resolve_reader_context(&configs, true).unwrap();
+
+        let rendered = format!("{:?}", ctx.instant_range);
+        assert!(rendered.contains("20230101000000000"), "got: {rendered}");
+        assert!(rendered.contains("20240101000000000"), "got: {rendered}");
+        assert!(
+            rendered.contains("start_inclusive: false"),
+            "incremental reads are exclusive at the start, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("end_inclusive: true"),
+            "the pinned commit is included, got: {rendered}"
+        );
+    }
+
+    /// The reader is handed the table's own configs and the per-read overrides
+    /// as separate maps, so a read config can never be mistaken for a table
+    /// property (or vice versa) once it reaches the merge code.
+    #[test]
+    fn separates_table_configs_from_read_configs() {
+        let configs = HudiConfigs::new(minimal_configs());
+
+        let ctx = resolve_reader_context(&configs, true).unwrap();
+
+        assert_eq!(
+            ctx.table_config
+                .get(HudiTableConfig::OrderingFields.as_ref()),
+            Some(&"ts".to_string())
+        );
+        assert!(
+            !ctx.table_config
+                .contains_key(HudiReadConfig::EndTimestamp.as_ref()),
+            "read configs must not leak into table config"
+        );
+
+        assert_eq!(
+            ctx.hoodie_reader_config
+                .get(HudiReadConfig::EndTimestamp.as_ref()),
+            Some(&"20240101000000000".to_string())
+        );
+        assert!(
+            !ctx.hoodie_reader_config
+                .contains_key(HudiTableConfig::OrderingFields.as_ref()),
+            "table configs must not leak into reader config"
+        );
+    }
+
+    /// Log blocks carry record positions, but nothing reads them yet. Keeping
+    /// this off means a v2 read merges by key exactly as a legacy read does;
+    /// the position-based merge turns it on when it lands.
+    #[test]
+    fn leaves_position_based_merge_off() {
+        let configs = HudiConfigs::new(minimal_configs());
+
+        let ctx = resolve_reader_context(&configs, true).unwrap();
+
+        assert!(!ctx.should_merge_use_record_position);
+    }
+
+    /// Defaults chosen to match what the legacy reader returns today: deletes
+    /// are applied but never emitted, output keeps merge order, and only
+    /// completed instants are read.
+    #[test]
+    fn defaults_reader_parameters_to_legacy_behavior() {
+        let params = ReaderParameters::default();
+
+        assert!(!params.emit_delete);
+        assert!(!params.sort_output);
+        assert!(!params.allow_inflight_instants);
+    }
+
+    #[test]
+    fn maps_overwrite_with_latest_to_event_time_ordering() {
+        let configs = HudiConfigs::new(minimal_configs());
+
+        let ctx = resolve_reader_context(&configs, true).unwrap();
+
+        assert_eq!(ctx.merge_mode, MergeMode::EventTimeOrdering);
+    }
+
+    /// `append_only` has no counterpart in the MOR merge modes — the reader
+    /// always merges by record key. Mapping it to a merge mode silently drops
+    /// rows, so the resolver refuses rather than guessing.
+    #[test]
+    fn rejects_append_only_derived_from_missing_ordering_fields() {
+        let configs = configs_without(HudiTableConfig::OrderingFields.as_ref());
+
+        let err = resolve_reader_context(&configs, true).unwrap_err();
+
+        assert!(
+            err.to_string().contains("append_only"),
+            "error should name the unmapped strategy, got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_append_only_derived_from_disabled_meta_fields() {
+        let mut options = minimal_configs();
+        options.push((
+            HudiTableConfig::PopulatesMetaFields.as_ref().to_string(),
+            "false".to_string(),
+        ));
+        let configs = HudiConfigs::new(options);
+
+        let err = resolve_reader_context(&configs, true).unwrap_err();
+
+        assert!(
+            err.to_string().contains("append_only"),
+            "error should name the unmapped strategy, got: {err}"
+        );
+    }
+}

--- a/crates/core/src/file_group/reader_v2/resolver.rs
+++ b/crates/core/src/file_group/reader_v2/resolver.rs
@@ -33,6 +33,7 @@ use std::str::FromStr;
 
 /// Resolve the MOR reader context from `hudi_configs`, which the caller has
 /// already merged read options into.
+#[allow(dead_code)]
 pub(crate) fn resolve_reader_context(
     hudi_configs: &HudiConfigs,
     has_log_files: bool,
@@ -68,11 +69,23 @@ pub(crate) fn resolve_reader_context(
     })
 }
 
-/// Prefix identifying a per-read config; everything else is a table property.
+/// Prefix identifying a per-read config.
+#[allow(dead_code)]
 const READ_CONFIG_PREFIX: &str = "hoodie.read.";
 
-/// Split the merged config bag back into table properties and per-read
-/// overrides, so the merge code can tell one from the other.
+/// Prefixes identifying configs that steer this crate's own behavior. They are
+/// neither something the table declares about itself nor a per-read override,
+/// so they reach the reader through neither map.
+#[allow(dead_code)]
+const CRATE_CONFIG_PREFIXES: [&str; 2] = ["hoodie.internal.", "hoodie.plan."];
+
+/// Split the merged config bag into the table's own properties and the
+/// per-read overrides, so the merge code can tell one from the other.
+///
+/// Anything belonging to neither is dropped rather than swept into the table
+/// properties: a reader has no way to tell a swept-in crate config from
+/// something the table actually declared.
+#[allow(dead_code)]
 fn partition_configs(
     hudi_configs: &HudiConfigs,
 ) -> (HashMap<String, String>, HashMap<String, String>) {
@@ -82,7 +95,10 @@ fn partition_configs(
     for (key, value) in hudi_configs.as_options() {
         if key.starts_with(READ_CONFIG_PREFIX) {
             reader_config.insert(key, value);
-        } else {
+        } else if !CRATE_CONFIG_PREFIXES
+            .iter()
+            .any(|prefix| key.starts_with(prefix))
+        {
             table_config.insert(key, value);
         }
     }
@@ -94,6 +110,7 @@ fn partition_configs(
 ///
 /// Mirrors the bounds the legacy file group reader applies, so a v2 read sees
 /// the same log blocks: exclusive at the start, inclusive at the pinned commit.
+#[allow(dead_code)]
 fn resolve_instant_range(hudi_configs: &HudiConfigs) -> Result<InstantRange> {
     let timezone: String = hudi_configs
         .get_or_default(HudiTableConfig::TimelineTimezone)
@@ -127,6 +144,7 @@ fn resolve_instant_range(hudi_configs: &HudiConfigs) -> Result<InstantRange> {
 /// ordering field is set, which makes it reachable for ordinary tables — so
 /// this returns an error rather than picking a mode that would change which
 /// rows a query returns.
+#[allow(dead_code)]
 fn resolve_merge_mode(hudi_configs: &HudiConfigs) -> Result<MergeMode> {
     let strategy: String = hudi_configs
         .get_or_default(HudiTableConfig::RecordMergeStrategy)
@@ -146,6 +164,8 @@ fn resolve_merge_mode(hudi_configs: &HudiConfigs) -> Result<MergeMode> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::internal::HudiInternalConfig;
+    use crate::config::plan::HudiPlanConfig;
     use crate::file_group::reader::FileGroupReader;
     use crate::file_group::reader_v2::reader_context::ReaderParameters;
     use std::sync::Arc;
@@ -328,6 +348,38 @@ mod tests {
                 .contains_key(HudiTableConfig::OrderingFields.as_ref()),
             "table configs must not leak into reader config"
         );
+    }
+
+    /// Neither map is a catch-all. Configs that steer this crate's own behavior
+    /// are not table properties and are not per-read overrides, so they belong
+    /// in neither — sweeping them into the table properties would leave a
+    /// reader unable to tell them from something the table declared about
+    /// itself.
+    #[test]
+    fn drops_configs_that_are_neither_table_nor_read() {
+        let crate_configs = [
+            HudiInternalConfig::SkipConfigValidation.as_ref(),
+            HudiInternalConfig::TimelineArchivedReadEnabled.as_ref(),
+            HudiPlanConfig::ListingParallelism.as_ref(),
+        ];
+        let mut options = minimal_configs();
+        for key in crate_configs {
+            options.push((key.to_string(), "1".to_string()));
+        }
+        let configs = HudiConfigs::new(options);
+
+        let ctx = resolve_reader_context(&configs, true).unwrap();
+
+        for key in crate_configs {
+            assert!(
+                !ctx.table_config.contains_key(key),
+                "{key} is not a table property"
+            );
+            assert!(
+                !ctx.hoodie_reader_config.contains_key(key),
+                "{key} is not a per-read override"
+            );
+        }
     }
 
     /// Log blocks carry record positions, but nothing reads them yet. Keeping


### PR DESCRIPTION
## What

Lays the groundwork for the merge-on-read file group reader, in three parts:

1. **`ReaderContext` + resolver** — everything the reader needs that is derived from table state, and the code that derives it from a table's configs.
2. **An equivalence test** — pins that the resolver derives the same instant range the existing file group reader does, so the two cannot drift.
3. **`FileGroupReader` entry point** — the shape callers will use. `read` returns `Unsupported` for now.

Nothing consumes any of it: `reader_v2` is `pub(crate)` and unreferenced. **Public API delta: none.**

## Why this first

This is the first change in a sequence that ports the merge-on-read file group reader. Resolving the context up front gives every later change a defined target to build against, and concentrates the read-semantics decisions in one small reviewable place rather than scattering them across the port.

## Decisions that need review

**`append_only` is rejected rather than mapped.** The merge-on-read reader always merges by record key, so no merge mode reproduces "keep every version". The table config derives `append_only` whenever meta fields are disabled or no ordering field is set, which makes it reachable for ordinary tables — so guessing a mode here would silently change which rows a query returns. This is also why `MergeMode::CommitTimeOrdering` is currently unconstructible; the variant documents what makes it reachable. See `resolver::resolve_merge_mode`.

**`latest_commit_time` is required, not defaulted.** It bounds which log blocks are visible. A `FileGroupReader` built straight from a base URI never loads the timeline, so the caller must supply it — defaulting would silently widen the read.

**`should_merge_use_record_position` stays off.** Log blocks already carry record positions but nothing reads them, so merging by key is what a read does today.

## Notable

`FileGroupReader::create_instant_range_for_log_file_scan` is widened from private to `pub(crate)` so the equivalence test can reach it. Visibility only — no behavior change, and its two existing call sites are untouched.

The new type shares a name with the existing `FileGroupReader`, which it replaces once the engine behind it is written. It carries the name it will keep, so the eventual swap is a module deletion rather than a rename touching every call site; until then the two are told apart by module path.

## Deferred

The schema handler, the record context, and the bootstrap flags — until something reads them. `merge_strategy_id` and `iterator_mode` are omitted too: the merger dispatches on the merge mode, and only one iterator mode is implemented.

## Testing

16 unit tests, written test-first. The two non-trivial assertions were checked by mutation — the equivalence test was confirmed to catch both a flipped range bound and a dropped start timestamp, and the not-implemented test was confirmed to fail when asserting the wrong message.

Full workspace suite green (903 tests); `cargo fmt --check` clean; no clippy findings in the new module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
