### PR TITLE
feat(core): port the reader's delete context and output converter

### DIFF
--- a/crates/core/src/file_group/mod.rs
+++ b/crates/core/src/file_group/mod.rs
@@ -25,6 +25,7 @@ pub mod builder;
 pub mod file_slice;
 pub mod log_file;
 pub mod reader;
+pub(crate) mod reader_v2;
 pub mod record_batches;
 
 use crate::Result;

--- a/crates/core/src/file_group/reader.rs
+++ b/crates/core/src/file_group/reader.rs
@@ -177,7 +177,9 @@ impl FileGroupReader {
         apply_commit_time_filter(&self.hudi_configs, records)
     }
 
-    fn create_instant_range_for_log_file_scan(&self) -> Result<InstantRange> {
+    /// Visible to the crate so the merge-on-read context resolver can assert it
+    /// derives the same range; see `reader_v2::resolver`.
+    pub(crate) fn create_instant_range_for_log_file_scan(&self) -> Result<InstantRange> {
         let timezone = self
             .hudi_configs
             .get_or_default(HudiTableConfig::TimelineTimezone)

--- a/crates/core/src/file_group/reader_v2/delete_context.rs
+++ b/crates/core/src/file_group/reader_v2/delete_context.rs
@@ -1,0 +1,343 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//! Ported from the merge-on-read reader. Nothing consumes it yet, so its
+//! items are unreachable from the crate's call graph until the reader wires in.
+#![allow(dead_code)]
+
+//! Mirrors `org.apache.hudi.common.table.read.DeleteContext`.
+//!
+//! Knows how to detect delete operations from schema metadata and
+//! table properties. Constructed in two phases:
+//! 1. `new(properties, table_schema)` — in the schema handler
+//! 2. `with_reader_schema(reader_schema)` — in the record buffer
+
+use arrow_schema::SchemaRef;
+use std::collections::HashMap;
+
+/// Context for detecting delete records in the merge pipeline.
+///
+/// Built from table properties and schema. Tells the buffer
+/// "how do I detect a delete in a record?"
+///
+/// ## Java counterpart
+/// `org.apache.hudi.common.table.read.DeleteContext`
+///
+/// ## Two-phase construction (mirrors Java)
+/// - Phase 1: `new(props, table_schema)` — created in `FileGroupReaderSchemaHandler`
+///   Sets `custom_delete_marker` and `has_built_in_delete_field` from props + tableSchema.
+/// - Phase 2: `with_reader_schema(schema)` — called in `FileGroupRecordBuffer`
+///   Sets `reader_schema` and computes `hoodie_operation_pos` from the reader schema.
+#[derive(Debug, Clone)]
+pub struct DeleteContext {
+    /// Custom delete marker key-value pair, if configured.
+    /// When set, a record is considered deleted if it contains this key-value.
+    /// Sourced from `DELETE_KEY` and `DELETE_MARKER` table properties.
+    pub custom_delete_marker: Option<(String, String)>,
+
+    /// Whether the schema has a built-in delete field (`_hoodie_is_deleted`).
+    pub has_built_in_delete_field: bool,
+
+    /// Position of the `_hoodie_operation` field in the reader schema, if present.
+    pub hoodie_operation_pos: Option<usize>,
+
+    /// The reader schema.
+    pub reader_schema: SchemaRef,
+}
+
+/// Property key for the custom delete marker field name.
+/// Mirrors Java's `DefaultHoodieRecordPayload.DELETE_KEY`.
+const DELETE_KEY_PROP: &str = "hoodie.payload.delete.field";
+
+/// Property key for the custom delete marker value.
+/// Mirrors Java's `DefaultHoodieRecordPayload.DELETE_MARKER`.
+const DELETE_MARKER_PROP: &str = "hoodie.payload.delete.marker";
+
+/// Prefix under which the delete key/marker are persisted in the table config.
+/// Mirrors Java's `HoodieTableConfig.RECORD_MERGE_PROPERTY_PREFIX`;
+/// `HoodieTableConfig.getTableMergeProperties()` extracts keys with this prefix
+/// (stripping it) into the reader's merge properties.
+const RECORD_MERGE_PROPERTY_PREFIX: &str = "hoodie.record.merge.property.";
+
+/// Table config key for the table version (Java `HoodieTableConfig.VERSION`). Below
+/// version NINE, legacy payload classes have their delete key/marker synthesized in
+/// `getTableMergeProperties()` rather than stored as properties.
+const TABLE_VERSION_KEY: &str = "hoodie.table.version";
+
+/// First table version (Java `HoodieTableVersion.NINE`) that persists legacy-payload
+/// merge properties directly, so no payload-class synthesis is needed at or above it.
+const MERGE_PROPS_SYNTHESIS_MAX_TABLE_VERSION: i32 = 9;
+
+/// Payload-class config keys, checked in Java `HoodieRecordPayload.getPayloadClassName`
+/// order (write class, then persisted table-config classes).
+const PAYLOAD_CLASS_KEYS: [&str; 3] = [
+    "hoodie.compaction.payload.class",
+    "hoodie.datasource.write.payload.class",
+    "hoodie.table.legacy.payload.class",
+];
+
+impl DeleteContext {
+    /// Phase 1: Create a `DeleteContext` from table properties and table schema.
+    ///
+    /// Mirrors Java's `new DeleteContext(Properties props, Schema tableSchema)`.
+    /// - Extracts custom delete marker from properties (DELETE_KEY, DELETE_MARKER).
+    /// - Checks if `_hoodie_is_deleted` field exists in the table schema.
+    /// - `hoodie_operation_pos` is NOT set here (set in `with_reader_schema`).
+    pub fn new(props: &HashMap<String, String>, table_schema: &SchemaRef) -> Self {
+        let custom_delete_marker = Self::get_custom_delete_marker(props);
+        let has_built_in_delete_field = table_schema
+            .column_with_name("_hoodie_is_deleted")
+            .is_some();
+
+        Self {
+            custom_delete_marker,
+            has_built_in_delete_field,
+            hoodie_operation_pos: None,
+            reader_schema: table_schema.clone(),
+        }
+    }
+
+    /// Create a `DeleteContext` from table properties only (no schema yet).
+    ///
+    /// Used at buffer construction time when the reader schema is not yet
+    /// available. Uses conservative defaults for schema-dependent fields
+    /// (`has_built_in_delete_field = true`) so that `is_delete_record` falls
+    /// through to runtime column lookups rather than skipping checks.
+    ///
+    /// Call `with_reader_schema()` later to provide actual schema info.
+    pub fn from_props(props: &HashMap<String, String>) -> Self {
+        let custom_delete_marker = Self::get_custom_delete_marker(props);
+        Self {
+            custom_delete_marker,
+            // Conservative: assume field might exist; is_delete_record will
+            // do a runtime column lookup and handle absence gracefully.
+            has_built_in_delete_field: true,
+            hoodie_operation_pos: None,
+            reader_schema: arrow_schema::Schema::empty().into(),
+        }
+    }
+
+    /// Phase 2: Enrich with the reader schema.
+    ///
+    /// Mirrors Java's `DeleteContext.withReaderSchema(Schema readerSchema)`.
+    /// Sets `reader_schema` and computes `hoodie_operation_pos` and
+    /// `has_built_in_delete_field` from it.
+    pub fn with_reader_schema(mut self, schema: SchemaRef) -> Self {
+        self.has_built_in_delete_field = schema.column_with_name("_hoodie_is_deleted").is_some();
+        self.hoodie_operation_pos = schema
+            .column_with_name("_hoodie_operation")
+            .map(|(idx, _)| idx);
+        self.reader_schema = schema;
+        self
+    }
+
+    /// Convenience: create from reader schema only (no properties).
+    ///
+    /// Used when properties are not available (e.g., in tests or simple paths).
+    pub fn from_reader_schema(schema: SchemaRef) -> Self {
+        let has_built_in_delete_field = schema.column_with_name("_hoodie_is_deleted").is_some();
+
+        let hoodie_operation_pos = schema
+            .column_with_name("_hoodie_operation")
+            .map(|(idx, _)| idx);
+
+        Self {
+            custom_delete_marker: None,
+            has_built_in_delete_field,
+            hoodie_operation_pos,
+            reader_schema: schema,
+        }
+    }
+
+    /// Extract the custom delete marker key-value from the table properties.
+    ///
+    /// Mirrors Java's `DeleteContext.getCustomDeleteMarkerKeyValue(Properties)` where
+    /// the properties are `HoodieTableConfig.getTableMergeProperties()`. hudi-rs
+    /// receives the RAW table config, so it must reproduce that method:
+    /// 1. The delete key/marker are persisted under the
+    ///    [`RECORD_MERGE_PROPERTY_PREFIX`] (e.g. a v9 `DefaultHoodieRecordPayload`
+    ///    table sets `hoodie.record.merge.property.hoodie.payload.delete.field`). The
+    ///    non-prefixed form is also accepted in case a caller already stripped it.
+    /// 2. For a table below version NINE, the delete key/marker for the legacy
+    ///    `AWSDmsAvroPayload` / `MySqlDebeziumAvroPayload` / `PostgresDebeziumAvroPayload`
+    ///    payloads are SYNTHESIZED from the payload class (they are not stored).
+    ///
+    /// Both the key and marker must be present and non-empty (matching Java's
+    /// `DELETE_MARKER should be configured with DELETE_KEY` invariant).
+    fn get_custom_delete_marker(props: &HashMap<String, String>) -> Option<(String, String)> {
+        // (1) Prefixed (as persisted) or bare Java delete key/marker.
+        let lookup = |suffix: &str| {
+            props
+                .get(&format!("{RECORD_MERGE_PROPERTY_PREFIX}{suffix}"))
+                .or_else(|| props.get(suffix))
+                .filter(|v| !v.is_empty())
+                .cloned()
+        };
+        if let (Some(key), Some(marker)) = (lookup(DELETE_KEY_PROP), lookup(DELETE_MARKER_PROP)) {
+            return Some((key, marker));
+        }
+
+        // (2) Legacy-payload synthesis for tables below version NINE.
+        Self::synthesize_legacy_delete_marker(props)
+    }
+
+    /// Synthesize the delete key/marker from the payload class for tables below
+    /// version NINE, mirroring Java `HoodieTableConfig.getTableMergeProperties()`.
+    /// Returns `None` for version >= NINE (properties are persisted, not synthesized),
+    /// an unparseable version, or a payload class without a legacy delete convention.
+    fn synthesize_legacy_delete_marker(
+        props: &HashMap<String, String>,
+    ) -> Option<(String, String)> {
+        let version = props.get(TABLE_VERSION_KEY)?.trim().parse::<i32>().ok()?;
+        if version >= MERGE_PROPS_SYNTHESIS_MAX_TABLE_VERSION {
+            return None;
+        }
+        let payload_class = PAYLOAD_CLASS_KEYS
+            .iter()
+            .find_map(|k| props.get(*k))
+            .map(String::as_str)?;
+        // Debezium op column / delete op (`DebeziumConstants`) and AWS DMS `Op`/`D`
+        // (`AWSDmsAvroPayload`). Matched by class-name suffix to tolerate shading.
+        if payload_class.ends_with("AWSDmsAvroPayload") {
+            Some(("Op".to_string(), "D".to_string()))
+        } else if payload_class.ends_with("MySqlDebeziumAvroPayload")
+            || payload_class.ends_with("PostgresDebeziumAvroPayload")
+        {
+            Some(("_change_operation_type".to_string(), "d".to_string()))
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_schema::{DataType, Field, Schema};
+    use std::sync::Arc;
+
+    fn schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("_hoodie_record_key", DataType::Utf8, false),
+            Field::new("Op", DataType::Utf8, true),
+            Field::new("val", DataType::Int64, true),
+        ]))
+    }
+
+    /// G-D: the custom delete marker MUST be read under the Java property keys
+    /// (`hoodie.payload.delete.field` / `.marker`, persisted under the
+    /// `hoodie.record.merge.property.` prefix) — NOT the non-existent
+    /// `hoodie.datasource.write.payload.delete.*` keys hudi-rs used before. A record
+    /// whose marker field equals the marker value is then a delete.
+    ///
+    /// Discriminating: with the old (wrong) keys, the same config produced NO custom
+    /// delete marker, so the marked record was NOT detected as a delete.
+    #[test]
+    fn test_custom_delete_marker_read_under_java_keys() {
+        let props = HashMap::from([
+            (
+                "hoodie.record.merge.property.hoodie.payload.delete.field".to_string(),
+                "Op".to_string(),
+            ),
+            (
+                "hoodie.record.merge.property.hoodie.payload.delete.marker".to_string(),
+                "D".to_string(),
+            ),
+        ]);
+        let ctx = DeleteContext::new(&props, &schema());
+        assert_eq!(
+            ctx.custom_delete_marker,
+            Some(("Op".to_string(), "D".to_string())),
+            "custom delete marker must be read under the Java keys"
+        );
+
+        // The non-prefixed Java keys are also accepted (already-stripped merge props).
+        let bare = HashMap::from([
+            ("hoodie.payload.delete.field".to_string(), "Op".to_string()),
+            ("hoodie.payload.delete.marker".to_string(), "D".to_string()),
+        ]);
+        assert_eq!(
+            DeleteContext::new(&bare, &schema()).custom_delete_marker,
+            Some(("Op".to_string(), "D".to_string()))
+        );
+
+        // The OLD hudi-rs keys must NOT be honored (they do not exist in Java).
+        let old_keys = HashMap::from([
+            (
+                "hoodie.datasource.write.payload.delete.field".to_string(),
+                "Op".to_string(),
+            ),
+            (
+                "hoodie.datasource.write.payload.delete.marker".to_string(),
+                "D".to_string(),
+            ),
+        ]);
+        assert_eq!(
+            DeleteContext::new(&old_keys, &schema()).custom_delete_marker,
+            None,
+            "the non-Java (old hudi-rs) keys must NOT configure a delete marker"
+        );
+    }
+
+    /// G-D: for a table below version NINE, a legacy payload's delete key/marker are
+    /// SYNTHESIZED from the payload class (mirrors Java `getTableMergeProperties`).
+    /// At/above version NINE they are persisted, not synthesized.
+    #[test]
+    fn test_legacy_payload_delete_marker_synthesis() {
+        let aws_v6 = HashMap::from([
+            ("hoodie.table.version".to_string(), "6".to_string()),
+            (
+                "hoodie.compaction.payload.class".to_string(),
+                "org.apache.hudi.common.model.AWSDmsAvroPayload".to_string(),
+            ),
+        ]);
+        assert_eq!(
+            DeleteContext::new(&aws_v6, &schema()).custom_delete_marker,
+            Some(("Op".to_string(), "D".to_string())),
+            "AWS DMS payload (v6) synthesizes Op/D"
+        );
+
+        let pg_v6 = HashMap::from([
+            ("hoodie.table.version".to_string(), "6".to_string()),
+            (
+                "hoodie.datasource.write.payload.class".to_string(),
+                "org.apache.hudi.common.model.debezium.PostgresDebeziumAvroPayload".to_string(),
+            ),
+        ]);
+        assert_eq!(
+            DeleteContext::new(&pg_v6, &schema()).custom_delete_marker,
+            Some(("_change_operation_type".to_string(), "d".to_string())),
+            "Postgres Debezium payload (v6) synthesizes _change_operation_type/d"
+        );
+
+        // Version >= NINE: no synthesis (properties would be persisted instead).
+        let aws_v9 = HashMap::from([
+            ("hoodie.table.version".to_string(), "9".to_string()),
+            (
+                "hoodie.compaction.payload.class".to_string(),
+                "org.apache.hudi.common.model.AWSDmsAvroPayload".to_string(),
+            ),
+        ]);
+        assert_eq!(
+            DeleteContext::new(&aws_v9, &schema()).custom_delete_marker,
+            None,
+            "v9+ does not synthesize; the marker is persisted as a merge property"
+        );
+    }
+}

