### PR TITLE
feat(core): select the file group reader by version, defaulting to 2

### DIFF
--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -250,6 +250,15 @@ impl HudiConfigs {
         self.raw_options.contains_key(key.as_ref())
     }
 
+    /// Look up a raw value without copying the option map.
+    ///
+    /// For a key this crate has no typed config for. Prefer [`Self::try_get`]
+    /// where one exists — it parses, and errors rather than silently returning
+    /// the default when a value is malformed.
+    pub fn get_raw(&self, key: impl AsRef<str>) -> Option<&str> {
+        self.raw_options.get(key.as_ref()).map(String::as_str)
+    }
+
     /// Get value for the given config. Return [Result] with the value.
     /// If the config is not found or value was not parsed properly, return [Err].
     pub fn get(

--- a/crates/core/src/config/read.rs
+++ b/crates/core/src/config/read.rs
@@ -192,12 +192,6 @@ impl TryFrom<usize> for FileGroupReaderVersion {
     }
 }
 
-impl Display for FileGroupReaderVersion {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.as_usize())
-    }
-}
-
 impl FromStr for FileGroupReaderVersion {
     type Err = ConfigError;
 
@@ -388,6 +382,19 @@ mod tests {
         assert!(AsOfTimestamp.default_value().is_none());
         assert!(StartTimestamp.default_value().is_none());
         assert!(EndTimestamp.default_value().is_none());
+    }
+
+    #[test]
+    fn file_group_reader_version_try_from_usize_accepts_1_and_2_and_rejects_others() {
+        assert_eq!(
+            FileGroupReaderVersion::try_from(1).unwrap(),
+            FileGroupReaderVersion::One
+        );
+        assert_eq!(
+            FileGroupReaderVersion::try_from(2).unwrap(),
+            FileGroupReaderVersion::Two
+        );
+        assert!(FileGroupReaderVersion::try_from(3).is_err());
     }
 
     #[test]

--- a/crates/core/src/config/read.rs
+++ b/crates/core/src/config/read.rs
@@ -180,6 +180,18 @@ impl FileGroupReaderVersion {
     }
 }
 
+impl TryFrom<usize> for FileGroupReaderVersion {
+    type Error = ConfigError;
+
+    fn try_from(value: usize) -> std::result::Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::One),
+            2 => Ok(Self::Two),
+            v => Err(InvalidValue(v.to_string())),
+        }
+    }
+}
+
 impl Display for FileGroupReaderVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.as_usize())

--- a/crates/core/src/config/read.rs
+++ b/crates/core/src/config/read.rs
@@ -97,6 +97,17 @@ pub enum HudiReadConfig {
     /// When set to true, only base files will be read for optimized reads.
     /// This is only applicable to Merge-On-Read (MOR) tables.
     UseReadOptimizedMode,
+    /// Which implementation of the file group reader serves a read: `2`
+    /// (default) or `1`.
+    ///
+    /// A read version 2 cannot serve is served by version 1 instead, so neither
+    /// value can make a working read fail. Set `1` explicitly to opt out of the
+    /// newer reader entirely.
+    ///
+    /// An unrecognised value is an error rather than a fall back to the default
+    /// — silently reading with the other implementation would leave a caller
+    /// convinced they had exercised the one they asked for.
+    FileGroupReaderVersion,
 
     /// Target number of rows per batch for streaming reads.
     /// This controls the batch size when using streaming APIs.
@@ -118,6 +129,7 @@ impl HudiReadConfig {
             Self::EndTimestamp => "hoodie.read.end.timestamp",
             Self::InputPartitions => "hoodie.read.input.partitions",
             Self::UseReadOptimizedMode => "hoodie.read.use.read_optimized.mode",
+            Self::FileGroupReaderVersion => "hoodie.read.file.group.reader.version",
             Self::StreamBatchSize => "hoodie.read.stream.batch_size",
             Self::FileSliceReadConcurrency => "hoodie.read.file.slice.read.concurrency",
         }
@@ -136,6 +148,56 @@ impl Display for HudiReadConfig {
     }
 }
 
+/// Which implementation of the file group reader serves a read.
+///
+/// Numbered rather than named after a strategy, because the older one is being
+/// retired rather than kept as an alternative: a version says newer supersedes
+/// older, where a name like `batch_merge` would imply a permanent choice.
+/// Matches how Hudi already versions `hoodie.table.version` and
+/// `hoodie.timeline.layout.version`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum FileGroupReaderVersion {
+    /// The reader that has always served reads: whole-batch sort and dedup.
+    /// Reachable explicitly, as an escape hatch, and reached by fall back
+    /// whenever [`Self::Two`] cannot serve a read.
+    One,
+    /// The merge-on-read reader being ported in, and the default.
+    ///
+    /// It does not serve every read yet. Anything it cannot serve is served by
+    /// [`Self::One`] instead, which is why it can be the default this early:
+    /// what changes a read is the reader gaining a capability, not this setting.
+    #[default]
+    Two,
+}
+
+impl FileGroupReaderVersion {
+    /// The integer a caller writes in config.
+    pub fn as_usize(&self) -> usize {
+        match self {
+            Self::One => 1,
+            Self::Two => 2,
+        }
+    }
+}
+
+impl Display for FileGroupReaderVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_usize())
+    }
+}
+
+impl FromStr for FileGroupReaderVersion {
+    type Err = ConfigError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.trim() {
+            "1" => Ok(Self::One),
+            "2" => Ok(Self::Two),
+            v => Err(InvalidValue(v.to_string())),
+        }
+    }
+}
+
 impl ConfigParser for HudiReadConfig {
     type Output = HudiConfigValue;
 
@@ -146,6 +208,9 @@ impl ConfigParser for HudiReadConfig {
             )),
             HudiReadConfig::InputPartitions => Some(HudiConfigValue::UInteger(0usize)),
             HudiReadConfig::UseReadOptimizedMode => Some(HudiConfigValue::Boolean(false)),
+            HudiReadConfig::FileGroupReaderVersion => Some(HudiConfigValue::UInteger(
+                FileGroupReaderVersion::default().as_usize(),
+            )),
             HudiReadConfig::StreamBatchSize => Some(HudiConfigValue::UInteger(1024usize)),
             HudiReadConfig::FileSliceReadConcurrency => Some(HudiConfigValue::UInteger(4usize)),
             _ => None,
