### PR TITLE
test(core): pin that append-only reads do not apply deletes

### DIFF
--- a/crates/core/src/merge/record_merger.rs
+++ b/crates/core/src/merge/record_merger.rs
@@ -459,4 +459,56 @@ mod tests {
             ]
         );
     }
+
+    /// Records what the append-only strategy does with a delete block.
+    ///
+    /// It concatenates the data batches and returns, so the delete batches are
+    /// never consulted: a deleted record is still present in the output. This
+    /// test exists to pin that, because it is reachable — the table config
+    /// derives `append_only` whenever meta fields are disabled or no ordering
+    /// field is set, including on merge-on-read tables whose log files carry
+    /// delete blocks.
+    #[test]
+    fn test_append_only_does_not_apply_deletes() {
+        let schema = create_test_schema(false);
+
+        let data = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["c1", "c1"])),
+                Arc::new(StringArray::from(vec!["s1", "s1"])),
+                Arc::new(StringArray::from(vec!["k1", "k2"])),
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(Int32Array::from(vec![10, 20])),
+            ],
+        )
+        .unwrap();
+
+        // A delete of k1 at a later ordering value than the row above.
+        let delete = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["c2"])),
+                Arc::new(StringArray::from(vec!["s2"])),
+                Arc::new(StringArray::from(vec!["k1"])),
+                Arc::new(Int32Array::from(vec![9])),
+                Arc::new(Int32Array::from(vec![90])),
+            ],
+        )
+        .unwrap();
+
+        let mut batches = RecordBatches::new_with_data_batches([data]);
+        batches.push_delete_batch(delete, "20240101000000000".to_string());
+
+        let configs = create_configs("APPEND_ONLY", false, None);
+        let merger = RecordMerger::new(schema.clone(), Arc::new(configs));
+        let merged = merger.merge_record_batches(batches).unwrap();
+
+        let keys: Vec<String> = get_sorted_rows(&merged).into_iter().map(|r| r.2).collect();
+        assert_eq!(
+            keys,
+            vec!["k1".to_string(), "k2".to_string()],
+            "k1 was deleted, yet it is still in the output"
+        );
+    }
 }


### PR DESCRIPTION
Independent of the merge-on-read reader port — this is about the **existing** read path.

## What I found

`RecordMerger`'s append-only arm is:

```rust
RecordMergeStrategyValue::AppendOnly => record_batches.concat_data_batches(self.schema.clone())
```

`concat_data_batches` concatenates `data_batches` and returns. `delete_batches` is never read. **A deleted record is still in the result.**

## Why that is reachable

Append-only is defensible for a table that genuinely only appends. But it is **not opt-in** — `config/table.rs` *derives* it:

- `hoodie.populate.meta.fields = false` → `append_only`, or
- no `hoodie.table.ordering.fields` / `precombine.field` → `append_only`

A merge-on-read table meeting either condition has log files that can carry delete blocks. Those deletes are dropped, and updates are returned as duplicates rather than merged (the existing `test_merge_records_append_only` already documents the duplication — 4 rows out of 2+2 with a repeated key).

## Why it went unnoticed

I checked every merge-on-read fixture in the repo: **all 14 set an ordering field and leave meta fields on**, so none derives append-only. The path has no fixture coverage at all.

## What this PR does

Adds a test pinning the current behavior, so a change to it is deliberate rather than accidental. It does **not** change behavior — I did not want to alter existing read results in a test-only PR, and the right fix is a design question:

- treat a merge-on-read table with delete blocks as never append-only, or
- apply deletes on the append-only path too, or
- reject the combination loudly

Worth a maintainer's call. This came up because the ported merge-on-read reader has no append-only equivalent — it always merges by key — so the same table would return different rows under it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)