--- a/crates/core/src/file_group/reader_v2/input_split.rs
+++ b/crates/core/src/file_group/reader_v2/input_split.rs
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//! Ported from the merge-on-read reader. Nothing consumes it yet, so its
+//! items are unreachable from the crate's call graph until the reader wires in.
+#![allow(dead_code)]
+
+//! Mirrors `org.apache.hudi.common.table.read.InputSplit`.
+//!
+//! Describes the data to be read from a file group: an optional base file,
+//! a list of log files, and the partition path context.
+
+use crate::file_group::log_file::LogFile;
+use std::str::FromStr;
+
+/// Describes the input data for a file group read.
+///
+/// Carries the base file (if any), the list of log files to scan,
+/// the partition path, and the byte range to read from the base file.
+#[derive(Debug, Clone)]
+pub struct InputSplit {
+    /// Path to the base file (relative to table root), if present.
+    pub base_file_path: Option<String>,
+
+    /// Commit time of the base file, if present.
+    pub base_file_commit_time: Option<String>,
+
+    /// Relative paths to log files to scan.
+    pub log_file_paths: Vec<String>,
+
+    /// Partition path for this file group (e.g. "year=2024/month=01").
+    pub partition_path: String,
+
+    /// Byte offset to start reading from in the base file.
+    pub start: i64,
+
+    /// Number of bytes to read from the base file.
+    pub length: i64,
+}
+
+/// CDC log-file suffix. Mirrors Java's `HoodieCDCUtils.CDC_LOGFILE_SUFFIX` (".cdc").
+/// CDC log files carry change-data-capture blocks and must be excluded from a
+/// normal snapshot read — gold drops them in `InputSplit`'s constructor
+/// (`InputSplit.java:57`).
+const CDC_LOGFILE_SUFFIX: &str = ".cdc";
+
+impl InputSplit {
+    pub fn new(
+        base_file_path: Option<String>,
+        base_file_commit_time: Option<String>,
+        log_file_paths: Vec<String>,
+        partition_path: String,
+    ) -> Self {
+        // Filter out CDC log files, then sort ascending by
+        // deltaCommitTime → logVersion → writeToken. This mirrors Java's
+        // InputSplit constructor (InputSplit.java:56-58), which sorts via
+        // HoodieLogFile.getLogFileComparator() and filters file names ending in
+        // HoodieCDCUtils.CDC_LOGFILE_SUFFIX. The C++ side may send log files in
+        // descending order (from FileSlice's reverse TreeSet), so we re-sort.
+        let log_file_paths = Self::filter_cdc_log_files(log_file_paths);
+        let log_file_paths = Self::sort_log_file_paths(log_file_paths);
+        Self {
+            base_file_path,
+            base_file_commit_time,
+            log_file_paths,
+            partition_path,
+            start: 0,
+            length: -1,
+        }
+    }
+
+    /// Drop CDC log files from the scan list.
+    ///
+    /// Mirrors Java's `InputSplit` constructor filter
+    /// (`InputSplit.java:57`): `!logFile.getFileName().endsWith(CDC_LOGFILE_SUFFIX)`.
+    /// The match is on the file-name portion (after the last `/`), matching gold's
+    /// `getFileName()` semantics.
+    fn filter_cdc_log_files(paths: Vec<String>) -> Vec<String> {
+        paths
+            .into_iter()
+            .filter(|p| {
+                let name = p.rsplit('/').next().unwrap_or(p);
+                !name.ends_with(CDC_LOGFILE_SUFFIX)
+            })
+            .collect()
+    }
+
+    /// Sort log file paths ascending by deltaCommitTime → logVersion → writeToken.
+    ///
+    /// Mirrors Java's `InputSplit` constructor which sorts via
+    /// `HoodieLogFile.getLogFileComparator()`.
+    fn sort_log_file_paths(mut paths: Vec<String>) -> Vec<String> {
+        if paths.len() <= 1 {
+            return paths;
+        }
+        paths.sort_by(|a, b| {
+            let name_a = a.rsplit('/').next().unwrap_or(a);
+            let name_b = b.rsplit('/').next().unwrap_or(b);
+            match (LogFile::from_str(name_a), LogFile::from_str(name_b)) {
+                (Ok(lf_a), Ok(lf_b)) => lf_a.cmp(&lf_b),
+                _ => a.cmp(b), // fallback to lexicographic if parsing fails
+            }
+        });
+        paths
+    }
+
+    /// Returns true if there are log files that need to be merged with the base file.
+    pub fn has_log_files(&self) -> bool {
+        !self.log_file_paths.is_empty()
+    }
+
+    /// Returns true if there is no base file and no log files.
+    pub fn has_no_records_to_merge(&self) -> bool {
+        !self.has_log_files()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Java's InputSplit sorts log files ascending by deltaCommitTime → logVersion → writeToken
+    /// (via HoodieLogFile.getLogFileComparator()). The C++ side sends them in descending order
+    /// (from FileSlice's reverse TreeSet). InputSplit must re-sort to ascending.
+    #[test]
+    fn test_log_file_paths_sorted_ascending() {
+        // Log files in DESCENDING deltaCommitTime order (as C++ sends them)
+        let log_files = vec![
+            ".72d44234-0_20260408194651210.log.1_0-272-505".to_string(), // NEWER
+            ".72d44234-0_20260408194649548.log.1_0-254-473".to_string(), // OLDER
+        ];
+
+        let split = InputSplit::new(
+            Some("base.parquet".to_string()),
+            None,
+            log_files,
+            String::new(),
+        );
+
+        // Must be re-sorted to ASCENDING deltaCommitTime
+        assert_eq!(split.log_file_paths.len(), 2);
+        assert!(
+            split.log_file_paths[0].contains("20260408194649548"),
+            "First log file should be the OLDER commit, got: {}",
+            split.log_file_paths[0]
+        );
+        assert!(
+            split.log_file_paths[1].contains("20260408194651210"),
+            "Second log file should be the NEWER commit, got: {}",
+            split.log_file_paths[1]
+        );
+    }
+
+    /// Same deltaCommitTime, different logVersions — should sort by version ascending.
+    #[test]
+    fn test_log_file_paths_sorted_by_version() {
+        let log_files = vec![
+            ".fileId-0_20260408194649548.log.3_0-100-200".to_string(), // version 3
+            ".fileId-0_20260408194649548.log.1_0-100-200".to_string(), // version 1
+            ".fileId-0_20260408194649548.log.2_0-100-200".to_string(), // version 2
+        ];
+
+        let split = InputSplit::new(None, None, log_files, String::new());
+
+        assert!(split.log_file_paths[0].contains(".log.1_"));
+        assert!(split.log_file_paths[1].contains(".log.2_"));
+        assert!(split.log_file_paths[2].contains(".log.3_"));
+    }
+
+    /// With partition path prefix — sort should work on the file name portion.
+    #[test]
+    fn test_log_file_paths_sorted_with_partition_prefix() {
+        let log_files = vec![
+            "year=2024/month=01/.fileId-0_20260408194651210.log.1_0-272-505".to_string(),
+            "year=2024/month=01/.fileId-0_20260408194649548.log.1_0-254-473".to_string(),
+        ];
+
+        let split = InputSplit::new(None, None, log_files, "year=2024/month=01".to_string());
+
+        assert!(split.log_file_paths[0].contains("20260408194649548"));
+        assert!(split.log_file_paths[1].contains("20260408194651210"));
+    }
+
+    /// CDC log files (`.cdc` suffix) must be dropped from the scan list, mirroring
+    /// gold's `InputSplit` constructor filter (`InputSplit.java:57`,
+    /// `HoodieCDCUtils.CDC_LOGFILE_SUFFIX`). A normal snapshot read must not pull
+    /// in change-data-capture blocks.
+    #[test]
+    fn test_cdc_log_files_filtered_out() {
+        let log_files = vec![
+            ".fileId-0_20260408194649548.log.1_0-100-200".to_string(), // normal
+            ".fileId-0_20260408194651210.log.2_0-101-201.cdc".to_string(), // CDC — must be dropped
+            ".fileId-0_20260408194652000.log.3_0-102-202".to_string(), // normal
+        ];
+
+        let split = InputSplit::new(None, None, log_files, String::new());
+
+        assert_eq!(
+            split.log_file_paths.len(),
+            2,
+            "CDC log file should be excluded, got: {:?}",
+            split.log_file_paths
+        );
+        assert!(
+            split.log_file_paths.iter().all(|p| !p.ends_with(".cdc")),
+            "no remaining log file should be a .cdc file, got: {:?}",
+            split.log_file_paths
+        );
+        // The two normal log files survive and are sorted ascending.
+        assert!(split.log_file_paths[0].contains("20260408194649548"));
+        assert!(split.log_file_paths[1].contains("20260408194652000"));
+    }
+
+    /// CDC filter matches on the file-name portion when a partition prefix is present.
+    #[test]
+    fn test_cdc_log_files_filtered_with_partition_prefix() {
+        let log_files = vec![
+            "year=2024/.fileId-0_20260408194649548.log.1_0-100-200".to_string(),
+            "year=2024/.fileId-0_20260408194651210.log.2_0-101-201.cdc".to_string(),
+        ];
+
+        let split = InputSplit::new(None, None, log_files, "year=2024".to_string());
+
+        assert_eq!(split.log_file_paths.len(), 1);
+        assert!(split.log_file_paths[0].contains("20260408194649548"));
+    }
+
+    /// Empty or single log file — no sorting needed, should not crash.
+    #[test]
+    fn test_log_file_paths_empty_and_single() {
+        let split_empty = InputSplit::new(None, None, vec![], String::new());
+        assert!(split_empty.log_file_paths.is_empty());
+
+        let split_single = InputSplit::new(
+            None,
+            None,
+            vec![".fileId-0_20260408194649548.log.1_0-254-473".to_string()],
+            String::new(),
+        );
+        assert_eq!(split_single.log_file_paths.len(), 1);
+    }
+}

--- a/crates/core/src/file_group/reader_v2/iterator_mode.rs
+++ b/crates/core/src/file_group/reader_v2/iterator_mode.rs
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//! Ported from the merge-on-read reader. Nothing consumes it yet, so its
+//! items are unreachable from the crate's call graph until the reader wires in.
+#![allow(dead_code)]
+
+//! Mirrors `org.apache.hudi.common.table.read.IteratorMode`.
+//!
+//! Controls what form the output records take when iterating.
+
+/// The mode in which the file group reader yields records.
+///
+/// In Java Hudi, this controls whether the iterator produces engine-native
+/// records, HoodieRecord wrappers, or just record keys.
+///
+/// In hudi-rs, we always work with Arrow RecordBatch, so `EngineRecord`
+/// is the primary mode. The other modes are kept for API symmetry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum IteratorMode {
+    /// Yield engine-native records (Arrow RecordBatch in Rust).
+    #[default]
+    EngineRecord,
+
+    /// Yield HoodieRecord wrappers (not yet implemented in Rust).
+    HoodieRecord,
+
+    /// Yield only record keys (not yet implemented in Rust).
+    RecordKey,
+}
+
+impl IteratorMode {
+    pub fn from_str_opt(s: &str) -> Option<Self> {
+        match s {
+            "ENGINE_RECORD" => Some(Self::EngineRecord),
+            "HOODIE_RECORD" => Some(Self::HoodieRecord),
+            "RECORD_KEY" => Some(Self::RecordKey),
+            _ => None,
+        }
+    }
+}

