### PR TITLE
feat(core): port the reader's stats, profiling, and input-split leaves

### DIFF
--- a/crates/core/src/file_group/mod.rs
+++ b/crates/core/src/file_group/mod.rs
@@ -25,6 +25,7 @@ pub mod builder;
 pub mod file_slice;
 pub mod log_file;
 pub mod reader;
+pub(crate) mod reader_v2;
 pub mod record_batches;
 
 use crate::Result;

--- a/crates/core/src/file_group/reader.rs
+++ b/crates/core/src/file_group/reader.rs
@@ -177,7 +177,9 @@ impl FileGroupReader {
         apply_commit_time_filter(&self.hudi_configs, records)
     }
 
-    fn create_instant_range_for_log_file_scan(&self) -> Result<InstantRange> {
+    /// Visible to the crate so the merge-on-read context resolver can assert it
+    /// derives the same range; see `reader_v2::resolver`.
+    pub(crate) fn create_instant_range_for_log_file_scan(&self) -> Result<InstantRange> {
         let timezone = self
             .hudi_configs
             .get_or_default(HudiTableConfig::TimelineTimezone)

--- a/crates/core/src/file_group/reader_v2/input_split.rs
+++ b/crates/core/src/file_group/reader_v2/input_split.rs
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//! Ported from the merge-on-read reader. Nothing consumes it yet, so its
+//! items are unreachable from the crate's call graph until the reader wires in.
+#![allow(dead_code)]
+
+//! Mirrors `org.apache.hudi.common.table.read.InputSplit`.
+//!
+//! Describes the data to be read from a file group: an optional base file,
+//! a list of log files, and the partition path context.
+
+use crate::file_group::log_file::LogFile;
+use std::str::FromStr;
+
+/// Describes the input data for a file group read.
+///
+/// Carries the base file (if any), the list of log files to scan,
+/// the partition path, and the byte range to read from the base file.
+#[derive(Debug, Clone)]
+pub struct InputSplit {
+    /// Path to the base file (relative to table root), if present.
+    pub base_file_path: Option<String>,
+
+    /// Commit time of the base file, if present.
+    pub base_file_commit_time: Option<String>,
+
+    /// Relative paths to log files to scan.
+    pub log_file_paths: Vec<String>,
+
+    /// Partition path for this file group (e.g. "year=2024/month=01").
+    pub partition_path: String,
+
+    /// Byte offset to start reading from in the base file.
+    pub start: i64,
+
+    /// Number of bytes to read from the base file.
+    pub length: i64,
+}
+
+/// CDC log-file suffix. Mirrors Java's `HoodieCDCUtils.CDC_LOGFILE_SUFFIX` (".cdc").
+/// CDC log files carry change-data-capture blocks and must be excluded from a
+/// normal snapshot read — gold drops them in `InputSplit`'s constructor
+/// (`InputSplit.java:57`).
+const CDC_LOGFILE_SUFFIX: &str = ".cdc";
+
+impl InputSplit {
+    pub fn new(
+        base_file_path: Option<String>,
+        base_file_commit_time: Option<String>,
+        log_file_paths: Vec<String>,
+        partition_path: String,
+    ) -> Self {
+        // Filter out CDC log files, then sort ascending by
+        // deltaCommitTime → logVersion → writeToken. This mirrors Java's
+        // InputSplit constructor (InputSplit.java:56-58), which sorts via
+        // HoodieLogFile.getLogFileComparator() and filters file names ending in
+        // HoodieCDCUtils.CDC_LOGFILE_SUFFIX. The C++ side may send log files in
+        // descending order (from FileSlice's reverse TreeSet), so we re-sort.
+        let log_file_paths = Self::filter_cdc_log_files(log_file_paths);
+        let log_file_paths = Self::sort_log_file_paths(log_file_paths);
+        Self {
+            base_file_path,
+            base_file_commit_time,
+            log_file_paths,
+            partition_path,
+            start: 0,
+            length: -1,
+        }
+    }
+
+    /// Drop CDC log files from the scan list.
+    ///
+    /// Mirrors Java's `InputSplit` constructor filter
+    /// (`InputSplit.java:57`): `!logFile.getFileName().endsWith(CDC_LOGFILE_SUFFIX)`.
+    /// The match is on the file-name portion (after the last `/`), matching gold's
+    /// `getFileName()` semantics.
+    fn filter_cdc_log_files(paths: Vec<String>) -> Vec<String> {
+        paths
+            .into_iter()
+            .filter(|p| {
+                let name = p.rsplit('/').next().unwrap_or(p);
+                !name.ends_with(CDC_LOGFILE_SUFFIX)
+            })
+            .collect()
+    }
+
+    /// Sort log file paths ascending by deltaCommitTime → logVersion → writeToken.
+    ///
+    /// Mirrors Java's `InputSplit` constructor which sorts via
+    /// `HoodieLogFile.getLogFileComparator()`.
+    fn sort_log_file_paths(mut paths: Vec<String>) -> Vec<String> {
+        if paths.len() <= 1 {
+            return paths;
+        }
+        paths.sort_by(|a, b| {
+            let name_a = a.rsplit('/').next().unwrap_or(a);
+            let name_b = b.rsplit('/').next().unwrap_or(b);
+            match (LogFile::from_str(name_a), LogFile::from_str(name_b)) {
+                (Ok(lf_a), Ok(lf_b)) => lf_a.cmp(&lf_b),
+                _ => a.cmp(b), // fallback to lexicographic if parsing fails
+            }
+        });
+        paths
+    }
+
+    /// Returns true if there are log files that need to be merged with the base file.
+    pub fn has_log_files(&self) -> bool {
+        !self.log_file_paths.is_empty()
+    }
+
+    /// Returns true if there is no base file and no log files.
+    pub fn has_no_records_to_merge(&self) -> bool {
+        !self.has_log_files()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Java's InputSplit sorts log files ascending by deltaCommitTime → logVersion → writeToken
+    /// (via HoodieLogFile.getLogFileComparator()). The C++ side sends them in descending order
+    /// (from FileSlice's reverse TreeSet). InputSplit must re-sort to ascending.
+    #[test]
+    fn test_log_file_paths_sorted_ascending() {
+        // Log files in DESCENDING deltaCommitTime order (as C++ sends them)
+        let log_files = vec![
+            ".72d44234-0_20260408194651210.log.1_0-272-505".to_string(), // NEWER
+            ".72d44234-0_20260408194649548.log.1_0-254-473".to_string(), // OLDER
+        ];
+
+        let split = InputSplit::new(
+            Some("base.parquet".to_string()),
+            None,
+            log_files,
+            String::new(),
+        );
+
+        // Must be re-sorted to ASCENDING deltaCommitTime
+        assert_eq!(split.log_file_paths.len(), 2);
+        assert!(
+            split.log_file_paths[0].contains("20260408194649548"),
+            "First log file should be the OLDER commit, got: {}",
+            split.log_file_paths[0]
+        );
+        assert!(
+            split.log_file_paths[1].contains("20260408194651210"),
+            "Second log file should be the NEWER commit, got: {}",
+            split.log_file_paths[1]
+        );
+    }
+
+    /// Same deltaCommitTime, different logVersions — should sort by version ascending.
+    #[test]
+    fn test_log_file_paths_sorted_by_version() {
+        let log_files = vec![
+            ".fileId-0_20260408194649548.log.3_0-100-200".to_string(), // version 3
+            ".fileId-0_20260408194649548.log.1_0-100-200".to_string(), // version 1
+            ".fileId-0_20260408194649548.log.2_0-100-200".to_string(), // version 2
+        ];
+
+        let split = InputSplit::new(None, None, log_files, String::new());
+
+        assert!(split.log_file_paths[0].contains(".log.1_"));
+        assert!(split.log_file_paths[1].contains(".log.2_"));
+        assert!(split.log_file_paths[2].contains(".log.3_"));
+    }
+
+    /// With partition path prefix — sort should work on the file name portion.
+    #[test]
+    fn test_log_file_paths_sorted_with_partition_prefix() {
+        let log_files = vec![
+            "year=2024/month=01/.fileId-0_20260408194651210.log.1_0-272-505".to_string(),
+            "year=2024/month=01/.fileId-0_20260408194649548.log.1_0-254-473".to_string(),
+        ];
+
+        let split = InputSplit::new(None, None, log_files, "year=2024/month=01".to_string());
+
+        assert!(split.log_file_paths[0].contains("20260408194649548"));
+        assert!(split.log_file_paths[1].contains("20260408194651210"));
+    }
+
+    /// CDC log files (`.cdc` suffix) must be dropped from the scan list, mirroring
+    /// gold's `InputSplit` constructor filter (`InputSplit.java:57`,
+    /// `HoodieCDCUtils.CDC_LOGFILE_SUFFIX`). A normal snapshot read must not pull
+    /// in change-data-capture blocks.
+    #[test]
+    fn test_cdc_log_files_filtered_out() {
+        let log_files = vec![
+            ".fileId-0_20260408194649548.log.1_0-100-200".to_string(), // normal
+            ".fileId-0_20260408194651210.log.2_0-101-201.cdc".to_string(), // CDC — must be dropped
+            ".fileId-0_20260408194652000.log.3_0-102-202".to_string(), // normal
+        ];
+
+        let split = InputSplit::new(None, None, log_files, String::new());
+
+        assert_eq!(
+            split.log_file_paths.len(),
+            2,
+            "CDC log file should be excluded, got: {:?}",
+            split.log_file_paths
+        );
+        assert!(
+            split.log_file_paths.iter().all(|p| !p.ends_with(".cdc")),
+            "no remaining log file should be a .cdc file, got: {:?}",
+            split.log_file_paths
+        );
+        // The two normal log files survive and are sorted ascending.
+        assert!(split.log_file_paths[0].contains("20260408194649548"));
+        assert!(split.log_file_paths[1].contains("20260408194652000"));
+    }
+
+    /// CDC filter matches on the file-name portion when a partition prefix is present.
+    #[test]
+    fn test_cdc_log_files_filtered_with_partition_prefix() {
+        let log_files = vec![
+            "year=2024/.fileId-0_20260408194649548.log.1_0-100-200".to_string(),
+            "year=2024/.fileId-0_20260408194651210.log.2_0-101-201.cdc".to_string(),
+        ];
+
+        let split = InputSplit::new(None, None, log_files, "year=2024".to_string());
+
+        assert_eq!(split.log_file_paths.len(), 1);
+        assert!(split.log_file_paths[0].contains("20260408194649548"));
+    }
+
+    /// Empty or single log file — no sorting needed, should not crash.
+    #[test]
+    fn test_log_file_paths_empty_and_single() {
+        let split_empty = InputSplit::new(None, None, vec![], String::new());
+        assert!(split_empty.log_file_paths.is_empty());
+
+        let split_single = InputSplit::new(
+            None,
+            None,
+            vec![".fileId-0_20260408194649548.log.1_0-254-473".to_string()],
+            String::new(),
+        );
+        assert_eq!(split_single.log_file_paths.len(), 1);
+    }
+}

--- a/crates/core/src/file_group/reader_v2/iterator_mode.rs
+++ b/crates/core/src/file_group/reader_v2/iterator_mode.rs
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//! Ported from the merge-on-read reader. Nothing consumes it yet, so its
+//! items are unreachable from the crate's call graph until the reader wires in.
+#![allow(dead_code)]
+
+//! Mirrors `org.apache.hudi.common.table.read.IteratorMode`.
+//!
+//! Controls what form the output records take when iterating.
+
+/// The mode in which the file group reader yields records.
+///
+/// In Java Hudi, this controls whether the iterator produces engine-native
+/// records, HoodieRecord wrappers, or just record keys.
+///
+/// In hudi-rs, we always work with Arrow RecordBatch, so `EngineRecord`
+/// is the primary mode. The other modes are kept for API symmetry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum IteratorMode {
+    /// Yield engine-native records (Arrow RecordBatch in Rust).
+    #[default]
+    EngineRecord,
+
+    /// Yield HoodieRecord wrappers (not yet implemented in Rust).
+    HoodieRecord,
+
+    /// Yield only record keys (not yet implemented in Rust).
+    RecordKey,
+}
+
+impl IteratorMode {
+    pub fn from_str_opt(s: &str) -> Option<Self> {
+        match s {
+            "ENGINE_RECORD" => Some(Self::EngineRecord),
+            "HOODIE_RECORD" => Some(Self::HoodieRecord),
+            "RECORD_KEY" => Some(Self::RecordKey),
+            _ => None,
+        }
+    }
+}

--- a/crates/core/src/file_group/reader_v2/mod.rs
+++ b/crates/core/src/file_group/reader_v2/mod.rs
@@ -24,12 +24,16 @@
 //! itself lands in later changes, and the existing read path is untouched
 //! until it does.
 //!
-//! Everything here is therefore unreachable from the crate's call graph. Each
-//! item that needs it carries its own `allow(dead_code)`, rather than a blanket
-//! allow on the module: a module-wide one would also silence an item that is
-//! dead by mistake, and this module has a lot of growing left to do. Drop the
-//! per-item allows as the reader wires in.
+//! Everything here is therefore unreachable from the crate's call graph, which
+//! the `allow(dead_code)` on each file silences. Hand-written items carry the
+//! allow per item so a mistakenly-dead one still warns; files ported wholesale
+//! carry it at file scope, since every item in them is live upstream. Drop the
+//! allows as the reader wires in.
 
+pub(crate) mod input_split;
+pub(crate) mod iterator_mode;
+pub(crate) mod profiling;
+pub(crate) mod read_stats;
 pub(crate) mod reader;
 pub(crate) mod reader_context;
 pub(crate) mod resolver;

--- a/crates/core/src/file_group/reader_v2/mod.rs
+++ b/crates/core/src/file_group/reader_v2/mod.rs
@@ -28,5 +28,6 @@
 //! is what the allow below silences. Remove it once the reader wires in.
 #![allow(dead_code)]
 
+pub(crate) mod reader;
 pub(crate) mod reader_context;
 pub(crate) mod resolver;

--- a/crates/core/src/file_group/reader_v2/mod.rs
+++ b/crates/core/src/file_group/reader_v2/mod.rs
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//! Context types for the merge-on-read file group reader.
+//!
+//! This module holds the inputs the MOR reader needs and the resolver that
+//! derives them from a table's configs. Nothing consumes it yet — the reader
+//! itself lands in later changes, and the existing read path is untouched
+//! until it does.
+//!
+//! Everything here is therefore unreachable from the crate's call graph, which
+//! is what the allow below silences. Remove it once the reader wires in.
+#![allow(dead_code)]
+
+pub(crate) mod reader_context;
+pub(crate) mod resolver;

--- a/crates/core/src/file_group/reader_v2/mod.rs
+++ b/crates/core/src/file_group/reader_v2/mod.rs
@@ -24,9 +24,11 @@
 //! itself lands in later changes, and the existing read path is untouched
 //! until it does.
 //!
-//! Everything here is therefore unreachable from the crate's call graph, which
-//! is what the allow below silences. Remove it once the reader wires in.
-#![allow(dead_code)]
+//! Everything here is therefore unreachable from the crate's call graph. Each
+//! item that needs it carries its own `allow(dead_code)`, rather than a blanket
+//! allow on the module: a module-wide one would also silence an item that is
+//! dead by mistake, and this module has a lot of growing left to do. Drop the
+//! per-item allows as the reader wires in.
 
 pub(crate) mod reader;
 pub(crate) mod reader_context;

--- a/crates/core/src/file_group/reader_v2/profiling.rs
+++ b/crates/core/src/file_group/reader_v2/profiling.rs
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//! Ported from the merge-on-read reader. Nothing consumes it yet, so its
+//! items are unreachable from the crate's call graph until the reader wires in.
+#![allow(dead_code, unused_macros, unused_imports)]
+
+//! Stage-timing profiling primitives for the file-group reader (perf harness).
+//!
+//! A single canonical write path for the per-stage wall-time counters, so the
+//! `let s = Instant::now(); …; self.x [+]= s.elapsed()…` shape isn't copy-pasted
+//! at every timing site. Inlining (rather than an RAII/`Drop` guard) is
+//! deliberate: a guard holding `&mut self.field` for the scope would double-borrow
+//! `self` against bodies that also need `&mut self` (e.g.
+//! `process_queued_blocks_for_instant`); a macro releases the body's borrow before
+//! the field write.
+
+/// Record wall-ms of `$body` once into the u64 place `$dst`.
+///
+/// Where the body is a single fallible expression, keep `?` OUTSIDE the macro so
+/// the elapsed time is still attributed on the error path.
+macro_rules! profile_once {
+    ($dst:expr, $body:expr) => {{
+        let __start = std::time::Instant::now();
+        #[allow(clippy::let_unit_value)]
+        let __out = $body;
+        $dst = __start.elapsed().as_millis() as u64;
+        __out
+    }};
+}
+
+pub(crate) use profile_once;

--- a/crates/core/src/file_group/reader_v2/read_stats.rs
+++ b/crates/core/src/file_group/reader_v2/read_stats.rs
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//! Ported from the merge-on-read reader. Nothing consumes it yet, so its
+//! items are unreachable from the crate's call graph until the reader wires in.
+#![allow(dead_code)]
+
+//! Mirrors `org.apache.hudi.common.table.read.HoodieReadStats`.
+//!
+//! Mutable accumulator for read statistics, written during log scanning
+//! and buffer processing, read by the caller after the read completes.
+
+/// Mutable accumulator for file group read statistics.
+#[derive(Debug, Clone, Default)]
+pub struct HoodieReadStats {
+    pub num_inserts: u64,
+    pub num_updates: u64,
+    pub num_deletes: u64,
+    pub total_log_read_time_ms: u64,
+    pub total_log_records: u64,
+    pub total_log_files_compacted: u64,
+    pub total_log_blocks: u64,
+    pub total_corrupt_log_blocks: u64,
+    pub total_rollback_blocks: u64,
+
+    // ── Stage timings (perf harness) ───────────────────────
+    // Cheap monotonic `Instant`-based accumulators wired at the matching
+    // code sites. Always-on, accumulated per block/batch (never per row).
+    // Used by `benchmark/filegroup` (fg-bench) to attribute wall time across
+    // the read pipeline. Zero behavioral effect — instrumentation only.
+    //
+    /// Wall ms spent reading + projecting the base parquet file
+    /// (`HoodieFileGroupReader::make_base_file_batches`).
+    pub base_read_ms: u64,
+    /// Wall ms spent reading log-block metadata + bytes off storage during the
+    /// log scan Pass-1 (`BaseHoodieLogRecordReader::scan_internal`).
+    pub log_block_read_ms: u64,
+    /// Wall ms spent inflating/decoding log blocks into arrow batches
+    /// (`LogBlock::inflate`, accumulated inside the record buffer).
+    /// NOTE: in hudi-rs inflate/decode is triggered lazily inside the buffer's
+    /// `process_data_block`, so this is measured there and is a SUBSET of the
+    /// `merge_insert_ms` window below (decode is nested inside merge insert).
+    pub log_block_decode_ms: u64,
+    /// Wall ms spent dispatching decoded log records into the merge map
+    /// (`process_queued_blocks_for_instant`: inflate/decode + per-key upsert).
+    pub merge_insert_ms: u64,
+    /// Wall ms spent in the final base+log merge collect
+    /// (`merge_and_collect_with_stats`).
+    pub final_merge_ms: u64,
+    /// Wall ms spent building/projecting the output batch
+    /// (`apply_output_converter` + base-only concat path).
+    pub output_build_ms: u64,
+    /// Peak number of entries held in the merge map during the log scan.
+    pub merge_map_peak_entries: u64,
+
+    // ── Spillable merge map (A1, ENG-42993) ──────────────────────────────
+    /// True if the size-tracked merge map spilled any entry to disk (RocksDB)
+    /// during the scan — i.e. the in-memory budget was exceeded. This is the M3
+    /// acceptance signal: a low `hoodie.memory.merge.max.size` should set it.
+    pub merge_map_spilled: bool,
+    /// Peak TRUE-retained in-memory bytes the merge map held during the scan
+    /// (A6e): the sum of the distinct pinned source batches' `get_array_memory_size`
+    /// plus owned/key/overhead bytes — NOT the pre-A6 per-row share, which
+    /// under-counted dense spread-key `BatchRef` maps (M5: stat read ~budget while
+    /// RSS was 21.9 GB). Bounded by `0.8 × hoodie.memory.merge.max.size − rocksdb
+    /// reserved` once A6e eviction is active, so a benchmark can confirm the
+    /// in-memory footprint stayed within budget while the rest spilled.
+    pub merge_map_peak_in_memory_bytes: u64,
+}

--- a/crates/core/src/file_group/reader_v2/reader.rs
+++ b/crates/core/src/file_group/reader_v2/reader.rs
@@ -38,11 +38,13 @@ use arrow_array::RecordBatch;
 /// Serves both table types: a merge-on-read slice merges its log records onto
 /// the base file, and a copy-on-write slice is the same read with no log files
 /// to merge.
+#[allow(dead_code)]
 pub(crate) struct FileGroupReader {
     context: ReaderContext,
     parameters: ReaderParameters,
 }
 
+#[allow(dead_code)]
 impl FileGroupReader {
     pub(crate) fn new(context: ReaderContext, parameters: ReaderParameters) -> Self {
         Self {
@@ -110,13 +112,20 @@ mod tests {
         );
     }
 
-    /// Constructing is deliberately separate from reading: later changes fill in
-    /// the engine behind `read`, and callers wiring up a reader should not have
-    /// to handle a failure until they actually ask for rows.
+    /// The reader hands back what it was built with, rather than re-deriving or
+    /// defaulting it. Uses non-default parameters so that substituting defaults
+    /// somewhere in construction would fail this rather than pass unnoticed.
     #[test]
-    fn construction_succeeds_even_though_reading_does_not() {
-        let reader = FileGroupReader::new(context(), ReaderParameters::default());
+    fn holds_the_context_and_parameters_it_was_built_with() {
+        let parameters = ReaderParameters {
+            emit_delete: true,
+            sort_output: true,
+            allow_inflight_instants: true,
+        };
+
+        let reader = FileGroupReader::new(context(), parameters);
 
         assert_eq!(reader.context().table_path, "file:///tmp/t");
+        assert_eq!(*reader.parameters(), parameters);
     }
 }

--- a/crates/core/src/file_group/reader_v2/reader.rs
+++ b/crates/core/src/file_group/reader_v2/reader.rs
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//! The file group reader.
+//!
+//! Only the entry point exists so far. It is here ahead of the engine so that
+//! the shape callers will use is settled, and so the gap is something tests can
+//! point at rather than an absence.
+//!
+//! Shares a name with [`crate::file_group::reader::FileGroupReader`], which
+//! reads file groups today. This one replaces it once the engine behind it is
+//! written, so it carries the name it will keep; until then, reach for either
+//! by module path. Nothing outside this module uses this one yet.
+
+use crate::Result;
+use crate::error::CoreError;
+use crate::file_group::reader_v2::reader_context::{ReaderContext, ReaderParameters};
+use arrow_array::RecordBatch;
+
+/// Reads one file slice.
+///
+/// Serves both table types: a merge-on-read slice merges its log records onto
+/// the base file, and a copy-on-write slice is the same read with no log files
+/// to merge.
+pub(crate) struct FileGroupReader {
+    context: ReaderContext,
+    parameters: ReaderParameters,
+}
+
+impl FileGroupReader {
+    pub(crate) fn new(context: ReaderContext, parameters: ReaderParameters) -> Self {
+        Self {
+            context,
+            parameters,
+        }
+    }
+
+    /// What the reader was resolved to read.
+    pub(crate) fn context(&self) -> &ReaderContext {
+        &self.context
+    }
+
+    /// Flags controlling what this reader emits.
+    pub(crate) fn parameters(&self) -> &ReaderParameters {
+        &self.parameters
+    }
+
+    /// Read the file slice and return the merged rows.
+    ///
+    /// # Errors
+    /// Always, for now: the merge engine has not been written. Failing is the
+    /// point — an empty batch would be indistinguishable from a file slice that
+    /// genuinely has no rows, and would let an unfinished reader look like it
+    /// worked.
+    pub(crate) async fn read(&self) -> Result<RecordBatch> {
+        Err(CoreError::Unsupported(
+            "The merge-on-read file group reader is not yet implemented. \
+             Its context resolves, but no merge engine is wired up behind it."
+                .to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::HudiConfigs;
+    use crate::config::read::HudiReadConfig;
+    use crate::config::table::HudiTableConfig;
+    use crate::file_group::reader_v2::reader_context::ReaderParameters;
+    use crate::file_group::reader_v2::resolver::resolve_reader_context;
+
+    fn context() -> ReaderContext {
+        let configs = HudiConfigs::new([
+            (HudiTableConfig::BasePath.as_ref(), "file:///tmp/t"),
+            (HudiReadConfig::EndTimestamp.as_ref(), "20240101000000000"),
+            (HudiTableConfig::OrderingFields.as_ref(), "ts"),
+        ]);
+        resolve_reader_context(&configs, true).unwrap()
+    }
+
+    /// The context resolves, but there is no engine behind it yet. Reading must
+    /// say so plainly — returning an empty batch would look like a table with no
+    /// rows, which is indistinguishable from a real answer.
+    #[tokio::test]
+    async fn read_reports_that_the_engine_is_not_implemented() {
+        let reader = FileGroupReader::new(context(), ReaderParameters::default());
+
+        let err = reader.read().await.unwrap_err();
+
+        assert!(
+            err.to_string().contains("not yet implemented"),
+            "error should say the engine is missing, got: {err}"
+        );
+    }
+
+    /// Constructing is deliberately separate from reading: later changes fill in
+    /// the engine behind `read`, and callers wiring up a reader should not have
+    /// to handle a failure until they actually ask for rows.
+    #[test]
+    fn construction_succeeds_even_though_reading_does_not() {
+        let reader = FileGroupReader::new(context(), ReaderParameters::default());
+
+        assert_eq!(reader.context().table_path, "file:///tmp/t");
+    }
+}

--- a/crates/core/src/file_group/reader_v2/reader_context.rs
+++ b/crates/core/src/file_group/reader_v2/reader_context.rs
@@ -27,9 +27,15 @@ use std::collections::HashMap;
 ///
 /// The string forms match the merge modes the Hudi Java reader uses, so the
 /// values survive a round trip through engine integrations unchanged.
+#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum MergeMode {
     /// Latest commit wins.
+    ///
+    /// Nothing selects this yet. A table with no ordering field derives
+    /// `append_only`, which the resolver rejects rather than mapping — see
+    /// `resolver::resolve_merge_mode`. Settling that question is what makes
+    /// this reachable, since commit-time ordering is what such a table wants.
     CommitTimeOrdering,
     /// Highest ordering-field value wins.
     EventTimeOrdering,
@@ -46,6 +52,7 @@ impl AsRef<str> for MergeMode {
 
 /// Everything the MOR reader needs that is derived from table state rather
 /// than from the file slice itself.
+#[allow(dead_code)]
 #[derive(Clone, Debug)]
 pub(crate) struct ReaderContext {
     /// Table base path, as configured.
@@ -72,6 +79,7 @@ pub(crate) struct ReaderContext {
 }
 
 /// Flags controlling what the reader emits, independent of table state.
+#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) struct ReaderParameters {
     /// Emit delete records to the caller instead of only applying them.

--- a/crates/core/src/file_group/reader_v2/reader_context.rs
+++ b/crates/core/src/file_group/reader_v2/reader_context.rs
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//! Inputs the merge-on-read file group reader needs for one file slice.
+
+use crate::config::table::BaseFileFormatValue;
+use crate::timeline::selector::InstantRange;
+use std::collections::HashMap;
+
+/// How the reader picks a winner among versions of the same record key.
+///
+/// The string forms match the merge modes the Hudi Java reader uses, so the
+/// values survive a round trip through engine integrations unchanged.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum MergeMode {
+    /// Latest commit wins.
+    CommitTimeOrdering,
+    /// Highest ordering-field value wins.
+    EventTimeOrdering,
+}
+
+impl AsRef<str> for MergeMode {
+    fn as_ref(&self) -> &str {
+        match self {
+            MergeMode::CommitTimeOrdering => "COMMIT_TIME_ORDERING",
+            MergeMode::EventTimeOrdering => "EVENT_TIME_ORDERING",
+        }
+    }
+}
+
+/// Everything the MOR reader needs that is derived from table state rather
+/// than from the file slice itself.
+#[derive(Clone, Debug)]
+pub(crate) struct ReaderContext {
+    /// Table base path, as configured.
+    pub table_path: String,
+    /// Timestamp the read is pinned to. Log blocks at or before this instant
+    /// are visible; later ones are not.
+    pub latest_commit_time: String,
+    /// How to pick a winner among versions of the same record key.
+    pub merge_mode: MergeMode,
+    /// Format of the base file backing the slice.
+    pub base_file_format: BaseFileFormatValue,
+    /// Whether the slice has log files to merge. `false` reduces the read to a
+    /// plain base-file scan.
+    pub has_log_files: bool,
+    /// Window bounding which instants the log scan admits.
+    pub instant_range: InstantRange,
+    /// The table's own properties, keyed by their `hoodie.*` config names.
+    pub table_config: HashMap<String, String>,
+    /// Per-read overrides, keyed by their `hoodie.read.*` config names.
+    pub hoodie_reader_config: HashMap<String, String>,
+    /// Whether to merge log records onto base rows by record position rather
+    /// than by record key.
+    pub should_merge_use_record_position: bool,
+}
+
+/// Flags controlling what the reader emits, independent of table state.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ReaderParameters {
+    /// Emit delete records to the caller instead of only applying them.
+    pub emit_delete: bool,
+    /// Sort the merged output.
+    pub sort_output: bool,
+    /// Admit log blocks from instants that have not completed.
+    pub allow_inflight_instants: bool,
+}

--- a/crates/core/src/file_group/reader_v2/resolver.rs
+++ b/crates/core/src/file_group/reader_v2/resolver.rs
@@ -146,7 +146,9 @@ fn resolve_merge_mode(hudi_configs: &HudiConfigs) -> Result<MergeMode> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::file_group::reader::FileGroupReader;
     use crate::file_group::reader_v2::reader_context::ReaderParameters;
+    use std::sync::Arc;
 
     /// Configs with just enough set for the resolver to succeed. Includes an
     /// ordering field so the table derives `overwrite_with_latest` rather than
@@ -175,6 +177,41 @@ mod tests {
                 .filter(|(k, _)| k != key)
                 .collect::<Vec<_>>(),
         )
+    }
+
+    /// [`resolve_instant_range`] deliberately reproduces the bounds the legacy
+    /// file group reader computes, so that a read through either path admits
+    /// the same log blocks. Nothing but this test enforces that: the two live
+    /// in different modules and neither calls the other, so an edit to one
+    /// would otherwise drift silently.
+    ///
+    /// Compares the `Debug` rendering rather than the fields because
+    /// `InstantRange`'s fields are private — which also means a field added to
+    /// the struct is covered here for free, instead of being silently skipped
+    /// by an explicit field-by-field comparison.
+    #[test]
+    fn instant_range_matches_the_legacy_reader() {
+        let mut options = minimal_configs();
+        options.push((
+            HudiReadConfig::StartTimestamp.as_ref().to_string(),
+            "20230101000000000".to_string(),
+        ));
+        let configs = HudiConfigs::new(options);
+
+        let legacy = FileGroupReader::new_with_overrides(
+            Arc::new(configs.clone()),
+            HashMap::new(),
+            HashMap::new(),
+        )
+        .unwrap()
+        .create_instant_range_for_log_file_scan()
+        .unwrap();
+
+        let resolved = resolve_reader_context(&configs, true)
+            .unwrap()
+            .instant_range;
+
+        assert_eq!(format!("{legacy:?}"), format!("{resolved:?}"));
     }
 
     #[test]

--- a/crates/core/src/file_group/reader_v2/resolver.rs
+++ b/crates/core/src/file_group/reader_v2/resolver.rs
@@ -1,0 +1,360 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//! Derives a [`ReaderContext`] from a table's resolved configs.
+
+use crate::Result;
+use crate::config::HudiConfigs;
+use crate::config::error::ConfigError;
+use crate::config::read::HudiReadConfig;
+use crate::config::table::{BaseFileFormatValue, HudiTableConfig};
+use crate::error::CoreError;
+use crate::file_group::reader_v2::reader_context::{MergeMode, ReaderContext};
+use crate::merge::RecordMergeStrategyValue;
+use crate::timeline::selector::InstantRange;
+use std::collections::HashMap;
+use std::str::FromStr;
+
+/// Resolve the MOR reader context from `hudi_configs`, which the caller has
+/// already merged read options into.
+pub(crate) fn resolve_reader_context(
+    hudi_configs: &HudiConfigs,
+    has_log_files: bool,
+) -> Result<ReaderContext> {
+    let table_path: String = hudi_configs.get(HudiTableConfig::BasePath)?.into();
+
+    // Resolved by `Table::prepare_reader_options` for table-level reads. A
+    // `FileGroupReader` built straight from a base URI never loads the timeline,
+    // so the caller must supply it; defaulting here would silently widen the read.
+    let latest_commit_time: String = hudi_configs
+        .try_get(HudiReadConfig::EndTimestamp)?
+        .ok_or_else(|| ConfigError::NotFound(HudiReadConfig::EndTimestamp.as_ref().to_string()))?
+        .into();
+
+    let merge_mode = resolve_merge_mode(hudi_configs)?;
+    let base_file_format = BaseFileFormatValue::resolve_from_configs(hudi_configs, None)?;
+    let instant_range = resolve_instant_range(hudi_configs)?;
+    let (table_config, hoodie_reader_config) = partition_configs(hudi_configs);
+
+    Ok(ReaderContext {
+        table_path,
+        latest_commit_time,
+        merge_mode,
+        base_file_format,
+        has_log_files,
+        instant_range,
+        table_config,
+        hoodie_reader_config,
+        // Log blocks carry record positions, but no code reads them yet.
+        // Merging by key is what the legacy reader does, so that is what a v2
+        // read must do until the position-based merge lands.
+        should_merge_use_record_position: false,
+    })
+}
+
+/// Prefix identifying a per-read config; everything else is a table property.
+const READ_CONFIG_PREFIX: &str = "hoodie.read.";
+
+/// Split the merged config bag back into table properties and per-read
+/// overrides, so the merge code can tell one from the other.
+fn partition_configs(
+    hudi_configs: &HudiConfigs,
+) -> (HashMap<String, String>, HashMap<String, String>) {
+    let mut table_config = HashMap::new();
+    let mut reader_config = HashMap::new();
+
+    for (key, value) in hudi_configs.as_options() {
+        if key.starts_with(READ_CONFIG_PREFIX) {
+            reader_config.insert(key, value);
+        } else {
+            table_config.insert(key, value);
+        }
+    }
+
+    (table_config, reader_config)
+}
+
+/// Build the window bounding which instants the log scan admits.
+///
+/// Mirrors the bounds the legacy file group reader applies, so a v2 read sees
+/// the same log blocks: exclusive at the start, inclusive at the pinned commit.
+fn resolve_instant_range(hudi_configs: &HudiConfigs) -> Result<InstantRange> {
+    let timezone: String = hudi_configs
+        .get_or_default(HudiTableConfig::TimelineTimezone)
+        .into();
+    let start_timestamp = hudi_configs
+        .try_get(HudiReadConfig::StartTimestamp)?
+        .map(|v| -> String { v.into() });
+    let end_timestamp = hudi_configs
+        .try_get(HudiReadConfig::EndTimestamp)?
+        .map(|v| -> String { v.into() });
+
+    Ok(InstantRange::new(
+        timezone,
+        start_timestamp,
+        end_timestamp,
+        false,
+        true,
+    ))
+}
+
+/// Map the table's record merge strategy onto a MOR [`MergeMode`].
+///
+/// | `hoodie.table.record.merge.strategy` | [`MergeMode`]           |
+/// |-------------------------------------|-------------------------|
+/// | `overwrite_with_latest`             | `EventTimeOrdering`     |
+/// | `append_only`                       | unsupported — see below |
+///
+/// `append_only` has no MOR counterpart: the reader always merges by record
+/// key, so there is no mode that reproduces "keep every version". The table
+/// config derives `append_only` whenever meta fields are disabled or no
+/// ordering field is set, which makes it reachable for ordinary tables — so
+/// this returns an error rather than picking a mode that would change which
+/// rows a query returns.
+fn resolve_merge_mode(hudi_configs: &HudiConfigs) -> Result<MergeMode> {
+    let strategy: String = hudi_configs
+        .get_or_default(HudiTableConfig::RecordMergeStrategy)
+        .into();
+
+    match RecordMergeStrategyValue::from_str(&strategy)? {
+        RecordMergeStrategyValue::OverwriteWithLatest => Ok(MergeMode::EventTimeOrdering),
+        RecordMergeStrategyValue::AppendOnly => Err(CoreError::Unsupported(format!(
+            "Record merge strategy '{}' has no merge-on-read equivalent. \
+             The merge-on-read reader merges by record key, which does not \
+             preserve every record version.",
+            RecordMergeStrategyValue::AppendOnly.as_ref(),
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::file_group::reader_v2::reader_context::ReaderParameters;
+
+    /// Configs with just enough set for the resolver to succeed. Includes an
+    /// ordering field so the table derives `overwrite_with_latest` rather than
+    /// the append-only fallback exercised in its own tests below.
+    fn minimal_configs() -> Vec<(String, String)> {
+        vec![
+            (
+                HudiTableConfig::BasePath.as_ref().to_string(),
+                "file:///tmp/t".to_string(),
+            ),
+            (
+                HudiReadConfig::EndTimestamp.as_ref().to_string(),
+                "20240101000000000".to_string(),
+            ),
+            (
+                HudiTableConfig::OrderingFields.as_ref().to_string(),
+                "ts".to_string(),
+            ),
+        ]
+    }
+
+    fn configs_without(key: &str) -> HudiConfigs {
+        HudiConfigs::new(
+            minimal_configs()
+                .into_iter()
+                .filter(|(k, _)| k != key)
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    #[test]
+    fn resolves_table_path_from_base_path_config() {
+        let configs = HudiConfigs::new(minimal_configs());
+
+        let ctx = resolve_reader_context(&configs, false).unwrap();
+
+        assert_eq!(ctx.table_path, "file:///tmp/t");
+    }
+
+    #[test]
+    fn resolves_latest_commit_time_from_end_timestamp() {
+        let configs = HudiConfigs::new(minimal_configs());
+
+        let ctx = resolve_reader_context(&configs, false).unwrap();
+
+        assert_eq!(ctx.latest_commit_time, "20240101000000000");
+    }
+
+    /// `latest_commit_time` gates which log blocks are visible, so a missing
+    /// value must fail loudly rather than silently reading everything.
+    #[test]
+    fn errors_when_end_timestamp_is_absent() {
+        let configs = configs_without(HudiReadConfig::EndTimestamp.as_ref());
+
+        let err = resolve_reader_context(&configs, false).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains(HudiReadConfig::EndTimestamp.as_ref()),
+            "error should name the missing key, got: {err}"
+        );
+    }
+
+    #[test]
+    fn resolves_has_log_files_from_the_caller() {
+        let configs = HudiConfigs::new(minimal_configs());
+
+        assert!(
+            resolve_reader_context(&configs, true)
+                .unwrap()
+                .has_log_files
+        );
+        assert!(
+            !resolve_reader_context(&configs, false)
+                .unwrap()
+                .has_log_files
+        );
+    }
+
+    #[test]
+    fn defaults_base_file_format_to_parquet() {
+        let configs = HudiConfigs::new(minimal_configs());
+
+        let ctx = resolve_reader_context(&configs, true).unwrap();
+
+        assert_eq!(ctx.base_file_format, BaseFileFormatValue::Parquet);
+    }
+
+    /// The log scan is bounded by the same window the legacy reader uses, so a
+    /// v2 read sees exactly the log blocks a legacy read would.
+    #[test]
+    fn bounds_instant_range_by_the_read_window() {
+        let mut options = minimal_configs();
+        options.push((
+            HudiReadConfig::StartTimestamp.as_ref().to_string(),
+            "20230101000000000".to_string(),
+        ));
+        let configs = HudiConfigs::new(options);
+
+        let ctx = resolve_reader_context(&configs, true).unwrap();
+
+        let rendered = format!("{:?}", ctx.instant_range);
+        assert!(rendered.contains("20230101000000000"), "got: {rendered}");
+        assert!(rendered.contains("20240101000000000"), "got: {rendered}");
+        assert!(
+            rendered.contains("start_inclusive: false"),
+            "incremental reads are exclusive at the start, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("end_inclusive: true"),
+            "the pinned commit is included, got: {rendered}"
+        );
+    }
+
+    /// The reader is handed the table's own configs and the per-read overrides
+    /// as separate maps, so a read config can never be mistaken for a table
+    /// property (or vice versa) once it reaches the merge code.
+    #[test]
+    fn separates_table_configs_from_read_configs() {
+        let configs = HudiConfigs::new(minimal_configs());
+
+        let ctx = resolve_reader_context(&configs, true).unwrap();
+
+        assert_eq!(
+            ctx.table_config
+                .get(HudiTableConfig::OrderingFields.as_ref()),
+            Some(&"ts".to_string())
+        );
+        assert!(
+            !ctx.table_config
+                .contains_key(HudiReadConfig::EndTimestamp.as_ref()),
+            "read configs must not leak into table config"
+        );
+
+        assert_eq!(
+            ctx.hoodie_reader_config
+                .get(HudiReadConfig::EndTimestamp.as_ref()),
+            Some(&"20240101000000000".to_string())
+        );
+        assert!(
+            !ctx.hoodie_reader_config
+                .contains_key(HudiTableConfig::OrderingFields.as_ref()),
+            "table configs must not leak into reader config"
+        );
+    }
+
+    /// Log blocks carry record positions, but nothing reads them yet. Keeping
+    /// this off means a v2 read merges by key exactly as a legacy read does;
+    /// the position-based merge turns it on when it lands.
+    #[test]
+    fn leaves_position_based_merge_off() {
+        let configs = HudiConfigs::new(minimal_configs());
+
+        let ctx = resolve_reader_context(&configs, true).unwrap();
+
+        assert!(!ctx.should_merge_use_record_position);
+    }
+
+    /// Defaults chosen to match what the legacy reader returns today: deletes
+    /// are applied but never emitted, output keeps merge order, and only
+    /// completed instants are read.
+    #[test]
+    fn defaults_reader_parameters_to_legacy_behavior() {
+        let params = ReaderParameters::default();
+
+        assert!(!params.emit_delete);
+        assert!(!params.sort_output);
+        assert!(!params.allow_inflight_instants);
+    }
+
+    #[test]
+    fn maps_overwrite_with_latest_to_event_time_ordering() {
+        let configs = HudiConfigs::new(minimal_configs());
+
+        let ctx = resolve_reader_context(&configs, true).unwrap();
+
+        assert_eq!(ctx.merge_mode, MergeMode::EventTimeOrdering);
+    }
+
+    /// `append_only` has no counterpart in the MOR merge modes — the reader
+    /// always merges by record key. Mapping it to a merge mode silently drops
+    /// rows, so the resolver refuses rather than guessing.
+    #[test]
+    fn rejects_append_only_derived_from_missing_ordering_fields() {
+        let configs = configs_without(HudiTableConfig::OrderingFields.as_ref());
+
+        let err = resolve_reader_context(&configs, true).unwrap_err();
+
+        assert!(
+            err.to_string().contains("append_only"),
+            "error should name the unmapped strategy, got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_append_only_derived_from_disabled_meta_fields() {
+        let mut options = minimal_configs();
+        options.push((
+            HudiTableConfig::PopulatesMetaFields.as_ref().to_string(),
+            "false".to_string(),
+        ));
+        let configs = HudiConfigs::new(options);
+
+        let err = resolve_reader_context(&configs, true).unwrap_err();
+
+        assert!(
+            err.to_string().contains("append_only"),
+            "error should name the unmapped strategy, got: {err}"
+        );
+    }
+}

--- a/crates/core/src/file_group/reader_v2/resolver.rs
+++ b/crates/core/src/file_group/reader_v2/resolver.rs
@@ -33,6 +33,7 @@ use std::str::FromStr;
 
 /// Resolve the MOR reader context from `hudi_configs`, which the caller has
 /// already merged read options into.
+#[allow(dead_code)]
 pub(crate) fn resolve_reader_context(
     hudi_configs: &HudiConfigs,
     has_log_files: bool,
@@ -68,11 +69,23 @@ pub(crate) fn resolve_reader_context(
     })
 }
 
-/// Prefix identifying a per-read config; everything else is a table property.
+/// Prefix identifying a per-read config.
+#[allow(dead_code)]
 const READ_CONFIG_PREFIX: &str = "hoodie.read.";
 
-/// Split the merged config bag back into table properties and per-read
-/// overrides, so the merge code can tell one from the other.
+/// Prefixes identifying configs that steer this crate's own behavior. They are
+/// neither something the table declares about itself nor a per-read override,
+/// so they reach the reader through neither map.
+#[allow(dead_code)]
+const CRATE_CONFIG_PREFIXES: [&str; 2] = ["hoodie.internal.", "hoodie.plan."];
+
+/// Split the merged config bag into the table's own properties and the
+/// per-read overrides, so the merge code can tell one from the other.
+///
+/// Anything belonging to neither is dropped rather than swept into the table
+/// properties: a reader has no way to tell a swept-in crate config from
+/// something the table actually declared.
+#[allow(dead_code)]
 fn partition_configs(
     hudi_configs: &HudiConfigs,
 ) -> (HashMap<String, String>, HashMap<String, String>) {
@@ -82,7 +95,10 @@ fn partition_configs(
     for (key, value) in hudi_configs.as_options() {
         if key.starts_with(READ_CONFIG_PREFIX) {
             reader_config.insert(key, value);
-        } else {
+        } else if !CRATE_CONFIG_PREFIXES
+            .iter()
+            .any(|prefix| key.starts_with(prefix))
+        {
             table_config.insert(key, value);
         }
     }
@@ -94,6 +110,7 @@ fn partition_configs(
 ///
 /// Mirrors the bounds the legacy file group reader applies, so a v2 read sees
 /// the same log blocks: exclusive at the start, inclusive at the pinned commit.
+#[allow(dead_code)]
 fn resolve_instant_range(hudi_configs: &HudiConfigs) -> Result<InstantRange> {
     let timezone: String = hudi_configs
         .get_or_default(HudiTableConfig::TimelineTimezone)
@@ -127,6 +144,7 @@ fn resolve_instant_range(hudi_configs: &HudiConfigs) -> Result<InstantRange> {
 /// ordering field is set, which makes it reachable for ordinary tables — so
 /// this returns an error rather than picking a mode that would change which
 /// rows a query returns.
+#[allow(dead_code)]
 fn resolve_merge_mode(hudi_configs: &HudiConfigs) -> Result<MergeMode> {
     let strategy: String = hudi_configs
         .get_or_default(HudiTableConfig::RecordMergeStrategy)
@@ -146,6 +164,8 @@ fn resolve_merge_mode(hudi_configs: &HudiConfigs) -> Result<MergeMode> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::internal::HudiInternalConfig;
+    use crate::config::plan::HudiPlanConfig;
     use crate::file_group::reader::FileGroupReader;
     use crate::file_group::reader_v2::reader_context::ReaderParameters;
     use std::sync::Arc;
@@ -328,6 +348,38 @@ mod tests {
                 .contains_key(HudiTableConfig::OrderingFields.as_ref()),
             "table configs must not leak into reader config"
         );
+    }
+
+    /// Neither map is a catch-all. Configs that steer this crate's own behavior
+    /// are not table properties and are not per-read overrides, so they belong
+    /// in neither — sweeping them into the table properties would leave a
+    /// reader unable to tell them from something the table declared about
+    /// itself.
+    #[test]
+    fn drops_configs_that_are_neither_table_nor_read() {
+        let crate_configs = [
+            HudiInternalConfig::SkipConfigValidation.as_ref(),
+            HudiInternalConfig::TimelineArchivedReadEnabled.as_ref(),
+            HudiPlanConfig::ListingParallelism.as_ref(),
+        ];
+        let mut options = minimal_configs();
+        for key in crate_configs {
+            options.push((key.to_string(), "1".to_string()));
+        }
+        let configs = HudiConfigs::new(options);
+
+        let ctx = resolve_reader_context(&configs, true).unwrap();
+
+        for key in crate_configs {
+            assert!(
+                !ctx.table_config.contains_key(key),
+                "{key} is not a table property"
+            );
+            assert!(
+                !ctx.hoodie_reader_config.contains_key(key),
+                "{key} is not a per-read override"
+            );
+        }
     }
 
     /// Log blocks carry record positions, but nothing reads them yet. Keeping


### PR DESCRIPTION
**Stacked on #639** — that PR's commits appear here until it merges. **Review only the last commit** (`port the reader's stats, profiling, and input-split leaves`).

## What

Four leaf modules of the merge-on-read reader, ported as-is: `read_stats`, `profiling`, `iterator_mode`, `input_split`. They have no dependencies inside the reader subsystem, so they need no adaptation.

Nothing consumes them — `reader_v2` stays `pub(crate)` and unreferenced, and the existing read path is untouched. **Public API delta: none.**

## Note on dead_code

Ported files carry a file-scope `allow(dead_code)`; every item in them is live upstream, so a per-item allow would be noise. Hand-written items (in #639) keep per-item allows so a mistakenly-dead one still warns.

Build warning-free; suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)