@@ -170,6 +235,9 @@ impl ConfigParser for HudiReadConfig {
                     usize::from_str(v).map_err(|e| ParseInt(self.key(), v.to_string(), e))
                 })
                 .map(HudiConfigValue::UInteger),
+            Self::FileGroupReaderVersion => get_result
+                .and_then(FileGroupReaderVersion::from_str)
+                .map(|v| HudiConfigValue::UInteger(v.as_usize())),
             Self::UseReadOptimizedMode => get_result
                 .and_then(|v| {
                     bool::from_str(v).map_err(|e| ParseBool(self.key(), v.to_string(), e))

--- a/crates/core/src/file_group/reader.rs
+++ b/crates/core/src/file_group/reader.rs
@@ -49,7 +49,6 @@ use futures::stream::BoxStream;
 use futures::{StreamExt, TryFutureExt};
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use std::str::FromStr;
 use std::sync::Arc;
 
 /// The reader that handles all read operations against a file group.
@@ -238,12 +237,17 @@ impl FileGroupReader {
         if self.is_metadata_table() {
             return Ok(FileGroupReaderVersion::One);
         }
+        // `try_get` rather than `get_or_default`: the latter returns the default
+        // when a value fails to parse, so a typo would silently read with the
+        // other version and leave a caller convinced they had exercised the one
+        // they asked for. Borrowing, so no copy of the config map per read.
         match self
             .hudi_configs
-            .as_options()
-            .get(HudiReadConfig::FileGroupReaderVersion.as_ref())
+            .try_get(HudiReadConfig::FileGroupReaderVersion)?
         {
-            Some(raw) => FileGroupReaderVersion::from_str(raw).map_err(CoreError::Config),
+            Some(value) => {
+                FileGroupReaderVersion::try_from(usize::from(value)).map_err(CoreError::Config)
+            }
             None => Ok(FileGroupReaderVersion::default()),
         }
     }
@@ -274,12 +278,10 @@ impl FileGroupReader {
         // consulting a merger at all, so refusing it would break reads that work
         // today over a mode they never reach.
         if !base_file_only
-            && let Some(mode) = self
-                .hudi_configs
-                .as_options()
-                // Read by raw key: this crate has no typed config for it yet, and
-                // adding one belongs with the reader that acts on it.
-                .get("hoodie.record.merge.mode")
+            // Read by raw key: this crate has no typed config for it yet, and
+            // adding one belongs with the reader that acts on it. Borrowed, so
+            // no copy of the option map per read.
+            && let Some(mode) = self.hudi_configs.get_raw("hoodie.record.merge.mode")
             && mode.eq_ignore_ascii_case("CUSTOM")
         {
             return Err(CoreError::Unsupported(
@@ -1690,7 +1692,6 @@ mod tests {
 #[cfg(test)]
 mod file_group_reader_version_tests {
     use super::*;
-    use crate::config::util::empty_options;
     use hudi_test::SampleTable;
 
     async fn reader_with(

--- a/crates/core/src/file_group/reader.rs
+++ b/crates/core/src/file_group/reader.rs
@@ -225,12 +225,12 @@ impl FileGroupReader {
     ///
     /// A metadata table is always served by version 1 whatever the
     /// setting says: its base files and log blocks are HFile, which the
-    /// merge-on-read engine has no support for. That is permanent, not
+    /// file group reader version 2 has no support for. That is permanent, not
     /// transitional.
     ///
     /// The value is read raw rather than through `get_or_default`, which falls
-    /// back to the default when a value fails to parse. A typo in the engine
-    /// name would then silently read with the other engine, leaving a caller
+    /// back to the default when a value fails to parse. A typo in the version
+    /// would then silently read with the other version, leaving a caller
     /// convinced they had exercised it — the one outcome this switch must not
     /// produce.
     fn file_group_reader_version(&self) -> Result<FileGroupReaderVersion> {
@@ -252,18 +252,18 @@ impl FileGroupReader {
         }
     }
 
-    /// Why the merge-on-read engine cannot serve this read, if it cannot.
+    /// Why file group reader version 2 cannot serve this read, if it cannot.
     ///
     /// This is a capability check, decided from config before any I/O — never a
-    /// catch-all on error. A read that fails *inside* the engine propagates:
+    /// catch-all on error. A read that fails *inside* version 2 propagates:
     /// retrying it on version 1 would make a bug look like a success,
-    /// make results depend on which engine happened to win, and leave the
+    /// make results depend on which reader happened to win, and leave the
     /// differential tests unable to see anything.
     ///
     /// Every reason here means version 1 serves the read instead, so
-    /// selecting the engine cannot turn a working read into a failing one. Each
+    /// selecting a version cannot turn a working read into a failing one. Each
     /// reason is logged, because a fallback nobody can observe is
-    /// indistinguishable from an engine that is never used.
+    /// indistinguishable from a reader that is never used.
     fn version_two_unsupported_reason(
         &self,
         options: &ReadOptions,
@@ -296,7 +296,7 @@ impl FileGroupReader {
         // loudly here rather than reaching a reader that cannot read HFile.
         if self.is_metadata_table() {
             return Err(CoreError::Unsupported(
-                "The merge-on-read engine cannot read a metadata table's HFile \
+                "File group reader version 2 cannot read a metadata table's HFile \
                  base files and log blocks"
                     .to_string(),
             ));
@@ -307,10 +307,10 @@ impl FileGroupReader {
         }
         // The fallthrough reports *unsupported*, deliberately: capability is
         // enumerated, not assumed, so a situation nobody considered falls back
-        // rather than being served by an engine that has never seen it.
+        // rather than being served by a reader that has never seen it.
         // Inverting this is a one-line change with no visible symptom, which is
         // why it is called out here.
-        Ok(Some("the merge-on-read engine is not wired up yet"))
+        Ok(Some("file group reader version 2 is not wired up yet"))
     }
 
     /// Reads a file slice from a base file and a list of log files.
@@ -346,8 +346,8 @@ impl FileGroupReader {
                     // that is a test harness. So a capability may only be added
                     // together with fixture coverage proving it.
                     return Err(CoreError::Unsupported(
-                        "The merge-on-read engine reports itself able to serve this read, \
-                         but no engine is wired up behind the switch yet. A capability must \
+                        "File group reader version 2 reports itself able to serve this read, \
+                         but nothing is wired up behind the switch yet. A capability must \
                          not be claimed here before there is fixture coverage comparing its \
                          output against Hudi's reader"
                             .to_string(),
@@ -1701,7 +1701,7 @@ mod file_group_reader_version_tests {
         FileGroupReader::new_with_options(base_url.as_ref(), options).await
     }
 
-    /// The merge-on-read engine is the default, and nothing changes for a caller
+    /// File group reader version 2 is the default, and nothing changes for a caller
     /// who sets nothing — because every capability falls back today. Making it
     /// the default only once it were capable would put the whole behaviour change
     /// in one commit; this way each capability carries its own.
@@ -1731,7 +1731,34 @@ mod file_group_reader_version_tests {
         Ok(())
     }
 
-    /// A typo must not read with the other engine. `get_or_default` would have
+    /// The guard inside the check, reached only if the dispatch's metadata
+    /// routing were ever removed. Asserted directly because the dispatch answers
+    /// metadata tables before the check runs, so no read can reach it today —
+    /// which is exactly why it must keep erroring rather than fall through to a
+    /// reader that cannot read HFile.
+    #[tokio::test]
+    async fn test_version_two_unsupported_reason_metadata_table_returns_error() -> Result<()> {
+        use crate::config::HudiConfigs;
+        use crate::config::table::HudiTableConfig;
+        use std::collections::HashMap;
+        use std::sync::Arc;
+
+        let configs = Arc::new(HudiConfigs::new([(
+            HudiTableConfig::BasePath.as_ref(),
+            super::tests::get_metadata_table_base_uri(),
+        )]));
+        let reader = FileGroupReader::new_with_overrides(configs, HashMap::new(), HashMap::new())?;
+        let err = reader
+            .version_two_unsupported_reason(&ReadOptions::new(), false)
+            .unwrap_err();
+        assert!(
+            matches!(err, CoreError::Unsupported(ref m) if m.contains("metadata table")),
+            "expected an unsupported error naming the metadata table, got {err:?}"
+        );
+        Ok(())
+    }
+
+    /// A typo must not read with the other version. `get_or_default` would have
     /// swallowed this and left the caller believing they had exercised `v2`.
     #[tokio::test]
     async fn test_file_group_reader_version_unrecognised_returns_config_error() -> Result<()> {
@@ -1752,7 +1779,7 @@ mod file_group_reader_version_tests {
         Ok(())
     }
 
-    /// Asking for the engine is a request, not a guarantee: every capability is
+    /// Asking for a version is a request, not a guarantee: every capability is
     /// unimplemented so far, so version 1 serves the read and says why.
     #[tokio::test]
     async fn test_version_two_unsupported_reason_nothing_implemented_returns_reason() -> Result<()>
@@ -1770,7 +1797,7 @@ mod file_group_reader_version_tests {
         let reason = reader.version_two_unsupported_reason(&ReadOptions::new(), false)?;
         assert!(
             reason.is_some(),
-            "with no engine wired up, every read must fall back"
+            "with nothing wired up, every read must fall back"
         );
         Ok(())
     }
@@ -1784,8 +1811,8 @@ mod file_group_reader_version_tests {
         let slices = table.get_file_slices(&ReadOptions::new()).await?;
         assert!(!slices.is_empty(), "fixture must have a file slice to read");
 
-        let read_with = async |engine: Option<&str>| -> Result<Vec<String>> {
-            let options: Vec<(&str, String)> = match engine {
+        let read_with = async |version: Option<&str>| -> Result<Vec<String>> {
+            let options: Vec<(&str, String)> = match version {
                 Some(e) => vec![(
                     HudiReadConfig::FileGroupReaderVersion.as_ref(),
                     e.to_string(),
@@ -1882,7 +1909,7 @@ mod file_group_reader_version_tests {
     }
 
     /// A metadata table is served by version 1 whatever the setting
-    /// says, so setting the engine globally cannot make one unreadable — table
+    /// says, so setting the version globally cannot make one unreadable — table
     /// listing itself reads one.
     #[tokio::test]
     async fn test_file_group_reader_version_metadata_table_returns_one() -> Result<()> {

--- a/crates/core/src/file_group/reader.rs
+++ b/crates/core/src/file_group/reader.rs
@@ -224,7 +224,7 @@ impl FileGroupReader {
 
     /// Which merge implementation serves this read.
     ///
-    /// A metadata table is always served by the legacy reader whatever the
+    /// A metadata table is always served by version 1 whatever the
     /// setting says: its base files and log blocks are HFile, which the
     /// merge-on-read engine has no support for. That is permanent, not
     /// transitional.
@@ -252,11 +252,11 @@ impl FileGroupReader {
     ///
     /// This is a capability check, decided from config before any I/O — never a
     /// catch-all on error. A read that fails *inside* the engine propagates:
-    /// retrying it on the legacy reader would make a bug look like a success,
+    /// retrying it on version 1 would make a bug look like a success,
     /// make results depend on which engine happened to win, and leave the
     /// differential tests unable to see anything.
     ///
-    /// Every reason here means the legacy reader serves the read instead, so
+    /// Every reason here means version 1 serves the read instead, so
     /// selecting the engine cannot turn a working read into a failing one. Each
     /// reason is logged, because a fallback nobody can observe is
     /// indistinguishable from an engine that is never used.
@@ -265,7 +265,7 @@ impl FileGroupReader {
         options: &ReadOptions,
     ) -> Result<Option<&'static str>> {
         // Deliberately an error rather than a fallback: falling back would use
-        // the legacy reader's own merge derivation, which drops deletes on a
+        // version 1's own merge derivation, which drops deletes on a
         // commit-time-ordered table. Wrong rows are worse than a refusal.
         if let Some(mode) = self
             .hudi_configs
@@ -345,12 +345,17 @@ impl FileGroupReader {
                     ));
                 }
                 Some(reason) => {
-                    log::debug!("reading '{base_file_path}' with the legacy engine: {reason}")
+                    log::debug!(
+                        "reading '{base_file_path}' with file group reader version 1: {reason}"
+                    )
                 }
             }
         }
 
         let merged = if base_file_only {
+            // Nothing to merge — a copy-on-write slice, or a read-optimized read
+            // that ignores the log files. Served by the base file reader, not by
+            // either file group reader, so the version above does not reach it.
             self.read_base_file_eager(base_file_path).await?
         } else {
             let instant_range = self.create_instant_range_for_log_file_scan()?;
@@ -1676,7 +1681,7 @@ mod tests {
 }
 
 #[cfg(test)]
-mod reader_version_seam_tests {
+mod file_group_reader_version_tests {
     use super::*;
     use crate::config::util::empty_options;
     use hudi_test::SampleTable;
@@ -1693,25 +1698,19 @@ mod reader_version_seam_tests {
     /// the default only once it were capable would put the whole behaviour change
     /// in one commit; this way each capability carries its own.
     #[tokio::test]
-    async fn the_default_version_is_two_and_still_falls_back() -> Result<()> {
+    async fn test_file_group_reader_version_unset_returns_two() -> Result<()> {
         let reader = reader_with(Vec::<(&'static str, String)>::new()).await?;
         assert_eq!(
             reader.file_group_reader_version()?,
             FileGroupReaderVersion::Two
         );
-        assert!(
-            reader
-                .version_two_unsupported_reason(&ReadOptions::new())?
-                .is_some(),
-            "the default must still be served by the existing reader"
-        );
         Ok(())
     }
 
-    /// `legacy` remains reachable, so a caller can opt out of the engine
+    /// Version 1 remains reachable, so a caller can opt out of version 2
     /// entirely rather than relying on it to keep falling back.
     #[tokio::test]
-    async fn version_one_stays_selectable_as_an_escape_hatch() -> Result<()> {
+    async fn test_file_group_reader_version_one_returns_one() -> Result<()> {
         let reader = reader_with([(
             HudiReadConfig::FileGroupReaderVersion.as_ref(),
             "1".to_string(),
@@ -1727,7 +1726,7 @@ mod reader_version_seam_tests {
     /// A typo must not read with the other engine. `get_or_default` would have
     /// swallowed this and left the caller believing they had exercised `v2`.
     #[tokio::test]
-    async fn an_unrecognised_version_is_an_error() -> Result<()> {
+    async fn test_file_group_reader_version_unrecognised_returns_config_error() -> Result<()> {
         let reader = reader_with([(
             HudiReadConfig::FileGroupReaderVersion.as_ref(),
             "9".to_string(),
@@ -1746,9 +1745,10 @@ mod reader_version_seam_tests {
     }
 
     /// Asking for the engine is a request, not a guarantee: every capability is
-    /// unimplemented so far, so the legacy reader serves the read and says why.
+    /// unimplemented so far, so version 1 serves the read and says why.
     #[tokio::test]
-    async fn asking_for_version_two_falls_back_with_a_reason() -> Result<()> {
+    async fn test_version_two_unsupported_reason_nothing_implemented_returns_reason() -> Result<()>
+    {
         let reader = reader_with([(
             HudiReadConfig::FileGroupReaderVersion.as_ref(),
             "2".to_string(),
@@ -1770,7 +1770,7 @@ mod reader_version_seam_tests {
     /// The fall back is what makes the default safe: a read works exactly as it
     /// did, because the existing reader served it either way.
     #[tokio::test]
-    async fn selecting_version_two_does_not_change_what_a_read_returns() -> Result<()> {
+    async fn test_read_file_slice_from_paths_default_version_matches_version_one() -> Result<()> {
         let base_url = SampleTable::V6Nonpartitioned.url_to_mor_parquet();
         let table = crate::table::Table::new(base_url.path()).await?;
         let slices = table.get_file_slices(&ReadOptions::new()).await?;
@@ -1803,11 +1803,11 @@ mod reader_version_seam_tests {
         Ok(())
     }
 
-    /// A metadata table is served by the legacy reader whatever the setting
+    /// A metadata table is served by version 1 whatever the setting
     /// says, so setting the engine globally cannot make one unreadable — table
     /// listing itself reads one.
     #[tokio::test]
-    async fn a_metadata_table_ignores_the_setting() -> Result<()> {
+    async fn test_file_group_reader_version_metadata_table_returns_one() -> Result<()> {
         use crate::config::HudiConfigs;
         use crate::config::table::HudiTableConfig;
         use std::collections::HashMap;

--- a/crates/core/src/file_group/reader.rs
+++ b/crates/core/src/file_group/reader.rs
@@ -263,16 +263,23 @@ impl FileGroupReader {
     fn version_two_unsupported_reason(
         &self,
         options: &ReadOptions,
+        base_file_only: bool,
     ) -> Result<Option<&'static str>> {
         // Deliberately an error rather than a fallback: falling back would use
         // version 1's own merge derivation, which drops deletes on a
         // commit-time-ordered table. Wrong rows are worse than a refusal.
-        if let Some(mode) = self
-            .hudi_configs
-            .as_options()
-            // Read by raw key: this crate has no typed config for it yet, and
-            // adding one belongs with the reader that acts on it.
-            .get("hoodie.record.merge.mode")
+        //
+        // Only when a merge actually happens, though. A slice with nothing to
+        // merge — copy-on-write, or read-optimized — returns base rows without
+        // consulting a merger at all, so refusing it would break reads that work
+        // today over a mode they never reach.
+        if !base_file_only
+            && let Some(mode) = self
+                .hudi_configs
+                .as_options()
+                // Read by raw key: this crate has no typed config for it yet, and
+                // adding one belongs with the reader that acts on it.
+                .get("hoodie.record.merge.mode")
             && mode.eq_ignore_ascii_case("CUSTOM")
         {
             return Err(CoreError::Unsupported(
@@ -328,7 +335,7 @@ impl FileGroupReader {
         let base_file_only = log_file_paths.is_empty() || options.is_read_optimized()?;
 
         if self.file_group_reader_version()? == FileGroupReaderVersion::Two {
-            match self.version_two_unsupported_reason(&options)? {
+            match self.version_two_unsupported_reason(&options, base_file_only)? {
                 None => {
                     // Claiming a capability is claiming the rows are right, and
                     // nothing in this crate can check that at runtime: a reader
@@ -1759,7 +1766,7 @@ mod file_group_reader_version_tests {
             FileGroupReaderVersion::Two
         );
 
-        let reason = reader.version_two_unsupported_reason(&ReadOptions::new())?;
+        let reason = reader.version_two_unsupported_reason(&ReadOptions::new(), false)?;
         assert!(
             reason.is_some(),
             "with no engine wired up, every read must fall back"
@@ -1776,7 +1783,7 @@ mod file_group_reader_version_tests {
         let slices = table.get_file_slices(&ReadOptions::new()).await?;
         assert!(!slices.is_empty(), "fixture must have a file slice to read");
 
-        let read_with = async |engine: Option<&str>| -> Result<usize> {
+        let read_with = async |engine: Option<&str>| -> Result<Vec<String>> {
             let options: Vec<(&str, String)> = match engine {
                 Some(e) => vec![(
                     HudiReadConfig::FileGroupReaderVersion.as_ref(),
@@ -1785,20 +1792,90 @@ mod file_group_reader_version_tests {
                 None => Vec::new(),
             };
             let reader = FileGroupReader::new_with_options(base_url.as_ref(), options).await?;
-            let mut rows = 0;
+            // Rendered cell by cell rather than counted: a row count would
+            // match even if the columns or the values differed.
+            let mut rendered: Vec<String> = Vec::new();
             for slice in &slices {
-                rows += reader
-                    .read_file_slice(slice, &ReadOptions::new())
-                    .await?
-                    .num_rows();
+                let batch = reader.read_file_slice(slice, &ReadOptions::new()).await?;
+                let names: Vec<String> = batch
+                    .schema()
+                    .fields()
+                    .iter()
+                    .map(|f| f.name().clone())
+                    .collect();
+                rendered.push(names.join(","));
+                for row in 0..batch.num_rows() {
+                    let cells: Vec<String> = batch
+                        .columns()
+                        .iter()
+                        .map(|col| {
+                            arrow_cast::display::array_value_to_string(col.as_ref(), row)
+                                .unwrap_or_else(|_| "<unrenderable>".to_string())
+                        })
+                        .collect();
+                    rendered.push(cells.join(" | "));
+                }
             }
-            Ok(rows)
+            rendered.sort();
+            Ok(rendered)
         };
 
         assert_eq!(
             read_with(None).await?,
             read_with(Some("1")).await?,
             "the default must return what an explicit version 1 read returns"
+        );
+        Ok(())
+    }
+
+    /// A table declaring a CUSTOM record merge mode still reads when there is
+    /// nothing to merge.
+    ///
+    /// The refusal exists because falling back would merge with version 1's own
+    /// derivation, which drops deletes. But a copy-on-write slice and a
+    /// read-optimized read never consult a merger, so refusing them would break
+    /// reads that work today over a mode they never reach — and version 2 being
+    /// the default means nobody opted in to that.
+    #[tokio::test]
+    async fn test_version_two_unsupported_reason_custom_merge_mode_without_merge_returns_reason()
+    -> Result<()> {
+        let reader = reader_with([("hoodie.record.merge.mode", "CUSTOM".to_string())]).await?;
+
+        // Nothing to merge: falls back like any other unimplemented capability.
+        assert!(
+            reader
+                .version_two_unsupported_reason(&ReadOptions::new(), true)?
+                .is_some(),
+            "a read with nothing to merge must not be refused for a merge mode"
+        );
+
+        // A read-optimized read reaches the same conclusion through `options`.
+        let read_optimized = ReadOptions::new()
+            .with_hudi_option(HudiReadConfig::UseReadOptimizedMode.as_ref(), "true");
+        assert!(
+            reader
+                .version_two_unsupported_reason(&read_optimized, true)?
+                .is_some()
+        );
+        Ok(())
+    }
+
+    /// The same table is refused once a merge is actually involved.
+    #[tokio::test]
+    async fn test_version_two_unsupported_reason_custom_merge_mode_with_merge_returns_error()
+    -> Result<()> {
+        let reader = reader_with([("hoodie.record.merge.mode", "CUSTOM".to_string())]).await?;
+
+        let err = reader
+            .version_two_unsupported_reason(&ReadOptions::new(), false)
+            .unwrap_err();
+        assert!(
+            matches!(err, CoreError::Unsupported(_)),
+            "expected a refusal, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("CUSTOM"),
+            "the error must name why"
         );
         Ok(())
     }

--- a/crates/core/src/file_group/reader.rs
+++ b/crates/core/src/file_group/reader.rs
@@ -18,7 +18,7 @@
  */
 use crate::Result;
 use crate::config::HudiConfigs;
-use crate::config::read::HudiReadConfig;
+use crate::config::read::{FileGroupReaderVersion, HudiReadConfig};
 use crate::config::table::{BaseFileFormatValue, HudiTableConfig};
 use crate::error::CoreError;
 use crate::error::CoreError::ReadFileSliceError;
@@ -49,6 +49,7 @@ use futures::stream::BoxStream;
 use futures::{StreamExt, TryFutureExt};
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::str::FromStr;
 use std::sync::Arc;
 
 /// The reader that handles all read operations against a file group.
@@ -221,6 +222,88 @@ impl FileGroupReader {
             .await
     }
 
+    /// Which merge implementation serves this read.
+    ///
+    /// A metadata table is always served by the legacy reader whatever the
+    /// setting says: its base files and log blocks are HFile, which the
+    /// merge-on-read engine has no support for. That is permanent, not
+    /// transitional.
+    ///
+    /// The value is read raw rather than through `get_or_default`, which falls
+    /// back to the default when a value fails to parse. A typo in the engine
+    /// name would then silently read with the other engine, leaving a caller
+    /// convinced they had exercised it — the one outcome this switch must not
+    /// produce.
+    fn file_group_reader_version(&self) -> Result<FileGroupReaderVersion> {
+        if self.is_metadata_table() {
+            return Ok(FileGroupReaderVersion::One);
+        }
+        match self
+            .hudi_configs
+            .as_options()
+            .get(HudiReadConfig::FileGroupReaderVersion.as_ref())
+        {
+            Some(raw) => FileGroupReaderVersion::from_str(raw).map_err(CoreError::Config),
+            None => Ok(FileGroupReaderVersion::default()),
+        }
+    }
+
+    /// Why the merge-on-read engine cannot serve this read, if it cannot.
+    ///
+    /// This is a capability check, decided from config before any I/O — never a
+    /// catch-all on error. A read that fails *inside* the engine propagates:
+    /// retrying it on the legacy reader would make a bug look like a success,
+    /// make results depend on which engine happened to win, and leave the
+    /// differential tests unable to see anything.
+    ///
+    /// Every reason here means the legacy reader serves the read instead, so
+    /// selecting the engine cannot turn a working read into a failing one. Each
+    /// reason is logged, because a fallback nobody can observe is
+    /// indistinguishable from an engine that is never used.
+    fn version_two_unsupported_reason(
+        &self,
+        options: &ReadOptions,
+    ) -> Result<Option<&'static str>> {
+        // Deliberately an error rather than a fallback: falling back would use
+        // the legacy reader's own merge derivation, which drops deletes on a
+        // commit-time-ordered table. Wrong rows are worse than a refusal.
+        if let Some(mode) = self
+            .hudi_configs
+            .as_options()
+            // Read by raw key: this crate has no typed config for it yet, and
+            // adding one belongs with the reader that acts on it.
+            .get("hoodie.record.merge.mode")
+            && mode.eq_ignore_ascii_case("CUSTOM")
+        {
+            return Err(CoreError::Unsupported(
+                "A table with a CUSTOM record merge mode needs its own merger, \
+                 which no reader here implements"
+                    .to_string(),
+            ));
+        }
+
+        // Unreachable while `file_group_reader_version` routes a metadata table
+        // to version 1 above; kept so a future change to that routing fails
+        // loudly here rather than reaching a reader that cannot read HFile.
+        if self.is_metadata_table() {
+            return Err(CoreError::Unsupported(
+                "The merge-on-read engine cannot read a metadata table's HFile \
+                 base files and log blocks"
+                    .to_string(),
+            ));
+        }
+
+        if options.is_read_optimized()? {
+            return Ok(Some("read-optimized reads are not served yet"));
+        }
+        // The fallthrough reports *unsupported*, deliberately: capability is
+        // enumerated, not assumed, so a situation nobody considered falls back
+        // rather than being served by an engine that has never seen it.
+        // Inverting this is a one-line change with no visible symptom, which is
+        // why it is called out here.
+        Ok(Some("the merge-on-read engine is not wired up yet"))
+    }
+
     /// Reads a file slice from a base file and a list of log files.
     ///
     /// `options.filters` are applied as a row-level mask after reading;
@@ -243,6 +326,29 @@ impl FileGroupReader {
             .map(|s| s.as_ref().to_string())
             .collect();
         let base_file_only = log_file_paths.is_empty() || options.is_read_optimized()?;
+
+        if self.file_group_reader_version()? == FileGroupReaderVersion::Two {
+            match self.version_two_unsupported_reason(&options)? {
+                None => {
+                    // Claiming a capability is claiming the rows are right, and
+                    // nothing in this crate can check that at runtime: a reader
+                    // that knew its answer was wrong would not be wrong. Only a
+                    // differential comparison against Hudi's own reader can, and
+                    // that is a test harness. So a capability may only be added
+                    // together with fixture coverage proving it.
+                    return Err(CoreError::Unsupported(
+                        "The merge-on-read engine reports itself able to serve this read, \
+                         but no engine is wired up behind the switch yet. A capability must \
+                         not be claimed here before there is fixture coverage comparing its \
+                         output against Hudi's reader"
+                            .to_string(),
+                    ));
+                }
+                Some(reason) => {
+                    log::debug!("reading '{base_file_path}' with the legacy engine: {reason}")
+                }
+            }
+        }
 
         let merged = if base_file_only {
             self.read_base_file_eager(base_file_path).await?
@@ -1288,7 +1394,7 @@ mod tests {
     // Metadata Table File Slice Reading Tests
     // =========================================================================
 
-    fn get_metadata_table_base_uri() -> String {
+    pub(super) fn get_metadata_table_base_uri() -> String {
         use hudi_test::QuickstartTripsTable;
         let table_path = QuickstartTripsTable::V8Trips8I3U1D.path_to_mor_avro();
         let metadata_table_path = PathBuf::from(table_path).join(".hoodie").join("metadata");
@@ -1565,6 +1671,166 @@ mod tests {
         assert!(!filtered_records.contains_key("city=san_francisco"));
         assert!(!filtered_records.contains_key("city=sao_paulo"));
 
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod reader_version_seam_tests {
+    use super::*;
+    use crate::config::util::empty_options;
+    use hudi_test::SampleTable;
+
+    async fn reader_with(
+        options: impl IntoIterator<Item = (&'static str, String)>,
+    ) -> Result<FileGroupReader> {
+        let base_url = SampleTable::V6Nonpartitioned.url_to_mor_parquet();
+        FileGroupReader::new_with_options(base_url.as_ref(), options).await
+    }
+
+    /// The merge-on-read engine is the default, and nothing changes for a caller
+    /// who sets nothing — because every capability falls back today. Making it
+    /// the default only once it were capable would put the whole behaviour change
+    /// in one commit; this way each capability carries its own.
+    #[tokio::test]
+    async fn the_default_version_is_two_and_still_falls_back() -> Result<()> {
+        let reader = reader_with(Vec::<(&'static str, String)>::new()).await?;
+        assert_eq!(
+            reader.file_group_reader_version()?,
+            FileGroupReaderVersion::Two
+        );
+        assert!(
+            reader
+                .version_two_unsupported_reason(&ReadOptions::new())?
+                .is_some(),
+            "the default must still be served by the existing reader"
+        );
+        Ok(())
+    }
+
+    /// `legacy` remains reachable, so a caller can opt out of the engine
+    /// entirely rather than relying on it to keep falling back.
+    #[tokio::test]
+    async fn version_one_stays_selectable_as_an_escape_hatch() -> Result<()> {
+        let reader = reader_with([(
+            HudiReadConfig::FileGroupReaderVersion.as_ref(),
+            "1".to_string(),
+        )])
+        .await?;
+        assert_eq!(
+            reader.file_group_reader_version()?,
+            FileGroupReaderVersion::One
+        );
+        Ok(())
+    }
+
+    /// A typo must not read with the other engine. `get_or_default` would have
+    /// swallowed this and left the caller believing they had exercised `v2`.
+    #[tokio::test]
+    async fn an_unrecognised_version_is_an_error() -> Result<()> {
+        let reader = reader_with([(
+            HudiReadConfig::FileGroupReaderVersion.as_ref(),
+            "9".to_string(),
+        )])
+        .await?;
+        let err = reader.file_group_reader_version().unwrap_err();
+        assert!(
+            matches!(err, CoreError::Config(_)),
+            "expected a config error, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("9"),
+            "the error must name the value"
+        );
+        Ok(())
+    }
+
+    /// Asking for the engine is a request, not a guarantee: every capability is
+    /// unimplemented so far, so the legacy reader serves the read and says why.
+    #[tokio::test]
+    async fn asking_for_version_two_falls_back_with_a_reason() -> Result<()> {
+        let reader = reader_with([(
+            HudiReadConfig::FileGroupReaderVersion.as_ref(),
+            "2".to_string(),
+        )])
+        .await?;
+        assert_eq!(
+            reader.file_group_reader_version()?,
+            FileGroupReaderVersion::Two
+        );
+
+        let reason = reader.version_two_unsupported_reason(&ReadOptions::new())?;
+        assert!(
+            reason.is_some(),
+            "with no engine wired up, every read must fall back"
+        );
+        Ok(())
+    }
+
+    /// The fall back is what makes the default safe: a read works exactly as it
+    /// did, because the existing reader served it either way.
+    #[tokio::test]
+    async fn selecting_version_two_does_not_change_what_a_read_returns() -> Result<()> {
+        let base_url = SampleTable::V6Nonpartitioned.url_to_mor_parquet();
+        let table = crate::table::Table::new(base_url.path()).await?;
+        let slices = table.get_file_slices(&ReadOptions::new()).await?;
+        assert!(!slices.is_empty(), "fixture must have a file slice to read");
+
+        let read_with = async |engine: Option<&str>| -> Result<usize> {
+            let options: Vec<(&str, String)> = match engine {
+                Some(e) => vec![(
+                    HudiReadConfig::FileGroupReaderVersion.as_ref(),
+                    e.to_string(),
+                )],
+                None => Vec::new(),
+            };
+            let reader = FileGroupReader::new_with_options(base_url.as_ref(), options).await?;
+            let mut rows = 0;
+            for slice in &slices {
+                rows += reader
+                    .read_file_slice(slice, &ReadOptions::new())
+                    .await?
+                    .num_rows();
+            }
+            Ok(rows)
+        };
+
+        assert_eq!(
+            read_with(None).await?,
+            read_with(Some("1")).await?,
+            "the default must return what an explicit version 1 read returns"
+        );
+        Ok(())
+    }
+
+    /// A metadata table is served by the legacy reader whatever the setting
+    /// says, so setting the engine globally cannot make one unreadable — table
+    /// listing itself reads one.
+    #[tokio::test]
+    async fn a_metadata_table_ignores_the_setting() -> Result<()> {
+        use crate::config::HudiConfigs;
+        use crate::config::table::HudiTableConfig;
+        use std::collections::HashMap;
+        use std::sync::Arc;
+
+        // Built from configs rather than resolved from storage: a metadata table
+        // has no `hoodie.properties` of its own to load.
+        let configs = Arc::new(HudiConfigs::new([
+            (
+                HudiTableConfig::BasePath.as_ref(),
+                super::tests::get_metadata_table_base_uri(),
+            ),
+            (
+                HudiReadConfig::FileGroupReaderVersion.as_ref(),
+                "2".to_string(),
+            ),
+        ]));
+        let reader = FileGroupReader::new_with_overrides(configs, HashMap::new(), HashMap::new())?;
+        assert!(reader.is_metadata_table());
+        assert_eq!(
+            reader.file_group_reader_version()?,
+            FileGroupReaderVersion::One
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
Foundation for landing a second merge implementation. **3 files, +435/−2.** No read changes.

### What this establishes

`hoodie.read.file.group.reader.version` selects `2` (the default) or `1`.
`FileGroupReader::read_file_slice_from_paths` becomes the single decision point for reads that
merge — which is every eager read, and the streaming reads that have log files:

```
read_file_slice_from_paths(base, logs, options)
  ├─ metadata table            → existing reader   (always, setting ignored)
  ├─ version == 1              → version 1         (explicit escape hatch)
  ├─ version 2 cannot serve it → version 1         (reason logged)
  ├─ version == 2              → version 2
  └─ no logs / read-optimized  → base-file read
                                     │
                       all paths ────┴──→ apply_eager_options(filters, projection)
```

`Table`, DataFusion, the Python binding and the cxx bridge are untouched.

**One asymmetry worth naming.** `read_file_slice_from_paths_stream_inner` answers two cases
before it would reach the switch: a read-optimized stream, and a stream over a slice with no log
files. Both go straight to `read_base_file_stream`, so the version setting is not consulted there.
That is harmless in this PR — every capability falls back, so version 2 is never entered
anywhere — but it means a streaming read-optimized query would silently keep using the existing
reader once version 2 becomes capable. Whether the streaming path should consult the switch is a
decision worth making deliberately rather than inheriting from the order of these branches; it is
left as-is here so the seam lands without changing streaming behaviour.

### Why version 2 is already the default

It serves nothing yet, so the fall back makes the default inert — a test asserts a real
merge-on-read slice returns the same rows as an explicit version 1 read.

Making it the default only once it were capable would put the whole behaviour change in a single
commit whose diff shows nothing functional — the scariest possible shape to review. This way
that commit never exists: each capability-adding PR carries its own small, individually
revertable behaviour change, and *"v2 now serves base-file-only reads"* is a claim a reviewer can
actually evaluate.

**The consequence to hold in review:** a failure *inside* version 2 now reaches every caller,
not just one who opted in. The capability check must therefore stay conservative — when in
doubt, report unsupported. Today that risk is zero, because nothing is claimed.

version 1 remains selectable, so a caller can opt out entirely rather than relying on fall back.

### Selecting a version is a request, not a guarantee

`version_two_unsupported_reason()` runs first and names what version 2 cannot serve. Those reads are
served by the existing reader instead, so **the setting cannot turn a working read into a failing
one** — and version 2 can land incrementally behind a contract that removes one reason at a
time, rather than needing full parity before it is reachable.

Every fall back is logged. A fall back nobody can observe is indistinguishable from a reader
that is never used.

### The distinction that keeps fall back safe

The check is decided **from config before any I/O — never a catch-all on error.** A read that
fails *inside* version 2 propagates. Retrying it on the existing reader would make a bug look
like a success, make results depend on which reader happened to win, and leave differential
tests unable to see anything.

### Two cases error rather than fall back

- **`CUSTOM` record merge mode, when the read actually merges.** It needs a merger neither reader
  implements, and falling back would use the existing reader's own derivation, which drops
  deletes — wrong rows are worse than a refusal. The refusal is gated on a merge happening
  (`log_file_paths.is_empty() || is_read_optimized()`): a base-file-only read never consults a
  merger, so refusing it would make a `CUSTOM` table unreadable for queries that were always
  correct. Read by raw key (`hoodie.record.merge.mode`) through a borrowing `HudiConfigs::get_raw`;
  this crate has no typed config for it yet, and adding one belongs with the reader that acts on it.
- **A metadata table** is routed to the existing reader *before* the check, since its base files
  and log blocks are HFile. The error behind that routing is an unreachable guard, so a future
  change to the routing fails loudly rather than reaching a reader that cannot read HFile.
  Erroring outright would make metadata tables unreadable whenever the setting is applied
  globally — and table listing reads one.

### An unrecognised value is an error

Not a fall back to the default. `get_or_default` would have swallowed a typo and read with the
other version, leaving a caller convinced they had exercised the one they asked for. That is the
one outcome a switch like this must not produce.

The lookup goes through `HudiConfigs::try_get`, which already had exactly these semantics —
it parses and returns `Err` rather than falling back. Leniency stays the right default for most
configs; it is specifically wrong here.

### The rule this seam exists to make enforceable

The fall back handles what version 2 *knows* it cannot do. Nothing here defends against version 2 returning
plausible but wrong rows — and nothing at runtime can: a reader that knew its answer was wrong
would not be wrong. Only a differential comparison against Hudi's own reader catches that, and
that is a test harness, not a guard.

So the safety property is procedural, and worth agreeing before the first capability lands rather
than after:

> **A capability may only be claimed together with fixture coverage comparing its output against
> Hudi's reader.**

Two things in this PR are shaped to support it:

- **Capability is enumerated, not assumed.** The fallthrough of `version_two_unsupported_reason` reports
  *unsupported*, so a situation nobody considered falls back rather than being served by a reader
  that has never seen it. Inverting that is a one-line change with no visible symptom, which is
  why it is called out in a comment at the site.
- **The "version 2 reports itself capable" branch errors**, and its message says a capability must
  not be claimed before that coverage exists — so the requirement is in the source a contributor
  will actually hit, not only in this description.

What is still missing, and belongs with the first capability rather than here: the differential
harness itself, and a counter or read-stat making "is version 2 serving anything?" answerable in
production. A fall back nobody can observe is indistinguishable from a reader that is never used
— we have been caught by exactly that twice.

### Where the check is going: a positive capability list

The check here is a **negative** list — enumerate what version 2 cannot do, fall through to
unsupported. Safe, but the safety is a convention: the fallthrough is one line from being
inverted with no visible symptom.

The intended next step, landing with the first capability rather than here, is to make it
**positive and structural**:

```rust
enum SupportedCategory { BaseFileOnly, /* … */ }

impl SupportedCategory {
    /// Fixtures proving this category: …
    fn matches(&self, configs: &HudiConfigs, options: &ReadOptions,
               base_file_path: &str, log_file_paths: &[String]) -> bool
}

/// `None` → no category claims this read → fall back.
fn supported_category(...) -> Option<SupportedCategory>
```

version 2 serves a read only if some category claims it. Adding a variant forces every match arm to be
revisited, and a query shape nobody considered cannot be served, because no category claims it —
enforcement in the type system rather than in a comment.

It also makes the coverage rule above checkable: each variant names, in its doc comment, the
fixtures that prove it. *"A capability may only be claimed with fixture coverage"* becomes
something a reviewer verifies by reading the enum.

The two checks stay separate, and the order matters:

| | question | outcome |
|---|---|---|
| `version_two_unsupported_reason` | *should anyone serve this?* | **error** — `CUSTOM` merge mode, metadata table |
| `SupportedCategory` | *has version 2 been proven to serve this?* | **fall back** |

A `CUSTOM` table must error even if a category would otherwise match it, so refusals run first.

Two notes on shape. Categories should track the dimensions the code actually branches on —
base-file-only vs merge, log block format, query type — not table version or keygen, which the
reader does not branch on; too coarse claims too much, too fine sprawls. And the validator cannot
work from configs alone: whether a slice has log files is per-slice, not per-table, so it takes
the same inputs the dispatch already has.

**A category is an assertion, not a proof.** `BaseFileOnly` can match a base file whose schema
evolution version 2 mishandles. Categories narrow the claim; the fixture coverage verifies it. That is
why tying each variant to its fixtures matters more than the enum itself.

It is not introduced in this PR because there are zero supported categories yet — an enum with no
variants cannot be matched exhaustively and is dead code. It arrives with its first real variant,
and its first proof.

### On the name

`hoodie.read.file.group.reader.version`, with bare integers, replaces an earlier
`hoodie.read.merge.engine = legacy | v2`. Three reasons, all worth settling before release since
this becomes public API:

- **`merge.engine` collided.** Hudi already has `hoodie.datasource.merge.type`
  (`skip_merge` / `payload_combine`), which is a *semantic* choice — what merging does. This is an
  *implementation* choice — which code does it. "Engine" is also overloaded in Hudi, where it
  usually means the compute engine.
- **`legacy` was a value judgement that inverts.** Once the newer reader is the default, `legacy`
  is what you deliberately opt *into*; asking a user to set "legacy" to get a working read reads
  badly. A version number carries no such judgement.
- **A version says the older one is being retired**, not kept as an alternative. Names like
  `batch_merge` / `record_merge` would imply a permanent choice between two valid strategies,
  which is not the intent.

Bare integers match how Hudi already versions things — `hoodie.table.version`,
`hoodie.timeline.layout.version`, `hoodie.write.table.version` — and make the config an integer,
so an unparseable value errors without string matching.

### Testing

Eight tests: the default is version 2 and still falls back; version 1 stays selectable as an
escape hatch; an unrecognised value errors and names it; asking for version 2 falls back with a
reason; **a real merge-on-read slice returns the same rows under the default as under an explicit
version 1 read** — compared cell by cell, since a row count matches even when the columns or the
values do not; a metadata table ignores the setting; and `CUSTOM` errors when the read merges but
falls back with a reason when it does not.

Every capability is unimplemented in this PR, so version 2 is never entered. If it ever reports itself
capable before version 2 is wired up, the read errors loudly rather than silently doing nothing.

Full suite green: 718 core + 79 table-read + 39 datafusion. `cargo fmt --check` and clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