--- a/crates/core/src/file_group/reader_v2/mod.rs
+++ b/crates/core/src/file_group/reader_v2/mod.rs
@@ -24,12 +24,16 @@
 //! itself lands in later changes, and the existing read path is untouched
 //! until it does.
 //!
-//! Everything here is therefore unreachable from the crate's call graph. Each
-//! item that needs it carries its own `allow(dead_code)`, rather than a blanket
-//! allow on the module: a module-wide one would also silence an item that is
-//! dead by mistake, and this module has a lot of growing left to do. Drop the
-//! per-item allows as the reader wires in.
+//! Everything here is therefore unreachable from the crate's call graph, which
+//! the `allow(dead_code)` on each file silences. Hand-written items carry the
+//! allow per item so a mistakenly-dead one still warns; files ported wholesale
+//! carry it at file scope, since every item in them is live upstream. Drop the
+//! allows as the reader wires in.
 
+pub(crate) mod input_split;
+pub(crate) mod iterator_mode;
+pub(crate) mod profiling;
+pub(crate) mod read_stats;
 pub(crate) mod reader;
 pub(crate) mod reader_context;
 pub(crate) mod resolver;

--- a/crates/core/src/file_group/reader_v2/mod.rs
+++ b/crates/core/src/file_group/reader_v2/mod.rs
@@ -28,5 +28,6 @@
 //! is what the allow below silences. Remove it once the reader wires in.
 #![allow(dead_code)]
 
+pub(crate) mod reader;
 pub(crate) mod reader_context;
 pub(crate) mod resolver;

--- a/crates/core/src/file_group/reader_v2/mod.rs
+++ b/crates/core/src/file_group/reader_v2/mod.rs
@@ -30,9 +30,11 @@
 //! carry it at file scope, since every item in them is live upstream. Drop the
 //! allows as the reader wires in.
 
+pub(crate) mod delete_context;
 pub(crate) mod input_split;
 pub(crate) mod iterator_mode;
 pub(crate) mod profiling;
+pub(crate) mod output_converter;
 pub(crate) mod read_stats;
 pub(crate) mod reader;
 pub(crate) mod reader_context;

--- a/crates/core/src/file_group/reader_v2/mod.rs
+++ b/crates/core/src/file_group/reader_v2/mod.rs
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//! Context types for the merge-on-read file group reader.
+//!
+//! This module holds the inputs the MOR reader needs and the resolver that
+//! derives them from a table's configs. Nothing consumes it yet — the reader
+//! itself lands in later changes, and the existing read path is untouched
+//! until it does.
+//!
+//! Everything here is therefore unreachable from the crate's call graph, which
+//! is what the allow below silences. Remove it once the reader wires in.
+#![allow(dead_code)]
+
+pub(crate) mod reader_context;
+pub(crate) mod resolver;

--- a/crates/core/src/file_group/reader_v2/mod.rs
+++ b/crates/core/src/file_group/reader_v2/mod.rs
@@ -24,9 +24,11 @@
 //! itself lands in later changes, and the existing read path is untouched
 //! until it does.
 //!
-//! Everything here is therefore unreachable from the crate's call graph, which
-//! is what the allow below silences. Remove it once the reader wires in.
-#![allow(dead_code)]
+//! Everything here is therefore unreachable from the crate's call graph. Each
+//! item that needs it carries its own `allow(dead_code)`, rather than a blanket
+//! allow on the module: a module-wide one would also silence an item that is
+//! dead by mistake, and this module has a lot of growing left to do. Drop the
+//! per-item allows as the reader wires in.
 
 pub(crate) mod reader;
 pub(crate) mod reader_context;

