### PR TITLE
fix: stop .gitignore from swallowing test fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,14 @@
 **/data
 **/results
 
+# Test fixtures live under a data/ directory and must be committed; without this
+# they are silently swallowed by the rule above and CI fails on tables nobody
+# can see are missing.
+# The directory itself has to be re-included, not just its contents — git never
+# descends into an excluded directory, so a pattern for the files alone is dead.
+!crates/test/data/
+!crates/core/tests/data/
+
 /.idea
 .vscode
 


### PR DESCRIPTION
## What

Re-include the two test-fixture directories that `.gitignore` currently hides.

## Why

`.gitignore` line 21 is `**/data`. That pattern also matches `crates/test/data/`
and `crates/core/tests/data/` — where every test fixture in this repo lives.

The consequence is silent: `git add -A` (or `git add .`) on a newly created
fixture **succeeds and stages nothing**. There is no error and no warning. The
author's working tree has the file, their local tests pass, and the fixture
never reaches the branch — so CI fails on tables that nobody can see are
missing, because they don't appear in the diff.

The rule came in with #538 (`perf: setup tpch benchmark infra`), a benchmark PR
that incidentally started hiding the fixture directories as a side effect. Every
fixture committed before that point is still tracked, and git keeps honoring
`.gitignore` only for untracked paths — which is exactly why this went unnoticed:
the existing fixtures kept working, and only *new* ones vanished.

This has already bitten us. 19 fixtures went missing across roughly 20 PRs
before anyone noticed. **This affects every contributor today**, not just one
workstream.

## The fix

```gitignore
**/data
**/results

# Test fixtures live under a data/ directory and must be committed; without this
# they are silently swallowed by the rule above and CI fails on tables nobody
# can see are missing.
# The directory itself has to be re-included, not just its contents — git never
# descends into an excluded directory, so a pattern for the files alone is dead.
!crates/test/data/
!crates/core/tests/data/
```

The re-include has to name the **directory**, not just the files under it. Git
never descends into an excluded directory, so a pattern like
`!crates/test/data/**` would never be evaluated and the fix would silently do
nothing. This is the documented behavior in `gitignore(5)`:

> It is not possible to re-include a file if a parent directory of that file is
> excluded.

## Verification

Both directions were checked against this branch:

```console
$ git check-ignore -v crates/test/data/quickstart_trips_table/mor/avro/table_log_only.zip
$ git check-ignore -v crates/core/tests/data/i3/modern_3level_map.parquet
# no output, exit 1 — no longer ignored

$ git check-ignore -v demo/data target/data
.gitignore:21:**/data   demo/data
.gitignore:20:**/target target/data
# exit 0 — unrelated data/ dirs are still ignored
```

For contrast, the same two fixture paths on `main` today:

```console
$ git check-ignore -v crates/test/data/quickstart_trips_table/mor/avro/table_log_only.zip
.gitignore:21:**/data   crates/test/data/quickstart_trips_table/mor/avro/table_log_only.zip
$ git check-ignore -v crates/core/tests/data/i3/modern_3level_map.parquet
.gitignore:21:**/data   crates/core/tests/data/i3/modern_3level_map.parquet
```

## Scope

One file, 8 added lines, no behavior change to any code. This is **independent
of the MOR reader stack** and of any other in-flight work — it does not depend
on them and they do not depend on it, so it can be reviewed and merged on its
own. Landing it early means fixtures added in subsequent PRs actually get
committed.