--- a/crates/core/src/file_group/reader_v2/output_converter.rs
+++ b/crates/core/src/file_group/reader_v2/output_converter.rs
@@ -1,0 +1,453 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//! Ported from the merge-on-read reader. Nothing consumes it yet, so its
+//! items are unreachable from the crate's call graph until the reader wires in.
+#![allow(dead_code)]
+
+//! Mirrors Java's `Option<UnaryOperator<T>> outputConverter` field
+//! on `HoodieFileGroupReader`.
+//!
+//! The output converter applies a final transformation (typically schema
+//! projection) to each record returned by the reader. In Java it is
+//! obtained from `readerContext.getSchemaHandler().getOutputConverter()`.
+
+use crate::Result;
+use crate::error::CoreError;
+use arrow_array::cast::AsArray;
+use arrow_array::{Array, ArrayRef, RecordBatch, RecordBatchOptions, StructArray};
+use arrow_schema::{DataType, Field, SchemaRef};
+use std::sync::Arc;
+
+/// A converter that transforms output records (e.g., schema projection).
+///
+/// Mirrors Java's `UnaryOperator<T>` used as `outputConverter` in
+/// `HoodieFileGroupReader`. Obtained from `FileGroupReaderSchemaHandler`.
+pub trait OutputConverter: Send + Sync + std::fmt::Debug {
+    /// Apply the conversion to a record batch.
+    fn apply(&self, batch: RecordBatch) -> Result<RecordBatch>;
+
+    /// Schema produced by [`apply`]. Used by the streaming FG reader
+    /// to report the post-projection schema on its
+    /// `RecordBatchReader::schema()` before any chunk is materialised.
+    fn target_schema(&self) -> SchemaRef;
+}
+
+/// Projects a `RecordBatch` from `required_schema` down to `requested_schema`.
+///
+/// Mirrors Java's `readerContext.getRecordContext().projectRecord(requiredSchema, requestedSchema)`.
+/// Selects only the columns present in the target schema, in the order they
+/// appear, **including narrowing nested struct fields** when the target's
+/// struct has fewer (or reordered) subfields than the source's.
+///
+/// Without nested narrowing, downstream consumers that expect a pruned struct
+/// (e.g. Velox's `RowVector` ctor type check at `ComplexVector.h:62`) reject
+/// the record because the child's type doesn't match the declared parent
+/// schema (ENG-40168).
+///
+/// Currently handles:
+///   - top-level reorder / drop / passthrough (as before)
+///   - nested struct narrowing: `fare<amount,currency>` → `fare<currency>`
+///   - nested struct reorder: `fare<amount,currency>` → `fare<currency,amount>`
+///
+/// Does NOT yet handle narrowing of struct elements inside `Array` or `Map`.
+/// If the test set ever exercises that path, expand `narrow_array_to_field`.
+#[derive(Debug)]
+pub struct ProjectionConverter {
+    target_schema: SchemaRef,
+}
+
+impl ProjectionConverter {
+    pub fn new(target_schema: &SchemaRef) -> Self {
+        Self {
+            target_schema: target_schema.clone(),
+        }
+    }
+}
+
+/// Narrow a single source array to match `target_field`'s type.
+///
+/// - Identical types → cheap clone of the Arc.
+/// - Both `Struct` → recursively narrow each requested subfield by name.
+///   Subfield order follows `target_field`'s order (so reordering also works).
+/// - Anything else → `Err`.  Arrow's `RecordBatch::try_new` would catch a
+///   primitive mismatch later, but raising here gives a column-name-aware
+///   error message.
+fn narrow_array_to_field(
+    source: &ArrayRef,
+    source_field: &Field,
+    target_field: &Field,
+) -> Result<ArrayRef> {
+    if source_field.data_type() == target_field.data_type() {
+        return Ok(Arc::clone(source));
+    }
+
+    match (source_field.data_type(), target_field.data_type()) {
+        (DataType::Struct(source_fields), DataType::Struct(target_fields)) => {
+            let source_struct: &StructArray = source.as_struct();
+            let mut narrowed_children: Vec<ArrayRef> = Vec::with_capacity(target_fields.len());
+            for tgt_sub in target_fields.iter() {
+                // Locate the matching subfield in the source struct by name.
+                let (idx, src_sub) = source_fields
+                    .iter()
+                    .enumerate()
+                    .find(|(_, f)| f.name() == tgt_sub.name())
+                    .ok_or_else(|| {
+                        CoreError::ReadFileSliceError(format!(
+                            "Output projection: subfield '{}' not found in struct '{}'. \
+                             Available: [{}]",
+                            tgt_sub.name(),
+                            source_field.name(),
+                            source_fields
+                                .iter()
+                                .map(|f| f.name().as_str())
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        ))
+                    })?;
+                let src_child = source_struct.column(idx);
+                narrowed_children.push(narrow_array_to_field(src_child, src_sub, tgt_sub)?);
+            }
+            // Preserve the source struct's parent null buffer.
+            let nulls = source_struct.nulls().cloned();
+            let narrowed = StructArray::try_new(target_fields.clone(), narrowed_children, nulls)
+                .map_err(|e| {
+                    CoreError::ReadFileSliceError(format!(
+                        "Output projection: failed to build narrowed struct '{}': {e}",
+                        source_field.name()
+                    ))
+                })?;
+            Ok(Arc::new(narrowed))
+        }
+        _ => Err(CoreError::ReadFileSliceError(format!(
+            "Output projection: incompatible types for column '{}': source={:?}, target={:?}",
+            source_field.name(),
+            source_field.data_type(),
+            target_field.data_type()
+        ))),
+    }
+}
+
+impl OutputConverter for ProjectionConverter {
+    fn target_schema(&self) -> SchemaRef {
+        self.target_schema.clone()
+    }
+
+    fn apply(&self, batch: RecordBatch) -> Result<RecordBatch> {
+        let source_schema = batch.schema();
+        let mut narrowed_columns: Vec<ArrayRef> =
+            Vec::with_capacity(self.target_schema.fields().len());
+
+        for tgt in self.target_schema.fields().iter() {
+            let (idx, src_field) = source_schema
+                .fields()
+                .iter()
+                .enumerate()
+                .find(|(_, f)| f.name() == tgt.name())
+                .ok_or_else(|| {
+                    CoreError::ReadFileSliceError(format!(
+                        "Output projection: column '{}' not found in batch schema. \
+                         Available: [{}]",
+                        tgt.name(),
+                        source_schema
+                            .fields()
+                            .iter()
+                            .map(|f| f.name().as_str())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ))
+                })?;
+            let src_col = batch.column(idx);
+            narrowed_columns.push(narrow_array_to_field(src_col, src_field, tgt)?);
+        }
+
+        // Preserve the source batch's row count explicitly. Without this,
+        // `RecordBatch::try_new` with zero columns fails Arrow's invariant
+        // ("must either specify a row count or at least one column"). That
+        // is reachable when Spark prunes the requested data schema to zero
+        // fields — e.g. a query that selects only partition columns. The
+        // standard Hive/Hudi scan path expects partition columns to be
+        // injected at a higher layer (split metadata), so the data-side
+        // batch can legitimately be empty.
+        let row_count = batch.num_rows();
+        RecordBatch::try_new_with_options(
+            self.target_schema.clone(),
+            narrowed_columns,
+            &RecordBatchOptions::new().with_row_count(Some(row_count)),
+        )
+        .map_err(|e| CoreError::ReadFileSliceError(format!("Output projection failed: {e}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::{Float64Array, Int64Array, StringArray};
+    use arrow_schema::{DataType, Field, Fields, Schema};
+    use std::sync::Arc;
+
+    /// Test that ProjectionConverter correctly narrows a RecordBatch.
+    #[test]
+    fn test_output_converter_projects_columns() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("col_a", DataType::Utf8, true),
+            Field::new("col_b", DataType::Int64, true),
+            Field::new("col_c", DataType::Utf8, true),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec!["a1", "a2"])),
+                Arc::new(Int64Array::from(vec![1, 2])),
+                Arc::new(StringArray::from(vec!["c1", "c2"])),
+            ],
+        )
+        .unwrap();
+
+        // Project to only col_a and col_c.
+        let target_schema = Arc::new(Schema::new(vec![
+            Field::new("col_a", DataType::Utf8, true),
+            Field::new("col_c", DataType::Utf8, true),
+        ]));
+        let converter = ProjectionConverter::new(&target_schema);
+        let projected = converter.apply(batch).unwrap();
+
+        assert_eq!(projected.num_columns(), 2);
+        assert_eq!(projected.schema().field(0).name(), "col_a");
+        assert_eq!(projected.schema().field(1).name(), "col_c");
+        assert_eq!(projected.num_rows(), 2);
+    }
+
+    /// Test that ProjectionConverter returns all columns when target matches source.
+    #[test]
+    fn test_output_converter_noop_when_same_schema() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("col_a", DataType::Utf8, true),
+            Field::new("col_b", DataType::Int64, true),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["a1"])),
+                Arc::new(Int64Array::from(vec![1])),
+            ],
+        )
+        .unwrap();
+
+        let converter = ProjectionConverter::new(&schema);
+        let projected = converter.apply(batch).unwrap();
+
+        assert_eq!(projected.num_columns(), 2);
+    }
+
+    /// Test that ProjectionConverter errors on missing column.
+    #[test]
+    fn test_output_converter_error_on_missing_column() {
+        let schema = Arc::new(Schema::new(vec![Field::new("col_a", DataType::Utf8, true)]));
+
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(StringArray::from(vec!["a1"]))]).unwrap();
+
+        let target_schema = Arc::new(Schema::new(vec![
+            Field::new("col_a", DataType::Utf8, true),
+            Field::new("col_missing", DataType::Utf8, true),
+        ]));
+        let converter = ProjectionConverter::new(&target_schema);
+        let result = converter.apply(batch);
+
+        assert!(result.is_err());
+    }
+
+    /// Helper: build the source `fare` struct array `{amount: f64, currency: str}`.
+    fn make_fare_struct(rows: &[(f64, &str)]) -> (Arc<Field>, ArrayRef) {
+        let amount = Arc::new(Float64Array::from(
+            rows.iter().map(|(a, _)| *a).collect::<Vec<_>>(),
+        ));
+        let currency = Arc::new(StringArray::from(
+            rows.iter().map(|(_, c)| *c).collect::<Vec<_>>(),
+        ));
+        let fields = Fields::from(vec![
+            Field::new("amount", DataType::Float64, true),
+            Field::new("currency", DataType::Utf8, true),
+        ]);
+        let struct_arr =
+            StructArray::try_new(fields.clone(), vec![amount, currency], None).unwrap();
+        let field = Arc::new(Field::new("fare", DataType::Struct(fields), true));
+        (field, Arc::new(struct_arr))
+    }
+
+    /// ENG-40168: top-level struct narrowing.
+    ///
+    /// Given: a RecordBatch whose `fare` column is `struct<amount, currency>`.
+    /// When:  target_schema requests `fare<currency>` only.
+    /// Then:  output's `fare` is a StructArray with a single `currency` child,
+    ///        sharing the original `currency` underlying array (zero-copy
+    ///        leaf), and the parent struct null buffer is preserved.
+    #[test]
+    fn test_output_converter_narrows_nested_struct() {
+        let (fare_field, fare_arr) = make_fare_struct(&[(1.5, "USD"), (2.5, "EUR")]);
+        let other_arr: ArrayRef = Arc::new(Int64Array::from(vec![100, 200]));
+
+        let source_schema = Arc::new(Schema::new(vec![
+            (*fare_field).clone(),
+            Field::new("other", DataType::Int64, true),
+        ]));
+        let batch = RecordBatch::try_new(source_schema.clone(), vec![fare_arr, other_arr]).unwrap();
+
+        // Drop `other` and narrow `fare` to just `currency`.
+        let target_fare = Field::new(
+            "fare",
+            DataType::Struct(Fields::from(vec![Field::new(
+                "currency",
+                DataType::Utf8,
+                true,
+            )])),
+            true,
+        );
+        let target_schema = Arc::new(Schema::new(vec![target_fare.clone()]));
+
+        let converter = ProjectionConverter::new(&target_schema);
+        let result = converter.apply(batch).unwrap();
+
+        assert_eq!(result.num_columns(), 1);
+        assert_eq!(result.num_rows(), 2);
+        assert_eq!(result.schema().field(0).name(), "fare");
+
+        // The narrowed `fare` struct has only one child: `currency`.
+        let narrowed_fare = result.column(0).as_struct();
+        assert_eq!(narrowed_fare.num_columns(), 1);
+        let narrowed_fields = match narrowed_fare.data_type() {
+            DataType::Struct(f) => f,
+            other => panic!("expected Struct, got {other:?}"),
+        };
+        assert_eq!(narrowed_fields.len(), 1);
+        assert_eq!(narrowed_fields[0].name(), "currency");
+
+        // Currency values intact.
+        let cur_arr = narrowed_fare
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(cur_arr.value(0), "USD");
+        assert_eq!(cur_arr.value(1), "EUR");
+    }
+
+    /// Reorder of struct subfields: `<amount, currency>` → `<currency, amount>`.
+    /// Both subfields are kept, order flips.
+    #[test]
+    fn test_output_converter_reorders_struct_subfields() {
+        let (fare_field, fare_arr) = make_fare_struct(&[(9.99, "JPY")]);
+
+        let source_schema = Arc::new(Schema::new(vec![(*fare_field).clone()]));
+        let batch = RecordBatch::try_new(source_schema, vec![fare_arr]).unwrap();
+
+        let target_fare = Field::new(
+            "fare",
+            DataType::Struct(Fields::from(vec![
+                Field::new("currency", DataType::Utf8, true),
+                Field::new("amount", DataType::Float64, true),
+            ])),
+            true,
+        );
+        let target_schema = Arc::new(Schema::new(vec![target_fare]));
+
+        let converter = ProjectionConverter::new(&target_schema);
+        let result = converter.apply(batch).unwrap();
+
+        let narrowed_fare = result.column(0).as_struct();
+        let narrowed_fields = match narrowed_fare.data_type() {
+            DataType::Struct(f) => f,
+            other => panic!("expected Struct, got {other:?}"),
+        };
+        assert_eq!(narrowed_fields[0].name(), "currency");
+        assert_eq!(narrowed_fields[1].name(), "amount");
+
+        let cur = narrowed_fare
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(cur.value(0), "JPY");
+        let amt = narrowed_fare
+            .column(1)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        assert_eq!(amt.value(0), 9.99);
+    }
+
+    /// Empty target schema (zero columns) preserves the source row count.
+    /// Reachable when Spark prunes the requested data schema to nothing —
+    /// e.g. a query that only references partition columns. Without
+    /// `with_row_count`, Arrow rejects an empty-column RecordBatch.
+    #[test]
+    fn test_output_converter_empty_target_preserves_row_count() {
+        let source_schema = Arc::new(Schema::new(vec![
+            Field::new("col_a", DataType::Utf8, true),
+            Field::new("col_b", DataType::Int64, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            source_schema,
+            vec![
+                Arc::new(StringArray::from(vec!["a", "b", "c"])),
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+            ],
+        )
+        .unwrap();
+        assert_eq!(batch.num_rows(), 3);
+
+        let target_schema = Arc::new(Schema::new(Vec::<Field>::new()));
+        let converter = ProjectionConverter::new(&target_schema);
+        let projected = converter.apply(batch).unwrap();
+
+        assert_eq!(projected.num_columns(), 0);
+        assert_eq!(projected.num_rows(), 3);
+    }
+
+    /// Asking for a subfield that doesn't exist in the source struct surfaces
+    /// a column-name-aware error rather than a cryptic Arrow type mismatch.
+    #[test]
+    fn test_output_converter_errors_on_missing_subfield() {
+        let (fare_field, fare_arr) = make_fare_struct(&[(1.0, "USD")]);
+        let source_schema = Arc::new(Schema::new(vec![(*fare_field).clone()]));
+        let batch = RecordBatch::try_new(source_schema, vec![fare_arr]).unwrap();
+
+        let target_fare = Field::new(
+            "fare",
+            DataType::Struct(Fields::from(vec![Field::new(
+                "missing_subfield",
+                DataType::Utf8,
+                true,
+            )])),
+            true,
+        );
+        let target_schema = Arc::new(Schema::new(vec![target_fare]));
+
+        let converter = ProjectionConverter::new(&target_schema);
+        let err = converter.apply(batch).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("missing_subfield"),
+            "error should name the missing subfield, got: {msg}"
+        );
+    }
+}

--- a/crates/core/src/file_group/reader_v2/profiling.rs
+++ b/crates/core/src/file_group/reader_v2/profiling.rs
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//! Ported from the merge-on-read reader. Nothing consumes it yet, so its
+//! items are unreachable from the crate's call graph until the reader wires in.
+#![allow(dead_code, unused_macros, unused_imports)]
+
+//! Stage-timing profiling primitives for the file-group reader (perf harness).
+//!
+//! A single canonical write path for the per-stage wall-time counters, so the
+//! `let s = Instant::now(); …; self.x [+]= s.elapsed()…` shape isn't copy-pasted
+//! at every timing site. Inlining (rather than an RAII/`Drop` guard) is
+//! deliberate: a guard holding `&mut self.field` for the scope would double-borrow
+//! `self` against bodies that also need `&mut self` (e.g.
+//! `process_queued_blocks_for_instant`); a macro releases the body's borrow before
+//! the field write.
+
+/// Record wall-ms of `$body` once into the u64 place `$dst`.
+///
+/// Where the body is a single fallible expression, keep `?` OUTSIDE the macro so
+/// the elapsed time is still attributed on the error path.
+macro_rules! profile_once {
+    ($dst:expr, $body:expr) => {{
+        let __start = std::time::Instant::now();
+        #[allow(clippy::let_unit_value)]
+        let __out = $body;
+        $dst = __start.elapsed().as_millis() as u64;
+        __out
+    }};
+}
+
+pub(crate) use profile_once;

--- a/crates/core/src/file_group/reader_v2/read_stats.rs
+++ b/crates/core/src/file_group/reader_v2/read_stats.rs
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//! Ported from the merge-on-read reader. Nothing consumes it yet, so its
+//! items are unreachable from the crate's call graph until the reader wires in.
+#![allow(dead_code)]
+
+//! Mirrors `org.apache.hudi.common.table.read.HoodieReadStats`.
+//!
+//! Mutable accumulator for read statistics, written during log scanning
+//! and buffer processing, read by the caller after the read completes.
+
+/// Mutable accumulator for file group read statistics.
+#[derive(Debug, Clone, Default)]
+pub struct HoodieReadStats {
+    pub num_inserts: u64,
+    pub num_updates: u64,
+    pub num_deletes: u64,
+    pub total_log_read_time_ms: u64,
+    pub total_log_records: u64,
+    pub total_log_files_compacted: u64,
+    pub total_log_blocks: u64,
+    pub total_corrupt_log_blocks: u64,
+    pub total_rollback_blocks: u64,
+
+    // ── Stage timings (perf harness) ───────────────────────
+    // Cheap monotonic `Instant`-based accumulators wired at the matching
+    // code sites. Always-on, accumulated per block/batch (never per row).
+    // Used by `benchmark/filegroup` (fg-bench) to attribute wall time across
+    // the read pipeline. Zero behavioral effect — instrumentation only.
+    //
+    /// Wall ms spent reading + projecting the base parquet file
+    /// (`HoodieFileGroupReader::make_base_file_batches`).
+    pub base_read_ms: u64,
+    /// Wall ms spent reading log-block metadata + bytes off storage during the
+    /// log scan Pass-1 (`BaseHoodieLogRecordReader::scan_internal`).
+    pub log_block_read_ms: u64,
+    /// Wall ms spent inflating/decoding log blocks into arrow batches
+    /// (`LogBlock::inflate`, accumulated inside the record buffer).
+    /// NOTE: in hudi-rs inflate/decode is triggered lazily inside the buffer's
+    /// `process_data_block`, so this is measured there and is a SUBSET of the
+    /// `merge_insert_ms` window below (decode is nested inside merge insert).
+    pub log_block_decode_ms: u64,
+    /// Wall ms spent dispatching decoded log records into the merge map
+    /// (`process_queued_blocks_for_instant`: inflate/decode + per-key upsert).
+    pub merge_insert_ms: u64,
+    /// Wall ms spent in the final base+log merge collect
+    /// (`merge_and_collect_with_stats`).
+    pub final_merge_ms: u64,
+    /// Wall ms spent building/projecting the output batch
+    /// (`apply_output_converter` + base-only concat path).
+    pub output_build_ms: u64,
+    /// Peak number of entries held in the merge map during the log scan.
+    pub merge_map_peak_entries: u64,
+
+    // ── Spillable merge map (A1, ENG-42993) ──────────────────────────────
+    /// True if the size-tracked merge map spilled any entry to disk (RocksDB)
+    /// during the scan — i.e. the in-memory budget was exceeded. This is the M3
+    /// acceptance signal: a low `hoodie.memory.merge.max.size` should set it.
+    pub merge_map_spilled: bool,
+    /// Peak TRUE-retained in-memory bytes the merge map held during the scan
+    /// (A6e): the sum of the distinct pinned source batches' `get_array_memory_size`
+    /// plus owned/key/overhead bytes — NOT the pre-A6 per-row share, which
+    /// under-counted dense spread-key `BatchRef` maps (M5: stat read ~budget while
+    /// RSS was 21.9 GB). Bounded by `0.8 × hoodie.memory.merge.max.size − rocksdb
+    /// reserved` once A6e eviction is active, so a benchmark can confirm the
+    /// in-memory footprint stayed within budget while the rest spilled.
+    pub merge_map_peak_in_memory_bytes: u64,
+}

--- a/crates/core/src/file_group/reader_v2/reader.rs
+++ b/crates/core/src/file_group/reader_v2/reader.rs
@@ -38,11 +38,13 @@ use arrow_array::RecordBatch;
 /// Serves both table types: a merge-on-read slice merges its log records onto
 /// the base file, and a copy-on-write slice is the same read with no log files
 /// to merge.
+#[allow(dead_code)]
 pub(crate) struct FileGroupReader {
     context: ReaderContext,
     parameters: ReaderParameters,
 }
 
+#[allow(dead_code)]
 impl FileGroupReader {
     pub(crate) fn new(context: ReaderContext, parameters: ReaderParameters) -> Self {
         Self {
@@ -110,13 +112,20 @@ mod tests {
         );
     }
 
-    /// Constructing is deliberately separate from reading: later changes fill in
-    /// the engine behind `read`, and callers wiring up a reader should not have
-    /// to handle a failure until they actually ask for rows.
+    /// The reader hands back what it was built with, rather than re-deriving or
+    /// defaulting it. Uses non-default parameters so that substituting defaults
+    /// somewhere in construction would fail this rather than pass unnoticed.
     #[test]
-    fn construction_succeeds_even_though_reading_does_not() {
-        let reader = FileGroupReader::new(context(), ReaderParameters::default());
+    fn holds_the_context_and_parameters_it_was_built_with() {
+        let parameters = ReaderParameters {
+            emit_delete: true,
+            sort_output: true,
+            allow_inflight_instants: true,
+        };
+
+        let reader = FileGroupReader::new(context(), parameters);
 
         assert_eq!(reader.context().table_path, "file:///tmp/t");
+        assert_eq!(*reader.parameters(), parameters);
     }
 }

--- a/crates/core/src/file_group/reader_v2/reader.rs
+++ b/crates/core/src/file_group/reader_v2/reader.rs
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//! The file group reader.
+//!
+//! Only the entry point exists so far. It is here ahead of the engine so that
+//! the shape callers will use is settled, and so the gap is something tests can
+//! point at rather than an absence.
+//!
+//! Shares a name with [`crate::file_group::reader::FileGroupReader`], which
+//! reads file groups today. This one replaces it once the engine behind it is
+//! written, so it carries the name it will keep; until then, reach for either
+//! by module path. Nothing outside this module uses this one yet.
+
+use crate::Result;
+use crate::error::CoreError;
+use crate::file_group::reader_v2::reader_context::{ReaderContext, ReaderParameters};
+use arrow_array::RecordBatch;
+
+/// Reads one file slice.
+///
+/// Serves both table types: a merge-on-read slice merges its log records onto
+/// the base file, and a copy-on-write slice is the same read with no log files
+/// to merge.
+pub(crate) struct FileGroupReader {
+    context: ReaderContext,
+    parameters: ReaderParameters,
+}
+
+impl FileGroupReader {
+    pub(crate) fn new(context: ReaderContext, parameters: ReaderParameters) -> Self {
+        Self {
+            context,
+            parameters,
+        }
+    }
+
+    /// What the reader was resolved to read.
+    pub(crate) fn context(&self) -> &ReaderContext {
+        &self.context
+    }
+
+    /// Flags controlling what this reader emits.
+    pub(crate) fn parameters(&self) -> &ReaderParameters {
+        &self.parameters
+    }
+
+    /// Read the file slice and return the merged rows.
+    ///
+    /// # Errors
+    /// Always, for now: the merge engine has not been written. Failing is the
+    /// point — an empty batch would be indistinguishable from a file slice that
+    /// genuinely has no rows, and would let an unfinished reader look like it
+    /// worked.
+    pub(crate) async fn read(&self) -> Result<RecordBatch> {
+        Err(CoreError::Unsupported(
+            "The merge-on-read file group reader is not yet implemented. \
+             Its context resolves, but no merge engine is wired up behind it."
+                .to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::HudiConfigs;
+    use crate::config::read::HudiReadConfig;
+    use crate::config::table::HudiTableConfig;
+    use crate::file_group::reader_v2::reader_context::ReaderParameters;
+    use crate::file_group::reader_v2::resolver::resolve_reader_context;
+
+    fn context() -> ReaderContext {
+        let configs = HudiConfigs::new([
+            (HudiTableConfig::BasePath.as_ref(), "file:///tmp/t"),
+            (HudiReadConfig::EndTimestamp.as_ref(), "20240101000000000"),
+            (HudiTableConfig::OrderingFields.as_ref(), "ts"),
+        ]);
+        resolve_reader_context(&configs, true).unwrap()
+    }
+
+    /// The context resolves, but there is no engine behind it yet. Reading must
+    /// say so plainly — returning an empty batch would look like a table with no
+    /// rows, which is indistinguishable from a real answer.
+    #[tokio::test]
+    async fn read_reports_that_the_engine_is_not_implemented() {
+        let reader = FileGroupReader::new(context(), ReaderParameters::default());
+
+        let err = reader.read().await.unwrap_err();
+
+        assert!(
+            err.to_string().contains("not yet implemented"),
+            "error should say the engine is missing, got: {err}"
+        );
+    }
+
+    /// Constructing is deliberately separate from reading: later changes fill in
+    /// the engine behind `read`, and callers wiring up a reader should not have
+    /// to handle a failure until they actually ask for rows.
+    #[test]
+    fn construction_succeeds_even_though_reading_does_not() {
+        let reader = FileGroupReader::new(context(), ReaderParameters::default());
+
+        assert_eq!(reader.context().table_path, "file:///tmp/t");
+    }
+}

--- a/crates/core/src/file_group/reader_v2/reader_context.rs
+++ b/crates/core/src/file_group/reader_v2/reader_context.rs
@@ -27,9 +27,15 @@ use std::collections::HashMap;
 ///
 /// The string forms match the merge modes the Hudi Java reader uses, so the
 /// values survive a round trip through engine integrations unchanged.
+#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum MergeMode {
     /// Latest commit wins.
+    ///
+    /// Nothing selects this yet. A table with no ordering field derives
+    /// `append_only`, which the resolver rejects rather than mapping — see
+    /// `resolver::resolve_merge_mode`. Settling that question is what makes
+    /// this reachable, since commit-time ordering is what such a table wants.
     CommitTimeOrdering,
     /// Highest ordering-field value wins.
     EventTimeOrdering,
@@ -46,6 +52,7 @@ impl AsRef<str> for MergeMode {
 
 /// Everything the MOR reader needs that is derived from table state rather
 /// than from the file slice itself.
+#[allow(dead_code)]
 #[derive(Clone, Debug)]
 pub(crate) struct ReaderContext {
     /// Table base path, as configured.
@@ -72,6 +79,7 @@ pub(crate) struct ReaderContext {
 }
 
 /// Flags controlling what the reader emits, independent of table state.
+#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) struct ReaderParameters {
     /// Emit delete records to the caller instead of only applying them.

--- a/crates/core/src/file_group/reader_v2/reader_context.rs
+++ b/crates/core/src/file_group/reader_v2/reader_context.rs
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//! Inputs the merge-on-read file group reader needs for one file slice.
+
+use crate::config::table::BaseFileFormatValue;
+use crate::timeline::selector::InstantRange;
+use std::collections::HashMap;
+
+/// How the reader picks a winner among versions of the same record key.
+///
+/// The string forms match the merge modes the Hudi Java reader uses, so the
+/// values survive a round trip through engine integrations unchanged.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum MergeMode {
+    /// Latest commit wins.
+    CommitTimeOrdering,
+    /// Highest ordering-field value wins.
+    EventTimeOrdering,
+}
+
+impl AsRef<str> for MergeMode {
+    fn as_ref(&self) -> &str {
+        match self {
+            MergeMode::CommitTimeOrdering => "COMMIT_TIME_ORDERING",
+            MergeMode::EventTimeOrdering => "EVENT_TIME_ORDERING",
+        }
+    }
+}
+
+/// Everything the MOR reader needs that is derived from table state rather
+/// than from the file slice itself.
+#[derive(Clone, Debug)]
+pub(crate) struct ReaderContext {
+    /// Table base path, as configured.
+    pub table_path: String,
+    /// Timestamp the read is pinned to. Log blocks at or before this instant
+    /// are visible; later ones are not.
+    pub latest_commit_time: String,
+    /// How to pick a winner among versions of the same record key.
+    pub merge_mode: MergeMode,
+    /// Format of the base file backing the slice.
+    pub base_file_format: BaseFileFormatValue,
+    /// Whether the slice has log files to merge. `false` reduces the read to a
+    /// plain base-file scan.
+    pub has_log_files: bool,
+    /// Window bounding which instants the log scan admits.
+    pub instant_range: InstantRange,
+    /// The table's own properties, keyed by their `hoodie.*` config names.
+    pub table_config: HashMap<String, String>,
+    /// Per-read overrides, keyed by their `hoodie.read.*` config names.
+    pub hoodie_reader_config: HashMap<String, String>,
+    /// Whether to merge log records onto base rows by record position rather
+    /// than by record key.
+    pub should_merge_use_record_position: bool,
+}
+
+/// Flags controlling what the reader emits, independent of table state.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ReaderParameters {
+    /// Emit delete records to the caller instead of only applying them.
+    pub emit_delete: bool,
+    /// Sort the merged output.
+    pub sort_output: bool,
+    /// Admit log blocks from instants that have not completed.
+    pub allow_inflight_instants: bool,
+}

--- a/crates/core/src/file_group/reader_v2/resolver.rs
+++ b/crates/core/src/file_group/reader_v2/resolver.rs
@@ -146,7 +146,9 @@ fn resolve_merge_mode(hudi_configs: &HudiConfigs) -> Result<MergeMode> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::file_group::reader::FileGroupReader;
     use crate::file_group::reader_v2::reader_context::ReaderParameters;
+    use std::sync::Arc;
 
     /// Configs with just enough set for the resolver to succeed. Includes an
     /// ordering field so the table derives `overwrite_with_latest` rather than
@@ -175,6 +177,41 @@ mod tests {
                 .filter(|(k, _)| k != key)
                 .collect::<Vec<_>>(),
         )
+    }
+
+    /// [`resolve_instant_range`] deliberately reproduces the bounds the legacy
+    /// file group reader computes, so that a read through either path admits
+    /// the same log blocks. Nothing but this test enforces that: the two live
+    /// in different modules and neither calls the other, so an edit to one
+    /// would otherwise drift silently.
+    ///
+    /// Compares the `Debug` rendering rather than the fields because
+    /// `InstantRange`'s fields are private — which also means a field added to
+    /// the struct is covered here for free, instead of being silently skipped
+    /// by an explicit field-by-field comparison.
+    #[test]
+    fn instant_range_matches_the_legacy_reader() {
+        let mut options = minimal_configs();
+        options.push((
+            HudiReadConfig::StartTimestamp.as_ref().to_string(),
+            "20230101000000000".to_string(),
+        ));
+        let configs = HudiConfigs::new(options);
+
+        let legacy = FileGroupReader::new_with_overrides(
+            Arc::new(configs.clone()),
+            HashMap::new(),
+            HashMap::new(),
+        )
+        .unwrap()
+        .create_instant_range_for_log_file_scan()
+        .unwrap();
+
+        let resolved = resolve_reader_context(&configs, true)
+            .unwrap()
+            .instant_range;
+
+        assert_eq!(format!("{legacy:?}"), format!("{resolved:?}"));
     }
 
     #[test]

--- a/crates/core/src/file_group/reader_v2/resolver.rs
+++ b/crates/core/src/file_group/reader_v2/resolver.rs
@@ -1,0 +1,360 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//! Derives a [`ReaderContext`] from a table's resolved configs.
+
+use crate::Result;
+use crate::config::HudiConfigs;
+use crate::config::error::ConfigError;
+use crate::config::read::HudiReadConfig;
+use crate::config::table::{BaseFileFormatValue, HudiTableConfig};
+use crate::error::CoreError;
+use crate::file_group::reader_v2::reader_context::{MergeMode, ReaderContext};
+use crate::merge::RecordMergeStrategyValue;
+use crate::timeline::selector::InstantRange;
+use std::collections::HashMap;
+use std::str::FromStr;
+
+/// Resolve the MOR reader context from `hudi_configs`, which the caller has
+/// already merged read options into.
+pub(crate) fn resolve_reader_context(
+    hudi_configs: &HudiConfigs,
+    has_log_files: bool,
+) -> Result<ReaderContext> {
+    let table_path: String = hudi_configs.get(HudiTableConfig::BasePath)?.into();
+
+    // Resolved by `Table::prepare_reader_options` for table-level reads. A
+    // `FileGroupReader` built straight from a base URI never loads the timeline,
+    // so the caller must supply it; defaulting here would silently widen the read.
+    let latest_commit_time: String = hudi_configs
+        .try_get(HudiReadConfig::EndTimestamp)?
+        .ok_or_else(|| ConfigError::NotFound(HudiReadConfig::EndTimestamp.as_ref().to_string()))?
+        .into();
+
+    let merge_mode = resolve_merge_mode(hudi_configs)?;
+    let base_file_format = BaseFileFormatValue::resolve_from_configs(hudi_configs, None)?;
+    let instant_range = resolve_instant_range(hudi_configs)?;
+    let (table_config, hoodie_reader_config) = partition_configs(hudi_configs);
+
+    Ok(ReaderContext {
+        table_path,
+        latest_commit_time,
+        merge_mode,
+        base_file_format,
+        has_log_files,
+        instant_range,
+        table_config,
+        hoodie_reader_config,
+        // Log blocks carry record positions, but no code reads them yet.
+        // Merging by key is what the legacy reader does, so that is what a v2
+        // read must do until the position-based merge lands.
+        should_merge_use_record_position: false,
+    })
+}
+
+/// Prefix identifying a per-read config; everything else is a table property.
+const READ_CONFIG_PREFIX: &str = "hoodie.read.";
+
+/// Split the merged config bag back into table properties and per-read
+/// overrides, so the merge code can tell one from the other.
+fn partition_configs(
+    hudi_configs: &HudiConfigs,
+) -> (HashMap<String, String>, HashMap<String, String>) {
+    let mut table_config = HashMap::new();
+    let mut reader_config = HashMap::new();
+
+    for (key, value) in hudi_configs.as_options() {
+        if key.starts_with(READ_CONFIG_PREFIX) {
+            reader_config.insert(key, value);
+        } else {
+            table_config.insert(key, value);
+        }
+    }
+
+    (table_config, reader_config)
+}
+
+/// Build the window bounding which instants the log scan admits.
+///
+/// Mirrors the bounds the legacy file group reader applies, so a v2 read sees
+/// the same log blocks: exclusive at the start, inclusive at the pinned commit.
+fn resolve_instant_range(hudi_configs: &HudiConfigs) -> Result<InstantRange> {
+    let timezone: String = hudi_configs
+        .get_or_default(HudiTableConfig::TimelineTimezone)
+        .into();
+    let start_timestamp = hudi_configs
+        .try_get(HudiReadConfig::StartTimestamp)?
+        .map(|v| -> String { v.into() });
+    let end_timestamp = hudi_configs
+        .try_get(HudiReadConfig::EndTimestamp)?
+        .map(|v| -> String { v.into() });
+
+    Ok(InstantRange::new(
+        timezone,
+        start_timestamp,
+        end_timestamp,
+        false,
+        true,
+    ))
+}
+
+/// Map the table's record merge strategy onto a MOR [`MergeMode`].
+///
+/// | `hoodie.table.record.merge.strategy` | [`MergeMode`]           |
+/// |-------------------------------------|-------------------------|
+/// | `overwrite_with_latest`             | `EventTimeOrdering`     |
+/// | `append_only`                       | unsupported — see below |
+///
+/// `append_only` has no MOR counterpart: the reader always merges by record
+/// key, so there is no mode that reproduces "keep every version". The table
+/// config derives `append_only` whenever meta fields are disabled or no
+/// ordering field is set, which makes it reachable for ordinary tables — so
+/// this returns an error rather than picking a mode that would change which
+/// rows a query returns.
+fn resolve_merge_mode(hudi_configs: &HudiConfigs) -> Result<MergeMode> {
+    let strategy: String = hudi_configs
+        .get_or_default(HudiTableConfig::RecordMergeStrategy)
+        .into();
+
+    match RecordMergeStrategyValue::from_str(&strategy)? {
+        RecordMergeStrategyValue::OverwriteWithLatest => Ok(MergeMode::EventTimeOrdering),
+        RecordMergeStrategyValue::AppendOnly => Err(CoreError::Unsupported(format!(
+            "Record merge strategy '{}' has no merge-on-read equivalent. \
+             The merge-on-read reader merges by record key, which does not \
+             preserve every record version.",
+            RecordMergeStrategyValue::AppendOnly.as_ref(),
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::file_group::reader_v2::reader_context::ReaderParameters;
+
+    /// Configs with just enough set for the resolver to succeed. Includes an
+    /// ordering field so the table derives `overwrite_with_latest` rather than
+    /// the append-only fallback exercised in its own tests below.
+    fn minimal_configs() -> Vec<(String, String)> {
+        vec![
+            (
+                HudiTableConfig::BasePath.as_ref().to_string(),
+                "file:///tmp/t".to_string(),
+            ),
+            (
+                HudiReadConfig::EndTimestamp.as_ref().to_string(),
+                "20240101000000000".to_string(),
+            ),
+            (
+                HudiTableConfig::OrderingFields.as_ref().to_string(),
+                "ts".to_string(),
+            ),
+        ]
+    }
+
+    fn configs_without(key: &str) -> HudiConfigs {
+        HudiConfigs::new(
+            minimal_configs()
+                .into_iter()
+                .filter(|(k, _)| k != key)
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    #[test]
+    fn resolves_table_path_from_base_path_config() {
+        let configs = HudiConfigs::new(minimal_configs());
+
+        let ctx = resolve_reader_context(&configs, false).unwrap();
+
+        assert_eq!(ctx.table_path, "file:///tmp/t");
+    }
+
+    #[test]
+    fn resolves_latest_commit_time_from_end_timestamp() {
+        let configs = HudiConfigs::new(minimal_configs());
+
+        let ctx = resolve_reader_context(&configs, false).unwrap();
+
+        assert_eq!(ctx.latest_commit_time, "20240101000000000");
+    }
+
+    /// `latest_commit_time` gates which log blocks are visible, so a missing
+    /// value must fail loudly rather than silently reading everything.
+    #[test]
+    fn errors_when_end_timestamp_is_absent() {
+        let configs = configs_without(HudiReadConfig::EndTimestamp.as_ref());
+
+        let err = resolve_reader_context(&configs, false).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains(HudiReadConfig::EndTimestamp.as_ref()),
+            "error should name the missing key, got: {err}"
+        );
+    }
+
+    #[test]
+    fn resolves_has_log_files_from_the_caller() {
+        let configs = HudiConfigs::new(minimal_configs());
+
+        assert!(
+            resolve_reader_context(&configs, true)
+                .unwrap()
+                .has_log_files
+        );
+        assert!(
+            !resolve_reader_context(&configs, false)
+                .unwrap()
+                .has_log_files
+        );
+    }
+
+    #[test]
+    fn defaults_base_file_format_to_parquet() {
+        let configs = HudiConfigs::new(minimal_configs());
+
+        let ctx = resolve_reader_context(&configs, true).unwrap();
+
+        assert_eq!(ctx.base_file_format, BaseFileFormatValue::Parquet);
+    }
+
+    /// The log scan is bounded by the same window the legacy reader uses, so a
+    /// v2 read sees exactly the log blocks a legacy read would.
+    #[test]
+    fn bounds_instant_range_by_the_read_window() {
+        let mut options = minimal_configs();
+        options.push((
+            HudiReadConfig::StartTimestamp.as_ref().to_string(),
+            "20230101000000000".to_string(),
+        ));
+        let configs = HudiConfigs::new(options);
+
+        let ctx = resolve_reader_context(&configs, true).unwrap();
+
+        let rendered = format!("{:?}", ctx.instant_range);
+        assert!(rendered.contains("20230101000000000"), "got: {rendered}");
+        assert!(rendered.contains("20240101000000000"), "got: {rendered}");
+        assert!(
+            rendered.contains("start_inclusive: false"),
+            "incremental reads are exclusive at the start, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("end_inclusive: true"),
+            "the pinned commit is included, got: {rendered}"
+        );
+    }
+
+    /// The reader is handed the table's own configs and the per-read overrides
+    /// as separate maps, so a read config can never be mistaken for a table
+    /// property (or vice versa) once it reaches the merge code.
+    #[test]
+    fn separates_table_configs_from_read_configs() {
+        let configs = HudiConfigs::new(minimal_configs());
+
+        let ctx = resolve_reader_context(&configs, true).unwrap();
+
+        assert_eq!(
+            ctx.table_config
+                .get(HudiTableConfig::OrderingFields.as_ref()),
+            Some(&"ts".to_string())
+        );
+        assert!(
+            !ctx.table_config
+                .contains_key(HudiReadConfig::EndTimestamp.as_ref()),
+            "read configs must not leak into table config"
+        );
+
+        assert_eq!(
+            ctx.hoodie_reader_config
+                .get(HudiReadConfig::EndTimestamp.as_ref()),
+            Some(&"20240101000000000".to_string())
+        );
+        assert!(
+            !ctx.hoodie_reader_config
+                .contains_key(HudiTableConfig::OrderingFields.as_ref()),
+            "table configs must not leak into reader config"
+        );
+    }
+
+    /// Log blocks carry record positions, but nothing reads them yet. Keeping
+    /// this off means a v2 read merges by key exactly as a legacy read does;
+    /// the position-based merge turns it on when it lands.
+    #[test]
+    fn leaves_position_based_merge_off() {
+        let configs = HudiConfigs::new(minimal_configs());
+
+        let ctx = resolve_reader_context(&configs, true).unwrap();
+
+        assert!(!ctx.should_merge_use_record_position);
+    }
+
+    /// Defaults chosen to match what the legacy reader returns today: deletes
+    /// are applied but never emitted, output keeps merge order, and only
+    /// completed instants are read.
+    #[test]
+    fn defaults_reader_parameters_to_legacy_behavior() {
+        let params = ReaderParameters::default();
+
+        assert!(!params.emit_delete);
+        assert!(!params.sort_output);
+        assert!(!params.allow_inflight_instants);
+    }
+
+    #[test]
+    fn maps_overwrite_with_latest_to_event_time_ordering() {
+        let configs = HudiConfigs::new(minimal_configs());
+
+        let ctx = resolve_reader_context(&configs, true).unwrap();
+
+        assert_eq!(ctx.merge_mode, MergeMode::EventTimeOrdering);
+    }
+
+    /// `append_only` has no counterpart in the MOR merge modes — the reader
+    /// always merges by record key. Mapping it to a merge mode silently drops
+    /// rows, so the resolver refuses rather than guessing.
+    #[test]
+    fn rejects_append_only_derived_from_missing_ordering_fields() {
+        let configs = configs_without(HudiTableConfig::OrderingFields.as_ref());
+
+        let err = resolve_reader_context(&configs, true).unwrap_err();
+
+        assert!(
+            err.to_string().contains("append_only"),
+            "error should name the unmapped strategy, got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_append_only_derived_from_disabled_meta_fields() {
+        let mut options = minimal_configs();
+        options.push((
+            HudiTableConfig::PopulatesMetaFields.as_ref().to_string(),
+            "false".to_string(),
+        ));
+        let configs = HudiConfigs::new(options);
+
+        let err = resolve_reader_context(&configs, true).unwrap_err();
+
+        assert!(
+            err.to_string().contains("append_only"),
+            "error should name the unmapped strategy, got: {err}"
+        );
+    }
+}

--- a/crates/core/src/file_group/reader_v2/resolver.rs
+++ b/crates/core/src/file_group/reader_v2/resolver.rs
@@ -33,6 +33,7 @@ use std::str::FromStr;
 
 /// Resolve the MOR reader context from `hudi_configs`, which the caller has
 /// already merged read options into.
+#[allow(dead_code)]
 pub(crate) fn resolve_reader_context(
     hudi_configs: &HudiConfigs,
     has_log_files: bool,
@@ -68,11 +69,23 @@ pub(crate) fn resolve_reader_context(
     })
 }
 
-/// Prefix identifying a per-read config; everything else is a table property.
+/// Prefix identifying a per-read config.
+#[allow(dead_code)]
 const READ_CONFIG_PREFIX: &str = "hoodie.read.";
 
-/// Split the merged config bag back into table properties and per-read
-/// overrides, so the merge code can tell one from the other.
+/// Prefixes identifying configs that steer this crate's own behavior. They are
+/// neither something the table declares about itself nor a per-read override,
+/// so they reach the reader through neither map.
+#[allow(dead_code)]
+const CRATE_CONFIG_PREFIXES: [&str; 2] = ["hoodie.internal.", "hoodie.plan."];
+
+/// Split the merged config bag into the table's own properties and the
+/// per-read overrides, so the merge code can tell one from the other.
+///
+/// Anything belonging to neither is dropped rather than swept into the table
+/// properties: a reader has no way to tell a swept-in crate config from
+/// something the table actually declared.
+#[allow(dead_code)]
 fn partition_configs(
     hudi_configs: &HudiConfigs,
 ) -> (HashMap<String, String>, HashMap<String, String>) {
@@ -82,7 +95,10 @@ fn partition_configs(
     for (key, value) in hudi_configs.as_options() {
         if key.starts_with(READ_CONFIG_PREFIX) {
             reader_config.insert(key, value);
-        } else {
+        } else if !CRATE_CONFIG_PREFIXES
+            .iter()
+            .any(|prefix| key.starts_with(prefix))
+        {
             table_config.insert(key, value);
         }
     }
@@ -94,6 +110,7 @@ fn partition_configs(
 ///
 /// Mirrors the bounds the legacy file group reader applies, so a v2 read sees
 /// the same log blocks: exclusive at the start, inclusive at the pinned commit.
+#[allow(dead_code)]
 fn resolve_instant_range(hudi_configs: &HudiConfigs) -> Result<InstantRange> {
     let timezone: String = hudi_configs
         .get_or_default(HudiTableConfig::TimelineTimezone)
@@ -127,6 +144,7 @@ fn resolve_instant_range(hudi_configs: &HudiConfigs) -> Result<InstantRange> {
 /// ordering field is set, which makes it reachable for ordinary tables — so
 /// this returns an error rather than picking a mode that would change which
 /// rows a query returns.
+#[allow(dead_code)]
 fn resolve_merge_mode(hudi_configs: &HudiConfigs) -> Result<MergeMode> {
     let strategy: String = hudi_configs
         .get_or_default(HudiTableConfig::RecordMergeStrategy)
@@ -146,6 +164,8 @@ fn resolve_merge_mode(hudi_configs: &HudiConfigs) -> Result<MergeMode> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::internal::HudiInternalConfig;
+    use crate::config::plan::HudiPlanConfig;
     use crate::file_group::reader::FileGroupReader;
     use crate::file_group::reader_v2::reader_context::ReaderParameters;
     use std::sync::Arc;
@@ -328,6 +348,38 @@ mod tests {
                 .contains_key(HudiTableConfig::OrderingFields.as_ref()),
             "table configs must not leak into reader config"
         );
+    }
+
+    /// Neither map is a catch-all. Configs that steer this crate's own behavior
+    /// are not table properties and are not per-read overrides, so they belong
+    /// in neither — sweeping them into the table properties would leave a
+    /// reader unable to tell them from something the table declared about
+    /// itself.
+    #[test]
+    fn drops_configs_that_are_neither_table_nor_read() {
+        let crate_configs = [
+            HudiInternalConfig::SkipConfigValidation.as_ref(),
+            HudiInternalConfig::TimelineArchivedReadEnabled.as_ref(),
+            HudiPlanConfig::ListingParallelism.as_ref(),
+        ];
+        let mut options = minimal_configs();
+        for key in crate_configs {
+            options.push((key.to_string(), "1".to_string()));
+        }
+        let configs = HudiConfigs::new(options);
+
+        let ctx = resolve_reader_context(&configs, true).unwrap();
+
+        for key in crate_configs {
+            assert!(
+                !ctx.table_config.contains_key(key),
+                "{key} is not a table property"
+            );
+            assert!(
+                !ctx.hoodie_reader_config.contains_key(key),
+                "{key} is not a per-read override"
+            );
+        }
     }
 
     /// Log blocks carry record positions, but nothing reads them yet. Keeping


### PR DESCRIPTION
**Stacked on #639 and #640** — their commits appear here until they merge. **Review only the last commit.**

Two more leaf modules of the merge-on-read reader: `delete_context` (how a read recognizes a delete — the marker field/value a payload uses) and `output_converter` (projects a merged batch to the requested columns).

Nothing consumes them; `reader_v2` stays `pub(crate)` and unreferenced. **Public API delta: none.** Build warning-free, suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)