### PR TITLE
perf(core): bound the merge chunk rather than moving the merge off the executor

### DIFF
--- a/crates/core/src/file_group/log_file/log_block.rs
+++ b/crates/core/src/file_group/log_file/log_block.rs
@@ -357,8 +357,14 @@ impl LogBlock {
             &self.header,
         )?;
         // Content is decoded, so the means to fetch it again is dead weight.
-        // Mirrors Java's `deflate()` releasing the block's `byte[]`.
-        self.deferred_content = None;
+        // Mirrors Java's `deflate()` releasing the block's `byte[]`. A block that
+        // decodes to no content keeps its location: a command block decodes to
+        // `Empty`, which is indistinguishable here from never having been loaded,
+        // so releasing it there would turn a second call into an error rather
+        // than the no-op it is.
+        if !self.content.is_empty() {
+            self.deferred_content = None;
+        }
         Ok(())
     }
 

--- a/crates/core/src/file_group/log_file/log_block.rs
+++ b/crates/core/src/file_group/log_file/log_block.rs
@@ -333,6 +333,21 @@ impl LogBlock {
         let bytes = fetcher
             .read_content(location.content_position, location.content_length)
             .map_err(CoreError::ReadLogFileError)?;
+        // A ranged read whose end runs past the file is CLAMPED rather than
+        // refused, so an overlong content length comes back as a short buffer.
+        // That length is read straight out of the file and nothing upstream
+        // validates it — `is_block_corrupted` checks the block's outer span, not
+        // this inner field — so decoding the short buffer would fail somewhere
+        // inside the block format rather than naming the real problem.
+        if bytes.len() as u64 != location.content_length {
+            return Err(CoreError::LogBlockError(format!(
+                "ranged read at offset {} returned {} bytes, expected {}: this block's content \
+                 runs past the end of the file (truncated or corrupt block)",
+                location.content_position,
+                bytes.len(),
+                location.content_length,
+            )));
+        }
         let mut reader = std::io::Cursor::new(bytes);
         self.content = decoder.decode_content(
             &mut reader,
@@ -341,6 +356,9 @@ impl LogBlock {
             &self.block_type,
             &self.header,
         )?;
+        // Content is decoded, so the means to fetch it again is dead weight.
+        // Mirrors Java's `deflate()` releasing the block's `byte[]`.
+        self.deferred_content = None;
         Ok(())
     }
 

--- a/crates/core/src/file_group/log_file/log_block.rs
+++ b/crates/core/src/file_group/log_file/log_block.rs
@@ -321,7 +321,7 @@ impl LogBlock {
     /// Reads only this block's own range, so a scan can walk a file without
     /// holding it and each admitted block costs its own content and no more.
     /// A block that already has content is left alone.
-    pub fn load_content(&mut self, decoder: &Decoder) -> Result<()> {
+    pub async fn load_content(&mut self, decoder: &Decoder) -> Result<()> {
         if !self.content.is_empty() {
             return Ok(());
         }
@@ -333,6 +333,7 @@ impl LogBlock {
 
         let bytes = fetcher
             .read_content(location.content_position, location.content_length)
+            .await
             .map_err(CoreError::ReadLogFileError)?;
         self.decode_fetched(decoder, bytes)
     }

--- a/crates/core/src/file_group/log_file/log_block.rs
+++ b/crates/core/src/file_group/log_file/log_block.rs
@@ -24,6 +24,7 @@ use crate::file_group::log_file::log_format::LogFormatVersion;
 use crate::file_group::record_batches::RecordBatches;
 use crate::hfile::HFileRecord;
 use crate::storage::reader::LogBlockFetcher;
+use bytes::Bytes;
 use std::collections::HashMap;
 use std::str::FromStr;
 
@@ -333,6 +334,24 @@ impl LogBlock {
         let bytes = fetcher
             .read_content(location.content_position, location.content_length)
             .map_err(CoreError::ReadLogFileError)?;
+        self.decode_fetched(decoder, bytes)
+    }
+
+    /// Decode content that was already fetched for this block.
+    ///
+    /// Pairs with the batched prefetch in Pass 3, which reads many blocks'
+    /// ranges in one call and then hands each block its own bytes. Identical to
+    /// [`Self::load_content`] from the length check onwards, so a prefetched
+    /// block and a self-fetched one decode by the same path.
+    pub fn decode_fetched(&mut self, decoder: &Decoder, bytes: Bytes) -> Result<()> {
+        if !self.content.is_empty() {
+            return Ok(());
+        }
+        let Some(DeferredContent { location, .. }) = self.deferred_content.as_ref() else {
+            return Err(CoreError::LogBlockError(
+                "Cannot load the content of a block that was not read headers-only".to_string(),
+            ));
+        };
         // A ranged read whose end runs past the file is CLAMPED rather than
         // refused, so an overlong content length comes back as a short buffer.
         // That length is read straight out of the file and nothing upstream

--- a/crates/core/src/file_group/log_file/memory_bench.rs
+++ b/crates/core/src/file_group/log_file/memory_bench.rs
@@ -163,6 +163,7 @@ async fn bench_log_read_memory() {
             let mut reader = LogFileReader::new(configs(), storage, name).await.unwrap();
             let blocks = reader
                 .read_all_blocks(&InstantRange::up_to("99991231235959999", "utc"))
+                .await
                 .unwrap();
             let rows: usize = blocks
                 .iter()
@@ -174,12 +175,12 @@ async fn bench_log_read_memory() {
             let mut reader = LogFileReader::new_streaming(configs(), storage, name)
                 .await
                 .unwrap();
-            let mut blocks = reader.read_all_blocks_metadata_only().unwrap();
+            let mut blocks = reader.read_all_blocks_metadata_only().await.unwrap();
             let decoder = Decoder::new(configs());
             let mut rows = 0usize;
             let mut peak = rss_mb();
             for block in blocks.iter_mut() {
-                block.load_content(&decoder).unwrap();
+                block.load_content(&decoder).await.unwrap();
                 rows += block
                     .content
                     .as_records()

--- a/crates/core/src/file_group/log_file/reader.rs
+++ b/crates/core/src/file_group/log_file/reader.rs
@@ -1040,6 +1040,153 @@ mod tests {
         Ok(())
     }
 
+    /// Options carrying a base path, and a streaming window when one is asked
+    /// for. `Storage::new_with_base_url` builds its own configs, so the window
+    /// knob has to be set on the storage the reader is opened from.
+    fn storage_with_window(dir: &str, window: Option<u64>) -> Result<Arc<Storage>> {
+        let mut options = HashMap::new();
+        options.insert(
+            HudiTableConfig::BasePath.as_ref().to_string(),
+            parse_uri(dir)?.as_str().to_string(),
+        );
+        options.insert(
+            HudiTableConfig::OrderingFields.as_ref().to_string(),
+            "ts".to_string(),
+        );
+        if let Some(window) = window {
+            options.insert(
+                crate::storage::reader::CONFIG_DFS_BUFFER_MAX_SIZE.to_string(),
+                window.to_string(),
+            );
+        }
+        Ok(Storage::new(
+            Arc::new(HashMap::new()),
+            Arc::new(HudiConfigs::new(options)),
+        )?)
+    }
+
+    /// A file whose first block is corrupt and whose second block's MAGIC starts
+    /// `straddle_by` bytes before the end of the recovery scan's first 1 MiB
+    /// window. Returns the directory, the file name, and where the good block
+    /// starts.
+    fn corrupt_then_good_file(straddle_by: u64) -> (tempfile::TempDir, String, u64) {
+        let (dir, file_name) = get_valid_log_avro_data();
+        let good = std::fs::read(PathBuf::from(&dir).join(&file_name)).unwrap();
+
+        let magic_len = MAGIC.len() as u64;
+        let scan = LogFileReader::<StorageReader>::BLOCK_SCAN_READ_BUFFER_SIZE as u64;
+        // The scan starts at `magic_len` and reads `scan` bytes, so its first
+        // window ends at `magic_len + scan`. Landing the good block's MAGIC
+        // `straddle_by` bytes before that end splits the marker across two
+        // windows.
+        let block_start = magic_len + scan - straddle_by;
+
+        let mut bytes = Vec::with_capacity(block_start as usize + good.len());
+        bytes.extend_from_slice(MAGIC);
+        // A length no file can hold, so the block is corrupt by arithmetic
+        // rather than by a trailing-pointer mismatch. All-ones also cannot
+        // contain MAGIC, which the scan would otherwise find.
+        bytes.extend_from_slice(&u64::MAX.to_be_bytes());
+        bytes.resize(block_start as usize, 0);
+        bytes.extend_from_slice(&good);
+
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join(&file_name), &bytes).unwrap();
+        (tmp, file_name, block_start)
+    }
+
+    /// Recovery from a corrupt block scans forward for the next MAGIC over 1 MiB
+    /// windows, and consecutive windows overlap by `MAGIC.len() - 1` so a marker
+    /// split across a boundary is still found.
+    ///
+    /// This is the one place the header walk is not a forward parse, so it is
+    /// also the case a windowed fetch gets wrong most easily: dropping the
+    /// overlap, or refilling a fetch window without it, makes the scan miss the
+    /// marker, run to EOF, and swallow every later block into the corrupt span.
+    /// Asserted for the eager reader and for streaming readers whose fetch
+    /// window is smaller than, larger than, and unrelated to the scan window.
+    async fn assert_corrupt_recovery_finds_a_straddling_magic(window: Option<u64>) -> Result<()> {
+        let scan = LogFileReader::<StorageReader>::BLOCK_SCAN_READ_BUFFER_SIZE as u64;
+        let magic_len = MAGIC.len() as u64;
+        let (tmp, file_name, block_start) = corrupt_then_good_file(3);
+        assert!(
+            block_start < magic_len + scan && block_start + magic_len > magic_len + scan,
+            "the fixture must split MAGIC across the scan's first window boundary"
+        );
+
+        let dir = tmp.path().to_str().unwrap();
+        let hudi_configs = Arc::new(HudiConfigs::new([(HudiTableConfig::OrderingFields, "ts")]));
+
+        // The scan itself lands exactly on the good block's magic, not on EOF.
+        let storage = storage_with_window(dir, window)?;
+        let mut reader = match window {
+            None => LogFileReader::new(hudi_configs.clone(), storage.clone(), &file_name).await?,
+            Some(_) => {
+                LogFileReader::new_streaming(hudi_configs.clone(), storage.clone(), &file_name)
+                    .await?
+            }
+        };
+        assert_eq!(
+            reader.scan_for_next_block_offset(0)?,
+            block_start,
+            "recovery must land on the good block's magic, not run to EOF"
+        );
+
+        // ... and the walk therefore reports the corrupt block followed by the
+        // good one, rather than one corrupt block covering the whole file.
+        let mut eager =
+            LogFileReader::new(hudi_configs.clone(), storage.clone(), &file_name).await?;
+        let eager_blocks =
+            eager.read_all_blocks(&InstantRange::up_to("99991231235959999", "utc"))?;
+        assert_eq!(
+            eager_blocks
+                .iter()
+                .map(|b| b.block_type.clone())
+                .collect::<Vec<_>>(),
+            vec![BlockType::Corrupted, BlockType::AvroData],
+        );
+        assert!(
+            eager_blocks[1].record_batches().unwrap().num_data_rows() > 0,
+            "the block after the corrupt span must still decode"
+        );
+
+        let mut lazy =
+            LogFileReader::new_streaming(hudi_configs.clone(), storage, &file_name).await?;
+        let mut lazy_blocks = lazy.read_all_blocks_metadata_only()?;
+        assert_eq!(
+            lazy_blocks
+                .iter()
+                .map(|b| b.block_type.clone())
+                .collect::<Vec<_>>(),
+            vec![BlockType::Corrupted, BlockType::AvroData],
+        );
+        let decoder = Decoder::new(hudi_configs);
+        lazy_blocks[1].load_content(&decoder)?;
+        assert_eq!(
+            lazy_blocks[1]
+                .content
+                .as_records()
+                .map(|b| b.num_data_rows()),
+            eager_blocks[1]
+                .content
+                .as_records()
+                .map(|b| b.num_data_rows()),
+            "the recovered block must decode the same either way"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_corrupt_recovery_scan_finds_a_magic_split_across_windows() -> Result<()> {
+        let scan = LogFileReader::<StorageReader>::BLOCK_SCAN_READ_BUFFER_SIZE as u64;
+        // Eager (whole file resident), a fetch window smaller than the scan
+        // window, one larger than it, and one that is not a multiple of it.
+        for window in [None, Some(scan / 2), Some(scan + 1024), Some(64 * 1024 + 7)] {
+            assert_corrupt_recovery_finds_a_straddling_magic(window).await?;
+        }
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_read_log_file_with_avro_data_block() -> Result<()> {
         let (dir, file_name) = get_valid_log_avro_data();

--- a/crates/core/src/file_group/log_file/reader.rs
+++ b/crates/core/src/file_group/log_file/reader.rs
@@ -32,26 +32,8 @@ use crate::storage::reader::StorageReader;
 use crate::storage::{RowFilterBuilder, Storage};
 use crate::timeline::selector::InstantRange;
 use std::collections::HashMap;
-use std::io::SeekFrom;
-use std::io::{self, Read, Seek};
+use std::io::{self, Cursor};
 use std::sync::Arc;
-
-/// Read until `buf` is full or the stream ends, retrying on interrupts.
-///
-/// `Read::read` may return fewer bytes than asked for without being at EOF, so
-/// a single call cannot decide whether the scan window is exhausted.
-fn read_up_to<R: Read>(reader: &mut R, buf: &mut [u8]) -> Result<usize> {
-    let mut filled = 0;
-    while filled < buf.len() {
-        match reader.read(&mut buf[filled..]) {
-            Ok(0) => break,
-            Ok(n) => filled += n,
-            Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
-            Err(e) => return Err(CoreError::ReadLogFileError(e)),
-        }
-    }
-    Ok(filled)
-}
 
 /// First offset of `needle` within `haystack`.
 fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
@@ -63,9 +45,9 @@ fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
         .position(|window| window == needle)
 }
 
-pub struct LogFileReader<R: Read + Seek> {
+pub struct LogFileReader {
     hudi_configs: Arc<HudiConfigs>,
-    reader: R,
+    reader: StorageReader,
     timezone: String,
     /// Predicate to push into parquet log blocks. Unset by default, so a caller
     /// that has not decided whether pushing is sound reads every row.
@@ -77,7 +59,7 @@ pub struct LogFileReader<R: Read + Seek> {
 
 // `row_filter` holds a closure, which has no `Debug`. Report whether one is set
 // rather than dropping the derive from the whole struct.
-impl<R: Read + Seek> std::fmt::Debug for LogFileReader<R> {
+impl std::fmt::Debug for LogFileReader {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("LogFileReader")
             .field("hudi_configs", &self.hudi_configs)
@@ -88,7 +70,7 @@ impl<R: Read + Seek> std::fmt::Debug for LogFileReader<R> {
     }
 }
 
-impl LogFileReader<StorageReader> {
+impl LogFileReader {
     pub async fn new(
         hudi_configs: Arc<HudiConfigs>,
         storage: Arc<Storage>,
@@ -135,18 +117,18 @@ impl LogFileReader<StorageReader> {
     ///
     /// `instant_range` is not applied here — the caller decides what to admit
     /// from the headers, which is the point of not decoding yet.
-    pub fn read_all_blocks_metadata_only(&mut self) -> Result<Vec<LogBlock>> {
+    pub async fn read_all_blocks_metadata_only(&mut self) -> Result<Vec<LogBlock>> {
         let fetcher = self.reader.block_fetcher();
         let mut blocks = Vec::new();
-        while let Some(block) = self.read_next_block_metadata_only(&fetcher)? {
+        while let Some(block) = self.read_next_block_metadata_only(&fetcher).await? {
             blocks.push(block);
         }
         Ok(blocks)
     }
 
-    pub fn read_all_blocks(&mut self, instant_range: &InstantRange) -> Result<Vec<LogBlock>> {
+    pub async fn read_all_blocks(&mut self, instant_range: &InstantRange) -> Result<Vec<LogBlock>> {
         let mut blocks = Vec::new();
-        while let Some(block) = self.read_next_block(instant_range)? {
+        while let Some(block) = self.read_next_block(instant_range).await? {
             if block.skipped {
                 continue;
             }
@@ -154,9 +136,7 @@ impl LogFileReader<StorageReader> {
         }
         Ok(blocks)
     }
-}
 
-impl<R: Read + Seek> LogFileReader<R> {
     /// Read [`MAGIC`] from the log file.
     ///
     /// Returns `Ok(true)` if the magic bytes are read successfully.
@@ -164,9 +144,9 @@ impl<R: Read + Seek> LogFileReader<R> {
     /// Returns `Ok(false)` if the end of the file is reached.
     ///
     /// Returns an error if the magic bytes are invalid or an I/O error occurs.
-    fn read_magic(&mut self) -> Result<bool> {
+    async fn read_magic(&mut self) -> Result<bool> {
         let mut magic = [0u8; 6];
-        match self.reader.read_exact(&mut magic) {
+        match self.reader.read_exact(&mut magic).await {
             Ok(_) => {
                 if magic != MAGIC {
                     return Err(CoreError::LogFormatError("Invalid magic".to_string()));
@@ -179,9 +159,9 @@ impl<R: Read + Seek> LogFileReader<R> {
     }
 
     /// Read 8 bytes for the log block's length excluding the magic.
-    fn read_block_length(&mut self) -> Result<u64> {
+    async fn read_block_length(&mut self) -> Result<u64> {
         let mut size_buf = [0u8; 8];
-        self.reader.read_exact(&mut size_buf)?;
+        self.reader.read_exact(&mut size_buf).await?;
         Ok(u64::from_be_bytes(size_buf))
     }
 
@@ -202,28 +182,12 @@ impl<R: Read + Seek> LogFileReader<R> {
     }
 
     /// Window used when scanning for the next MAGIC after a corrupt block.
-    const BLOCK_SCAN_READ_BUFFER_SIZE: usize = 1024 * 1024;
-
-    /// Total length of the stream, restoring the original position.
-    fn stream_len(&mut self) -> Result<u64> {
-        let cur = self
-            .reader
-            .stream_position()
-            .map_err(CoreError::ReadLogFileError)?;
-        let end = self
-            .reader
-            .seek(SeekFrom::End(0))
-            .map_err(CoreError::ReadLogFileError)?;
-        self.reader
-            .seek(SeekFrom::Start(cur))
-            .map_err(CoreError::ReadLogFileError)?;
-        Ok(end)
-    }
+    const BLOCK_SCAN_READ_BUFFER_SIZE: u64 = 1024 * 1024;
 
     /// Whether the next bytes are a MAGIC marker, treating end-of-file as one.
-    fn next_is_magic_or_eof(&mut self) -> Result<bool> {
+    async fn next_is_magic_or_eof(&mut self) -> Result<bool> {
         let mut magic = [0u8; 6];
-        match self.reader.read_exact(&mut magic) {
+        match self.reader.read_exact(&mut magic).await {
             Ok(_) => Ok(magic == MAGIC),
             Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => Ok(true),
             Err(e) => Err(CoreError::ReadLogFileError(e)),
@@ -245,7 +209,7 @@ impl<R: Read + Seek> LogFileReader<R> {
     ///
     /// The reader is left just after the length field either way, which is
     /// where the caller expects to continue from.
-    fn is_block_corrupted(&mut self, magic_pos: u64, block_length: u64) -> Result<bool> {
+    async fn is_block_corrupted(&mut self, magic_pos: u64, block_length: u64) -> Result<bool> {
         let after_length = magic_pos
             .checked_add(MAGIC.len() as u64)
             .and_then(|v| v.checked_add(8));
@@ -260,25 +224,22 @@ impl<R: Read + Seek> LogFileReader<R> {
             return Ok(true);
         };
 
-        let stream_len = self.stream_len()?;
+        let stream_len = self.reader.file_len();
 
         if trailing_pos
             .checked_add(8)
             .map(|e| e > stream_len)
             .unwrap_or(true)
         {
-            self.reader
-                .seek(SeekFrom::Start(after_length))
-                .map_err(CoreError::ReadLogFileError)?;
+            self.reader.seek_to(after_length);
             return Ok(true);
         }
 
-        self.reader
-            .seek(SeekFrom::Start(trailing_pos))
-            .map_err(CoreError::ReadLogFileError)?;
+        self.reader.seek_to(trailing_pos);
         let mut buf = [0u8; 8];
         self.reader
             .read_exact(&mut buf)
+            .await
             .map_err(CoreError::ReadLogFileError)?;
         let trailing = u64::from_be_bytes(buf);
 
@@ -295,15 +256,11 @@ impl<R: Read + Seek> LogFileReader<R> {
         let result = if corrupt {
             true
         } else {
-            self.reader
-                .seek(SeekFrom::Start(block_end))
-                .map_err(CoreError::ReadLogFileError)?;
-            !self.next_is_magic_or_eof()?
+            self.reader.seek_to(block_end);
+            !self.next_is_magic_or_eof().await?
         };
 
-        self.reader
-            .seek(SeekFrom::Start(after_length))
-            .map_err(CoreError::ReadLogFileError)?;
+        self.reader.seek_to(after_length);
         Ok(result)
     }
 
@@ -314,45 +271,45 @@ impl<R: Read + Seek> LogFileReader<R> {
     ///
     /// Windows overlap by `MAGIC.len() - 1` so a marker straddling a window
     /// boundary is still found.
-    fn scan_for_next_block_offset(&mut self, from_pos: u64) -> Result<u64> {
-        let stream_len = self.stream_len()?;
+    async fn scan_for_next_block_offset(&mut self, from_pos: u64) -> Result<u64> {
+        let stream_len = self.reader.file_len();
         let mut pos = from_pos.saturating_add(MAGIC.len() as u64);
-        if pos >= stream_len {
-            return Ok(stream_len);
-        }
-        self.reader
-            .seek(SeekFrom::Start(pos))
-            .map_err(CoreError::ReadLogFileError)?;
-        let mut buf = vec![0u8; Self::BLOCK_SCAN_READ_BUFFER_SIZE];
         loop {
-            let n = read_up_to(&mut self.reader, &mut buf)?;
-            if n == 0 {
+            let Some(remaining) = stream_len.checked_sub(pos) else {
+                return Ok(stream_len);
+            };
+            let window = remaining.min(Self::BLOCK_SCAN_READ_BUFFER_SIZE);
+            if window == 0 {
                 return Ok(stream_len);
             }
-            if let Some(idx) = find_subslice(&buf[..n], MAGIC) {
+            self.reader.seek_to(pos);
+            let buf = self
+                .reader
+                .read_bytes(window)
+                .await
+                .map_err(CoreError::ReadLogFileError)?;
+            if let Some(idx) = find_subslice(&buf, MAGIC) {
                 return Ok(pos + idx as u64);
             }
-            if n < buf.len() {
+            // A short window means the file ended inside it, so there is no
+            // later marker to find. This is also what makes the loop terminate:
+            // past it the window is a full buffer, so the advance below is
+            // positive.
+            if window < Self::BLOCK_SCAN_READ_BUFFER_SIZE {
                 return Ok(stream_len);
             }
-            let advance = (n - (MAGIC.len() - 1)) as u64;
-            pos += advance;
-            self.reader
-                .seek(SeekFrom::Start(pos))
-                .map_err(CoreError::ReadLogFileError)?;
+            pos += window - (MAGIC.len() as u64 - 1);
         }
     }
 
     /// Synthesize a corrupt block and leave the reader at the recovery offset,
     /// so one bad block costs its own span rather than the rest of the file.
-    fn create_corrupted_block(&mut self, magic_pos: u64) -> Result<LogBlock> {
-        let next_offset = self.scan_for_next_block_offset(magic_pos)?;
+    async fn create_corrupted_block(&mut self, magic_pos: u64) -> Result<LogBlock> {
+        let next_offset = self.scan_for_next_block_offset(magic_pos).await?;
         log::warn!(
             "Found corrupt log block at offset {magic_pos}; next available block at {next_offset}"
         );
-        self.reader
-            .seek(SeekFrom::Start(next_offset))
-            .map_err(CoreError::ReadLogFileError)?;
+        self.reader.seek_to(next_offset);
         Ok(LogBlock::new(
             LogFormatVersion::V1,
             BlockType::Corrupted,
@@ -363,21 +320,21 @@ impl<R: Read + Seek> LogFileReader<R> {
     }
 
     /// Read 4 bytes for [`LogFormatVersion`].
-    fn read_log_format_version(&mut self) -> Result<LogFormatVersion> {
+    async fn read_log_format_version(&mut self) -> Result<LogFormatVersion> {
         let mut version_buf = [0u8; 4];
-        self.reader.read_exact(&mut version_buf)?;
+        self.reader.read_exact(&mut version_buf).await?;
         LogFormatVersion::try_from(version_buf)
     }
 
     /// Read 4 bytes for [`BlockType`].
-    fn read_block_type(&mut self, format_version: &LogFormatVersion) -> Result<BlockType> {
+    async fn read_block_type(&mut self, format_version: &LogFormatVersion) -> Result<BlockType> {
         if !format_version.has_block_type() {
             return Err(CoreError::LogFormatError(
                 "Block type is not supported".to_string(),
             ));
         }
         let mut type_buf = [0u8; 4];
-        self.reader.read_exact(&mut type_buf)?;
+        self.reader.read_exact(&mut type_buf).await?;
         BlockType::try_from(type_buf)
     }
 
@@ -389,7 +346,7 @@ impl<R: Read + Seek> LogFileReader<R> {
     ///    - 4 bytes: key ordinal (see [`BlockMetadataKey`])
     ///    - 4 bytes: value length
     ///    - N bytes: value string
-    fn read_block_metadata(
+    async fn read_block_metadata(
         &mut self,
         metadata_type: BlockMetadataType,
         format_version: &LogFormatVersion,
@@ -404,28 +361,27 @@ impl<R: Read + Seek> LogFileReader<R> {
             _ => {}
         }
         let mut num_entries_buf = [0u8; 4];
-        self.reader.read_exact(&mut num_entries_buf)?;
+        self.reader.read_exact(&mut num_entries_buf).await?;
         let num_entries = u32::from_be_bytes(num_entries_buf);
         let mut metadata: HashMap<BlockMetadataKey, String> =
             HashMap::with_capacity(num_entries as usize);
         for _ in 0..num_entries {
             let mut key_buf = [0u8; 4];
-            self.reader.read_exact(&mut key_buf)?;
+            self.reader.read_exact(&mut key_buf).await?;
             let key = BlockMetadataKey::try_from(key_buf)?;
             let mut value_len_buf = [0u8; 4];
-            self.reader.read_exact(&mut value_len_buf)?;
+            self.reader.read_exact(&mut value_len_buf).await?;
             let value_len = u32::from_be_bytes(value_len_buf);
-            let mut value_buf = vec![0u8; value_len as usize];
-            self.reader.read_exact(&mut value_buf)?;
-            let value =
-                String::from_utf8(value_buf).map_err(|e| CoreError::Utf8Error(e.utf8_error()))?;
+            let value_buf = self.reader.read_bytes(value_len as u64).await?;
+            let value = String::from_utf8(value_buf.to_vec())
+                .map_err(|e| CoreError::Utf8Error(e.utf8_error()))?;
             metadata.insert(key, value);
         }
         Ok(metadata)
     }
 
     /// Read 8 bytes for the total length of the log block.
-    fn read_total_block_length(
+    async fn read_total_block_length(
         &mut self,
         format_version: &LogFormatVersion,
     ) -> Result<Option<u64>> {
@@ -433,7 +389,7 @@ impl<R: Read + Seek> LogFileReader<R> {
             return Ok(None);
         }
         let mut size_buf = [0u8; 8];
-        self.reader.read_exact(&mut size_buf)?;
+        self.reader.read_exact(&mut size_buf).await?;
         Ok(Some(u64::from_be_bytes(size_buf)))
     }
 
@@ -451,44 +407,52 @@ impl<R: Read + Seek> LogFileReader<R> {
         instant_range.not_in_range(instant_time, &self.timezone)
     }
 
+    /// End of the block whose magic sits at `magic_pos`, which is also where
+    /// the next block's magic sits. `block_length` excludes the magic and its
+    /// own 8-byte field, so both are added back.
+    fn block_end(magic_pos: u64, block_length: u64) -> Result<u64> {
+        magic_pos
+            .checked_add(MAGIC.len() as u64)
+            .and_then(|v| v.checked_add(8))
+            .and_then(|v| v.checked_add(block_length))
+            .ok_or_else(|| CoreError::LogFormatError("Block length overflow".to_string()))
+    }
+
     /// Read one block's header, recording where its content sits and seeking
     /// past it without decoding.
     ///
     /// Corruption is still detected — a corrupt block cannot be trusted to say
     /// where the next one starts, so the check has to happen during the sweep
     /// rather than being deferred with the content.
-    fn read_next_block_metadata_only(
+    async fn read_next_block_metadata_only(
         &mut self,
         fetcher: &LogBlockFetcher,
     ) -> Result<Option<LogBlock>> {
-        let magic_pos = self
-            .reader
-            .stream_position()
-            .map_err(CoreError::ReadLogFileError)?;
-        if !self.read_magic()? {
+        let magic_pos = self.reader.position();
+        if !self.read_magic().await? {
             return Ok(None);
         }
 
-        let block_length = self.read_block_length()?;
-        if self.is_block_corrupted(magic_pos, block_length)? {
-            return Ok(Some(self.create_corrupted_block(magic_pos)?));
+        let block_length = self.read_block_length().await?;
+        if self.is_block_corrupted(magic_pos, block_length).await? {
+            return Ok(Some(self.create_corrupted_block(magic_pos).await?));
         }
 
-        let format_version = self.read_log_format_version()?;
-        let block_type = self.read_block_type(&format_version)?;
-        let header = self.read_block_metadata(BlockMetadataType::Header, &format_version)?;
+        let format_version = self.read_log_format_version().await?;
+        let block_type = self.read_block_type(&format_version).await?;
+        let header = self
+            .read_block_metadata(BlockMetadataType::Header, &format_version)
+            .await?;
 
         // The range starts at the content-length field, not after it, because
         // decoding reads that field itself — inflate hands the same bytes to the
         // same decoder the eager path uses.
-        let content_position = self
-            .reader
-            .stream_position()
-            .map_err(CoreError::ReadLogFileError)?;
+        let content_position = self.reader.position();
         let payload_length = if format_version.has_content_length() {
             let mut buf = [0u8; 8];
             self.reader
                 .read_exact(&mut buf)
+                .await
                 .map_err(CoreError::ReadLogFileError)?;
             u64::from_be_bytes(buf)
         } else {
@@ -512,11 +476,11 @@ impl<R: Read + Seek> LogFileReader<R> {
         let after_content = content_position
             .checked_add(content_length)
             .ok_or_else(|| CoreError::LogFormatError("Content length overflow".to_string()))?;
-        self.reader
-            .seek(SeekFrom::Start(after_content))
-            .map_err(CoreError::ReadLogFileError)?;
-        let footer = self.read_block_metadata(BlockMetadataType::Footer, &format_version)?;
-        let _ = self.read_total_block_length(&format_version)?;
+        self.reader.seek_to(after_content);
+        let footer = self
+            .read_block_metadata(BlockMetadataType::Footer, &format_version)
+            .await?;
+        let _ = self.read_total_block_length(&format_version).await?;
 
         let mut block = LogBlock::new(
             format_version,
@@ -535,44 +499,29 @@ impl<R: Read + Seek> LogFileReader<R> {
         Ok(Some(block))
     }
 
-    fn read_next_block(&mut self, instant_range: &InstantRange) -> Result<Option<LogBlock>> {
+    async fn read_next_block(&mut self, instant_range: &InstantRange) -> Result<Option<LogBlock>> {
         // The magic's own offset — where a corrupt block's span starts.
-        let magic_pos = self
-            .reader
-            .stream_position()
-            .map_err(CoreError::ReadLogFileError)?;
-        if !self.read_magic()? {
+        let magic_pos = self.reader.position();
+        if !self.read_magic().await? {
             return Ok(None);
         }
 
-        let curr_pos = self
-            .reader
-            .stream_position()
-            .map_err(CoreError::ReadLogFileError)?;
-
-        let block_length = self.read_block_length()?;
+        let block_length = self.read_block_length().await?;
         // Validate before parsing the body: a corrupt or truncated block must
         // yield a corrupt marker and resume at the next block, rather than
         // failing the whole file on one bad span.
-        if self.is_block_corrupted(magic_pos, block_length)? {
-            return Ok(Some(self.create_corrupted_block(magic_pos)?));
+        if self.is_block_corrupted(magic_pos, block_length).await? {
+            return Ok(Some(self.create_corrupted_block(magic_pos).await?));
         }
-        let format_version = self.read_log_format_version()?;
-        let block_type = self.read_block_type(&format_version)?;
-        let header = self.read_block_metadata(BlockMetadataType::Header, &format_version)?;
+        let block_end = Self::block_end(magic_pos, block_length)?;
+        let format_version = self.read_log_format_version().await?;
+        let block_type = self.read_block_type(&format_version).await?;
+        let header = self
+            .read_block_metadata(BlockMetadataType::Header, &format_version)
+            .await?;
         // If block is out of the requested range, fast skip its payload without decoding
         if self.should_skip_block(&header, instant_range)? {
-            // block_length excludes the magic; we consumed 8 bytes of length already.
-            // Jump to the end of this block (absolute seek from start of file):
-            // end_pos = curr_pos (right after magic) + 8 (length field) + block_length
-            let target = curr_pos
-                .checked_add(8)
-                .and_then(|v| v.checked_add(block_length))
-                .ok_or_else(|| CoreError::LogFormatError("Block length overflow".to_string()))?;
-            self.reader
-                .seek(SeekFrom::Start(target))
-                .map_err(CoreError::ReadLogFileError)?;
-
+            self.reader.seek_to(block_end);
             return Ok(Some(LogBlock::new_skipped(
                 format_version,
                 block_type,
@@ -583,15 +532,34 @@ impl<R: Read + Seek> LogFileReader<R> {
         let decoder = Decoder::new(self.hudi_configs.clone())
             .with_row_filter(self.row_filter.clone())
             .with_reader_schema(self.reader_schema_json.clone());
+        // Decode out of the block's own remaining bytes rather than straight off
+        // the reader: the reader is async and the decoders are not. The span
+        // ends where the block does, so a content length that lies runs out of
+        // bytes instead of reading into the next block.
+        let content_start = self.reader.position();
+        let remaining = block_end.checked_sub(content_start).ok_or_else(|| {
+            CoreError::LogFormatError(format!(
+                "the block at offset {magic_pos} declares {block_length} bytes, fewer than its \
+                 own header occupies"
+            ))
+        })?;
+        let mut content_bytes = Cursor::new(self.reader.read_bytes(remaining).await?);
         let content = decoder.decode_content(
-            self.reader.by_ref(),
+            &mut content_bytes,
             &format_version,
             block_length,
             &block_type,
             &header,
         )?;
-        let footer = self.read_block_metadata(BlockMetadataType::Footer, &format_version)?;
-        let _ = self.read_total_block_length(&format_version)?;
+        // What follows the content is at whatever offset the decoder stopped at,
+        // which is not a function of the block length: a decoder is capped at
+        // the content length but need not consume all of it.
+        self.reader
+            .seek_to(content_start + content_bytes.position());
+        let footer = self
+            .read_block_metadata(BlockMetadataType::Footer, &format_version)
+            .await?;
+        let _ = self.read_total_block_length(&format_version).await?;
 
         Ok(Some(LogBlock::new(
             format_version,
@@ -645,10 +613,7 @@ mod tests {
         )
     }
 
-    async fn create_log_file_reader(
-        dir: &str,
-        file_name: &str,
-    ) -> Result<LogFileReader<StorageReader>> {
+    async fn create_log_file_reader(dir: &str, file_name: &str) -> Result<LogFileReader> {
         let dir_url = parse_uri(dir)?;
         let hudi_configs = Arc::new(HudiConfigs::new([(HudiTableConfig::OrderingFields, "ts")]));
         let storage = Storage::new_with_base_url(dir_url)?;
@@ -669,12 +634,13 @@ mod tests {
 
         let mut eager =
             LogFileReader::new(hudi_configs.clone(), storage.clone(), file_name).await?;
-        let eager_blocks =
-            eager.read_all_blocks(&InstantRange::up_to("99991231235959999", "utc"))?;
+        let eager_blocks = eager
+            .read_all_blocks(&InstantRange::up_to("99991231235959999", "utc"))
+            .await?;
 
         let mut lazy =
             LogFileReader::new_streaming(hudi_configs.clone(), storage, file_name).await?;
-        let mut lazy_blocks = lazy.read_all_blocks_metadata_only()?;
+        let mut lazy_blocks = lazy.read_all_blocks_metadata_only().await?;
 
         assert_eq!(
             lazy_blocks.len(),
@@ -686,7 +652,7 @@ mod tests {
         for (lazy_block, eager_block) in lazy_blocks.iter_mut().zip(eager_blocks.iter()) {
             assert_eq!(lazy_block.block_type, eager_block.block_type);
             assert_eq!(lazy_block.header, eager_block.header);
-            lazy_block.load_content(&decoder)?;
+            lazy_block.load_content(&decoder).await?;
             assert_eq!(
                 lazy_block.content.as_records().map(|b| b.num_data_rows()),
                 eager_block.content.as_records().map(|b| b.num_data_rows()),
@@ -722,15 +688,17 @@ mod tests {
 
         let magic_pos = 0;
         let real_length = {
-            reader.read_magic()?;
-            reader.read_block_length()?
+            reader.read_magic().await?;
+            reader.read_block_length().await?
         };
         assert!(
-            !reader.is_block_corrupted(magic_pos, real_length)?,
+            !reader.is_block_corrupted(magic_pos, real_length).await?,
             "a well-formed block must not be reported corrupt"
         );
         assert!(
-            reader.is_block_corrupted(magic_pos, real_length + 1)?,
+            reader
+                .is_block_corrupted(magic_pos, real_length + 1)
+                .await?,
             "a length disagreeing with the trailing pointer must be reported corrupt"
         );
         Ok(())
@@ -744,11 +712,11 @@ mod tests {
         let mut reader = create_log_file_reader(&dir, &file_name).await?;
 
         assert!(
-            reader.is_block_corrupted(0, u64::MAX)?,
+            reader.is_block_corrupted(0, u64::MAX).await?,
             "overflow is corrupt"
         );
         assert!(
-            reader.is_block_corrupted(0, 1 << 40)?,
+            reader.is_block_corrupted(0, 1 << 40).await?,
             "a length past EOF is corrupt"
         );
         Ok(())
@@ -769,7 +737,7 @@ mod tests {
         let storage = Storage::new_with_base_url(dir_url)?;
         let mut reader = LogFileReader::new_streaming(hudi_configs, storage, &file_name).await?;
 
-        let blocks = reader.read_all_blocks_metadata_only()?;
+        let blocks = reader.read_all_blocks_metadata_only().await?;
         assert!(!blocks.is_empty(), "the fixture has blocks to walk");
         for block in &blocks {
             assert!(
@@ -806,7 +774,7 @@ mod tests {
         let hudi_configs = Arc::new(HudiConfigs::new([(HudiTableConfig::OrderingFields, "ts")]));
         let storage = Storage::new_with_base_url(parse_uri(tmp.path().to_str().unwrap())?)?;
         let mut reader = LogFileReader::new_streaming(hudi_configs, storage, &file_name).await?;
-        let blocks = reader.read_all_blocks_metadata_only()?;
+        let blocks = reader.read_all_blocks_metadata_only().await?;
 
         let deferred: Vec<_> = blocks
             .iter()
@@ -830,7 +798,8 @@ mod tests {
         for (i, d) in deferred.iter().enumerate() {
             let alone = d
                 .fetcher
-                .read_content(d.location.content_position, d.location.content_length)?;
+                .read_content(d.location.content_position, d.location.content_length)
+                .await?;
             assert_eq!(
                 batched[i], alone,
                 "batched range {i} must be byte-identical to reading it alone"
@@ -855,7 +824,7 @@ mod tests {
         let storage = Storage::new_with_base_url(parse_uri(tmp.path().to_str().unwrap())?)?;
         let mut reader =
             LogFileReader::new_streaming(hudi_configs.clone(), storage, &file_name).await?;
-        let mut blocks = reader.read_all_blocks_metadata_only()?;
+        let mut blocks = reader.read_all_blocks_metadata_only().await?;
 
         let block = blocks.last_mut().expect("the fixture has a block to walk");
         let location = block
@@ -878,6 +847,7 @@ mod tests {
         let decoder = Decoder::new(hudi_configs);
         let err = block
             .load_content(&decoder)
+            .await
             .expect_err("content running past the file end must be an error");
         assert!(
             err.to_string().contains("truncated or corrupt block"),
@@ -896,7 +866,7 @@ mod tests {
         let storage = Storage::new_with_base_url(parse_uri(&dir)?)?;
         let mut reader =
             LogFileReader::new_streaming(hudi_configs.clone(), storage, &file_name).await?;
-        let mut blocks = reader.read_all_blocks_metadata_only()?;
+        let mut blocks = reader.read_all_blocks_metadata_only().await?;
         assert!(
             blocks.iter().any(|b| b.block_type == BlockType::Command),
             "this fixture is chosen for its command block, which decodes to no content"
@@ -904,9 +874,10 @@ mod tests {
 
         let decoder = Decoder::new(hudi_configs);
         for block in blocks.iter_mut() {
-            block.load_content(&decoder)?;
+            block.load_content(&decoder).await?;
             block
                 .load_content(&decoder)
+                .await
                 .expect("loading an already-loaded block must be a no-op, whatever it decoded to");
         }
         Ok(())
@@ -920,19 +891,20 @@ mod tests {
         let (dir, file_name) = get_valid_log_avro_data();
 
         let mut eager_reader = create_log_file_reader(&dir, &file_name).await?;
-        let eager =
-            eager_reader.read_all_blocks(&InstantRange::up_to("29991231235959999", "utc"))?;
+        let eager = eager_reader
+            .read_all_blocks(&InstantRange::up_to("29991231235959999", "utc"))
+            .await?;
 
         let dir_url = parse_uri(&dir)?;
         let hudi_configs = Arc::new(HudiConfigs::new([(HudiTableConfig::OrderingFields, "ts")]));
         let storage = Storage::new_with_base_url(dir_url)?;
         let mut lazy_reader =
             LogFileReader::new_streaming(hudi_configs.clone(), storage, &file_name).await?;
-        let mut lazy = lazy_reader.read_all_blocks_metadata_only()?;
+        let mut lazy = lazy_reader.read_all_blocks_metadata_only().await?;
 
         let decoder = Decoder::new(hudi_configs);
         for block in lazy.iter_mut() {
-            block.load_content(&decoder)?;
+            block.load_content(&decoder).await?;
         }
 
         let rows = |bs: &[LogBlock]| -> usize {
@@ -959,15 +931,16 @@ mod tests {
     async fn test_load_content_without_a_deferred_location_is_an_error() -> Result<()> {
         let (dir, file_name) = get_valid_log_avro_data();
         let mut reader = create_log_file_reader(&dir, &file_name).await?;
-        let mut blocks =
-            reader.read_all_blocks(&InstantRange::up_to("29991231235959999", "utc"))?;
+        let mut blocks = reader
+            .read_all_blocks(&InstantRange::up_to("29991231235959999", "utc"))
+            .await?;
         let decoder = Decoder::new(Arc::new(HudiConfigs::new([(
             HudiTableConfig::OrderingFields,
             "ts",
         )])));
 
         // Already decoded by the eager read: nothing to do.
-        blocks[0].load_content(&decoder)?;
+        blocks[0].load_content(&decoder).await?;
         assert!(
             blocks[0].deferred_content.is_none(),
             "an eagerly read block has nothing deferred to release"
@@ -979,6 +952,7 @@ mod tests {
         blocks[0].deferred_content = None;
         let err = blocks[0]
             .load_content(&decoder)
+            .await
             .expect_err("a block with nowhere to read from must be an error");
         assert!(
             err.to_string().contains("headers-only"),
@@ -1031,8 +1005,8 @@ mod tests {
         let (dir, file_name) = get_valid_log_avro_data();
         let mut reader = create_log_file_reader(&dir, &file_name).await?;
 
-        let len = reader.stream_len()?;
-        let offset = reader.scan_for_next_block_offset(0)?;
+        let len = reader.reader.file_len();
+        let offset = reader.scan_for_next_block_offset(0).await?;
         assert!(
             offset <= len,
             "recovery offset {offset} must lie within the file ({len})"
@@ -1074,7 +1048,7 @@ mod tests {
         let good = std::fs::read(PathBuf::from(&dir).join(&file_name)).unwrap();
 
         let magic_len = MAGIC.len() as u64;
-        let scan = LogFileReader::<StorageReader>::BLOCK_SCAN_READ_BUFFER_SIZE as u64;
+        let scan = LogFileReader::BLOCK_SCAN_READ_BUFFER_SIZE;
         // The scan starts at `magic_len` and reads `scan` bytes, so its first
         // window ends at `magic_len + scan`. Landing the good block's MAGIC
         // `straddle_by` bytes before that end splits the marker across two
@@ -1106,7 +1080,7 @@ mod tests {
     /// Asserted for the eager reader and for streaming readers whose fetch
     /// window is smaller than, larger than, and unrelated to the scan window.
     async fn assert_corrupt_recovery_finds_a_straddling_magic(window: Option<u64>) -> Result<()> {
-        let scan = LogFileReader::<StorageReader>::BLOCK_SCAN_READ_BUFFER_SIZE as u64;
+        let scan = LogFileReader::BLOCK_SCAN_READ_BUFFER_SIZE;
         let magic_len = MAGIC.len() as u64;
         let (tmp, file_name, block_start) = corrupt_then_good_file(3);
         assert!(
@@ -1127,7 +1101,7 @@ mod tests {
             }
         };
         assert_eq!(
-            reader.scan_for_next_block_offset(0)?,
+            reader.scan_for_next_block_offset(0).await?,
             block_start,
             "recovery must land on the good block's magic, not run to EOF"
         );
@@ -1136,8 +1110,9 @@ mod tests {
         // good one, rather than one corrupt block covering the whole file.
         let mut eager =
             LogFileReader::new(hudi_configs.clone(), storage.clone(), &file_name).await?;
-        let eager_blocks =
-            eager.read_all_blocks(&InstantRange::up_to("99991231235959999", "utc"))?;
+        let eager_blocks = eager
+            .read_all_blocks(&InstantRange::up_to("99991231235959999", "utc"))
+            .await?;
         assert_eq!(
             eager_blocks
                 .iter()
@@ -1152,7 +1127,7 @@ mod tests {
 
         let mut lazy =
             LogFileReader::new_streaming(hudi_configs.clone(), storage, &file_name).await?;
-        let mut lazy_blocks = lazy.read_all_blocks_metadata_only()?;
+        let mut lazy_blocks = lazy.read_all_blocks_metadata_only().await?;
         assert_eq!(
             lazy_blocks
                 .iter()
@@ -1161,7 +1136,7 @@ mod tests {
             vec![BlockType::Corrupted, BlockType::AvroData],
         );
         let decoder = Decoder::new(hudi_configs);
-        lazy_blocks[1].load_content(&decoder)?;
+        lazy_blocks[1].load_content(&decoder).await?;
         assert_eq!(
             lazy_blocks[1]
                 .content
@@ -1178,7 +1153,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_corrupt_recovery_scan_finds_a_magic_split_across_windows() -> Result<()> {
-        let scan = LogFileReader::<StorageReader>::BLOCK_SCAN_READ_BUFFER_SIZE as u64;
+        let scan = LogFileReader::BLOCK_SCAN_READ_BUFFER_SIZE;
         // Eager (whole file resident), a fetch window smaller than the scan
         // window, one larger than it, and one that is not a multiple of it.
         for window in [None, Some(scan / 2), Some(scan + 1024), Some(64 * 1024 + 7)] {
@@ -1187,12 +1162,48 @@ mod tests {
         Ok(())
     }
 
+    /// Skipping a block has to land exactly on the next block's magic. On a
+    /// one-block file it cannot: landing anywhere in the last few bytes reads as
+    /// end-of-file either way, so the arithmetic is only pinned when another
+    /// block follows. Two copies of a fixture is a valid two-block file, and
+    /// both carry the same instant time, so a window below it skips both — the
+    /// walk then has to reach the end cleanly rather than find garbage where the
+    /// second magic should be.
+    #[tokio::test]
+    async fn test_skipping_a_block_lands_on_the_next_ones_magic() -> Result<()> {
+        let (dir, file_name) = get_valid_log_avro_data();
+        let one = std::fs::read(PathBuf::from(&dir).join(&file_name)).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let mut doubled = one.clone();
+        doubled.extend_from_slice(&one);
+        std::fs::write(tmp.path().join(&file_name), &doubled).unwrap();
+
+        let hudi_configs = Arc::new(HudiConfigs::new([(HudiTableConfig::OrderingFields, "ts")]));
+        let storage = Storage::new_with_base_url(parse_uri(tmp.path().to_str().unwrap())?)?;
+        let mut reader = LogFileReader::new(hudi_configs, storage, &file_name).await?;
+
+        // Everything is out of the window, so every block takes the skip path.
+        let instant_range = InstantRange::up_to("20200101000000000", "utc");
+        let mut skipped = 0;
+        while let Some(block) = reader.read_next_block(&instant_range).await? {
+            assert!(block.skipped, "a block below the window must be skipped");
+            skipped += 1;
+        }
+        assert_eq!(skipped, 2, "both blocks must be walked and skipped");
+        assert_eq!(
+            reader.reader.position(),
+            doubled.len() as u64,
+            "the walk must consume the file exactly, with no bytes left over"
+        );
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_read_log_file_with_avro_data_block() -> Result<()> {
         let (dir, file_name) = get_valid_log_avro_data();
         let mut reader = create_log_file_reader(&dir, &file_name).await?;
         let instant_range = InstantRange::up_to("20250316025828811", "utc");
-        let blocks = reader.read_all_blocks(&instant_range)?;
+        let blocks = reader.read_all_blocks(&instant_range).await?;
         assert_eq!(blocks.len(), 1);
 
         let block = &blocks[0];
@@ -1218,7 +1229,7 @@ mod tests {
         let (dir, file_name) = get_valid_log_parquet_data();
         let mut reader = create_log_file_reader(&dir, &file_name).await?;
         let instant_range = InstantRange::up_to("20250113230424191", "utc");
-        let blocks = reader.read_all_blocks(&instant_range)?;
+        let blocks = reader.read_all_blocks(&instant_range).await?;
         assert_eq!(blocks.len(), 1);
 
         let block = &blocks[0];
@@ -1244,7 +1255,7 @@ mod tests {
         let (dir, file_name) = get_valid_log_delete();
         let mut reader = create_log_file_reader(&dir, &file_name).await?;
         let instant_range = InstantRange::up_to("20250618054714114", "utc");
-        let blocks = reader.read_all_blocks(&instant_range)?;
+        let blocks = reader.read_all_blocks(&instant_range).await?;
         assert_eq!(blocks.len(), 1, "Expected one delete block");
 
         let block = &blocks[0];
@@ -1298,7 +1309,7 @@ mod tests {
         let (dir, file_name) = get_valid_log_rollback();
         let mut reader = create_log_file_reader(&dir, &file_name).await?;
         let instant_range = InstantRange::up_to("20250126040936578", "utc");
-        let blocks = reader.read_all_blocks(&instant_range)?;
+        let blocks = reader.read_all_blocks(&instant_range).await?;
         assert_eq!(blocks.len(), 1, "Expected one rollback block");
 
         let block = &blocks[0];
@@ -1350,7 +1361,7 @@ mod tests {
         let instant_range = InstantRange::up_to("20200101000000000", "utc");
 
         // call the internal reader to inspect the skipped block
-        let maybe_block = reader.read_next_block(&instant_range)?;
+        let maybe_block = reader.read_next_block(&instant_range).await?;
         assert!(maybe_block.is_some(), "Expected a block to be read");
         let block = maybe_block.unwrap();
         assert!(block.skipped, "Block should be marked as skipped");
@@ -1358,7 +1369,7 @@ mod tests {
         assert!(block.record_batches().is_none());
 
         // next call should hit EOF
-        let next = reader.read_next_block(&instant_range)?;
+        let next = reader.read_next_block(&instant_range).await?;
         assert!(
             next.is_none(),
             "Should reach EOF after skipping the only block"

--- a/crates/core/src/file_group/log_file/reader.rs
+++ b/crates/core/src/file_group/log_file/reader.rs
@@ -835,6 +835,32 @@ mod tests {
         Ok(())
     }
 
+    /// Loading is a no-op the second time. A block that decodes to no content —
+    /// a command block does — looks unloaded afterwards, so releasing its
+    /// location on the way out would make the second call fail instead.
+    #[tokio::test]
+    async fn test_load_content_is_idempotent_for_every_block_type() -> Result<()> {
+        let (dir, file_name) = get_valid_log_rollback();
+        let hudi_configs = Arc::new(HudiConfigs::new([(HudiTableConfig::OrderingFields, "ts")]));
+        let storage = Storage::new_with_base_url(parse_uri(&dir)?)?;
+        let mut reader =
+            LogFileReader::new_streaming(hudi_configs.clone(), storage, &file_name).await?;
+        let mut blocks = reader.read_all_blocks_metadata_only()?;
+        assert!(
+            blocks.iter().any(|b| b.block_type == BlockType::Command),
+            "this fixture is chosen for its command block, which decodes to no content"
+        );
+
+        let decoder = Decoder::new(hudi_configs);
+        for block in blocks.iter_mut() {
+            block.load_content(&decoder)?;
+            block
+                .load_content(&decoder)
+                .expect("loading an already-loaded block must be a no-op, whatever it decoded to");
+        }
+        Ok(())
+    }
+
     /// A block deferred by the metadata-only pass reads back the same records
     /// the eager path produces. Deferring must change when the bytes are read,
     /// not what they decode to.

--- a/crates/core/src/file_group/log_file/reader.rs
+++ b/crates/core/src/file_group/log_file/reader.rs
@@ -788,6 +788,57 @@ mod tests {
         Ok(())
     }
 
+    /// One batched read returns exactly what the same ranges return one at a
+    /// time. This is the property the Pass-3 prefetch rests on: fewer round
+    /// trips must not mean different bytes.
+    #[tokio::test]
+    async fn test_read_contents_matches_reading_each_range_alone() -> Result<()> {
+        // No shipped fixture holds more than one block, and a log file is just a
+        // sequence of self-contained blocks, so two of them concatenated is a
+        // valid two-block file and the smallest thing that can batch.
+        let (dir, file_name) = get_valid_log_avro_data();
+        let one = std::fs::read(PathBuf::from(&dir).join(&file_name)).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let mut doubled = one.clone();
+        doubled.extend_from_slice(&one);
+        std::fs::write(tmp.path().join(&file_name), &doubled).unwrap();
+
+        let hudi_configs = Arc::new(HudiConfigs::new([(HudiTableConfig::OrderingFields, "ts")]));
+        let storage = Storage::new_with_base_url(parse_uri(tmp.path().to_str().unwrap())?)?;
+        let mut reader = LogFileReader::new_streaming(hudi_configs, storage, &file_name).await?;
+        let blocks = reader.read_all_blocks_metadata_only()?;
+
+        let deferred: Vec<_> = blocks
+            .iter()
+            .filter_map(|b| b.deferred_content.as_ref())
+            .collect();
+        assert_eq!(
+            deferred.len(),
+            2,
+            "the doubled file must walk as two blocks for this to be a batch"
+        );
+
+        let fetcher = &deferred[0].fetcher;
+        let ranges: Vec<std::ops::Range<u64>> = deferred
+            .iter()
+            .map(|d| {
+                d.location.content_position..d.location.content_position + d.location.content_length
+            })
+            .collect();
+        let batched = fetcher.read_contents(&ranges).await?;
+        assert_eq!(batched.len(), ranges.len(), "one buffer per range");
+        for (i, d) in deferred.iter().enumerate() {
+            let alone = d
+                .fetcher
+                .read_content(d.location.content_position, d.location.content_length)?;
+            assert_eq!(
+                batched[i], alone,
+                "batched range {i} must be byte-identical to reading it alone"
+            );
+        }
+        Ok(())
+    }
+
     /// A block whose content runs past the end of the file must say so. The
     /// ranged read comes back CLAMPED rather than refused, so without a length
     /// check the decoder is handed a short buffer and fails somewhere inside the

--- a/crates/core/src/file_group/log_file/reader.rs
+++ b/crates/core/src/file_group/log_file/reader.rs
@@ -788,6 +788,53 @@ mod tests {
         Ok(())
     }
 
+    /// A block whose content runs past the end of the file must say so. The
+    /// ranged read comes back CLAMPED rather than refused, so without a length
+    /// check the decoder is handed a short buffer and fails somewhere inside the
+    /// block format instead. Also pins that a loaded block releases what it
+    /// needed to fetch itself.
+    #[tokio::test]
+    async fn test_load_content_reports_a_block_running_past_the_file_end() -> Result<()> {
+        let (dir, file_name) = get_valid_log_avro_data();
+        let tmp = tempfile::tempdir().unwrap();
+        let copied = tmp.path().join(&file_name);
+        std::fs::copy(PathBuf::from(&dir).join(&file_name), &copied).unwrap();
+
+        let hudi_configs = Arc::new(HudiConfigs::new([(HudiTableConfig::OrderingFields, "ts")]));
+        let storage = Storage::new_with_base_url(parse_uri(tmp.path().to_str().unwrap())?)?;
+        let mut reader =
+            LogFileReader::new_streaming(hudi_configs.clone(), storage, &file_name).await?;
+        let mut blocks = reader.read_all_blocks_metadata_only()?;
+
+        let block = blocks.last_mut().expect("the fixture has a block to walk");
+        let location = block
+            .deferred_content
+            .as_ref()
+            .expect("a metadata-only block records where its content is")
+            .location
+            .clone();
+
+        // Cut the file one byte short of this block's content so the ranged read
+        // returns less than it asked for.
+        let end = location.content_position + location.content_length;
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&copied)
+            .unwrap()
+            .set_len(end - 1)
+            .unwrap();
+
+        let decoder = Decoder::new(hudi_configs);
+        let err = block
+            .load_content(&decoder)
+            .expect_err("content running past the file end must be an error");
+        assert!(
+            err.to_string().contains("truncated or corrupt block"),
+            "the error must name the truncation rather than fail inside the decoder, got: {err}"
+        );
+        Ok(())
+    }
+
     /// A block deferred by the metadata-only pass reads back the same records
     /// the eager path produces. Deferring must change when the bytes are read,
     /// not what they decode to.
@@ -844,6 +891,10 @@ mod tests {
 
         // Already decoded by the eager read: nothing to do.
         blocks[0].load_content(&decoder)?;
+        assert!(
+            blocks[0].deferred_content.is_none(),
+            "an eagerly read block has nothing deferred to release"
+        );
 
         // A block with content cleared and no deferred location cannot say where
         // to read from.

--- a/crates/core/src/file_group/log_file/scanner.rs
+++ b/crates/core/src/file_group/log_file/scanner.rs
@@ -149,7 +149,7 @@ impl LogFileScanner {
         for path in relative_paths {
             let mut reader =
                 LogFileReader::new(self.hudi_configs.clone(), self.storage.clone(), &path).await?;
-            let blocks = reader.read_all_blocks(instant_range)?;
+            let blocks = reader.read_all_blocks(instant_range).await?;
 
             // Collect rollback targets from command blocks
             for block in &blocks {

--- a/crates/core/src/file_group/reader_v2/adapter.rs
+++ b/crates/core/src/file_group/reader_v2/adapter.rs
@@ -96,7 +96,7 @@ pub(crate) async fn read_file_slice_stream(
         completion_gate_inputs,
     )?;
 
-    reader.open_blocking_stream().await
+    reader.open_stream().await
 }
 
 /// Assemble the reader both entry points use, so the eager and streaming reads

--- a/crates/core/src/file_group/reader_v2/buffer/key_based.rs
+++ b/crates/core/src/file_group/reader_v2/buffer/key_based.rs
@@ -2965,7 +2965,7 @@ mod tests {
     }
 
     /// Drive a populated-buffer base-vs-log merge through the production
-    /// streaming path (log block → base source → `FileGroupMergeIterator`)
+    /// streaming path (log block → base source → `FileGroupMergeStream`)
     /// and return the concatenated output in the requested schema.
     fn merge_log_block_with_base_streaming(
         mut buffer: KeyBasedFileGroupRecordBuffer,
@@ -5366,7 +5366,7 @@ mod tests {
     }
 
     // =========================================================================
-    // streaming output via FileGroupMergeIterator.
+    // streaming output via FileGroupMergeStream.
     //
     // These tests compare the streaming iterator's output against the
     // legacy `merge_and_collect` path on the same buffer fixture. The
@@ -5376,7 +5376,7 @@ mod tests {
     // =========================================================================
 
     use crate::file_group::reader_v2::merge_iterator::{
-        FileGroupMergeIterator, new_stream_stats_handle,
+        FileGroupMergeStream, new_stream_stats_handle,
     };
 
     /// Test shim: build a streaming iterator with a throwaway stats handle.
@@ -5392,9 +5392,9 @@ mod tests {
             Box<dyn crate::file_group::reader_v2::output_converter::OutputConverter>,
         >,
         _batch_size: usize,
-    ) -> FileGroupMergeIterator {
+    ) -> FileGroupMergeStream {
         let base_source = take_base_source(&mut buffer, &merge_schema);
-        FileGroupMergeIterator::new_buffered(
+        FileGroupMergeStream::new_buffered(
             Box::new(buffer),
             base_source,
             merge_schema,
@@ -5411,13 +5411,50 @@ mod tests {
     /// group looks like.
     fn take_base_source(
         buffer: &mut KeyBasedFileGroupRecordBuffer,
-        schema: &SchemaRef,
-    ) -> Box<dyn arrow_array::RecordBatchReader + Send> {
-        buffer.base.base_file_source.take().unwrap_or_else(|| {
-            Box::new(arrow_array::RecordBatchIterator::new(
-                std::iter::empty(),
-                schema.clone(),
-            ))
+        _schema: &SchemaRef,
+    ) -> crate::file_group::reader_v2::merge_iterator::BaseBatchStream {
+        use futures::StreamExt;
+        match buffer.base.base_file_source.take() {
+            Some(reader) => futures::stream::iter(
+                reader
+                    .map(|b| {
+                        b.map_err(|e| {
+                            crate::error::CoreError::ReadFileSliceError(format!(
+                                "base file source error: {e}"
+                            ))
+                        })
+                    })
+                    .collect::<Vec<_>>(),
+            )
+            .boxed(),
+            None => futures::stream::empty().boxed(),
+        }
+    }
+
+    /// As [`drain_ok`], but keeping each chunk's `Result`.
+    fn drain(
+        mut merge: crate::file_group::reader_v2::merge_iterator::FileGroupMergeStream,
+    ) -> Vec<Result<RecordBatch>> {
+        futures::executor::block_on(async {
+            let mut out = Vec::new();
+            while let Some(chunk) = merge.next_chunk().await {
+                out.push(chunk);
+            }
+            out
+        })
+    }
+
+    /// Drive a merge to exhaustion from a synchronous test. The base sources
+    /// here are in-memory, so a local executor is enough.
+    fn drain_ok(
+        mut merge: crate::file_group::reader_v2::merge_iterator::FileGroupMergeStream,
+    ) -> Vec<RecordBatch> {
+        futures::executor::block_on(async {
+            let mut out = Vec::new();
+            while let Some(chunk) = merge.next_chunk().await {
+                out.push(chunk.unwrap());
+            }
+            out
         })
     }
 
@@ -5459,7 +5496,7 @@ mod tests {
         batch_size: usize,
     ) -> Vec<RecordBatch> {
         let it = new_buffered_test(buffer, schema.clone(), schema, None, batch_size);
-        it.map(|r| r.unwrap()).collect()
+        drain_ok(it)
     }
 
     /// Streaming with batch_size larger than the merged-row count → one chunk;
@@ -5535,7 +5572,7 @@ mod tests {
     }
 
     /// A3 — the production chunked streaming iterator
-    /// (`FileGroupMergeIterator::Buffered`) driving a base source split across
+    /// (`FileGroupMergeStream::Buffered`) driving a base source split across
     /// MULTIPLE row-groups produces output byte-identical to the eager single
     /// base-batch fixture, at every chunk size. This is the end-to-end proof
     /// that the streamed base (decoded row-group-at-a-time, fed into A2
@@ -5643,7 +5680,7 @@ mod tests {
         let stats = new_stream_stats_handle();
         let mut buffer = buffer;
         let base_source = take_base_source(&mut buffer, &schema);
-        let it = FileGroupMergeIterator::new_buffered(
+        let it = FileGroupMergeStream::new_buffered(
             Box::new(buffer),
             base_source,
             schema.clone(),
@@ -5651,7 +5688,7 @@ mod tests {
             None,
             stats.clone(),
         );
-        let chunks: Vec<RecordBatch> = it.map(|r| r.unwrap()).collect();
+        let chunks: Vec<RecordBatch> = drain_ok(it);
         assert_eq!(chunks.len(), 1, "should fit in one chunk");
         let records = extract_records(&chunks[0]);
         assert_eq!(chunks[0].num_rows(), 2);
@@ -5673,7 +5710,7 @@ mod tests {
             None,
             1, // batch_size ignored on the new path
         );
-        let chunks: Vec<RecordBatch> = it.map(|r| r.unwrap()).collect();
+        let chunks: Vec<RecordBatch> = drain_ok(it);
         let total_rows: usize = chunks.iter().map(|c| c.num_rows()).sum();
         assert_eq!(total_rows, 2, "two output rows total");
 
@@ -5865,23 +5902,22 @@ mod tests {
     }
 
     // =========================================================================
-    // T1-T4: probe the STREAMING output path (FileGroupMergeIterator::new_buffered)
+    // T1-T4: probe the STREAMING output path (FileGroupMergeStream::new_buffered)
     //
     // The tests above (Part B / Phase A-C) all exercise `merge_and_collect`,
     // which is the legacy bulk-materialise API. The streaming API is what the
     // FFI now uses, over the lazy base-file source. T1-T4 verify that driving the same
-    // populated buffer through `FileGroupMergeIterator::new_buffered` produces
+    // populated buffer through `FileGroupMergeStream::new_buffered` produces
     // the same record counts.
     // =========================================================================
 
     use crate::file_group::reader_v2::merge_iterator::DEFAULT_BATCH_SIZE;
 
-    /// Helper: drain a `FileGroupMergeIterator` into a Vec<RecordBatch>,
+    /// Helper: drain a `FileGroupMergeStream` into a Vec<RecordBatch>,
     /// panicking on any iteration error. Mirrors how the FFI driver consumes
     /// the stream (no error swallowing).
-    fn drain_streaming(iter: FileGroupMergeIterator) -> Vec<RecordBatch> {
-        iter.map(|r| r.expect("streaming iterator yielded error"))
-            .collect()
+    fn drain_streaming(iter: FileGroupMergeStream) -> Vec<RecordBatch> {
+        drain_ok(iter)
     }
 
     /// T1 — pins B1/B2.
@@ -6929,8 +6965,7 @@ mod tests {
 
         // Catch the panic from records_to_batch → reconcile_batch_to_schema.
         // Either a panic OR an Err — but NOT a silent 0-row stream.
-        let result =
-            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| iter.collect::<Vec<_>>()));
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| drain(iter)));
 
         match result {
             Ok(chunks) => {
@@ -7172,7 +7207,7 @@ mod tests {
     //
     // i.e. PostMergePredicateFilter saw the iterator emit EXACTLY ONE chunk
     // of 4096 rows then stop. We need to know:
-    //   (a) does FileGroupMergeIterator::Buffered correctly continue past
+    //   (a) does FileGroupMergeStream::Buffered correctly continue past
     //       the first chunk when base_file_source has more rows?
     //   (b) if YES — the production stop is downstream (Velox/FFI/Drop).
     //   (c) if NO — the bug is here in the Buffered iterator.
@@ -7262,7 +7297,7 @@ mod tests {
         );
 
         // Minimal Rust analogue of PostMergePredicateFilter that returns
-        // an EMPTY batch for every inner chunk (i.e. filter rejects all).
+        // an EMPTY batch for every merged chunk (i.e. filter rejects all).
         struct AlwaysFalseFilter<I> {
             inner: I,
             chunks_in: usize,
@@ -7270,11 +7305,11 @@ mod tests {
         }
         impl<I> Iterator for AlwaysFalseFilter<I>
         where
-            I: Iterator<Item = Result<RecordBatch, arrow_schema::ArrowError>>,
+            I: Iterator<Item = RecordBatch>,
         {
-            type Item = Result<RecordBatch, arrow_schema::ArrowError>;
+            type Item = Result<RecordBatch>;
             fn next(&mut self) -> Option<Self::Item> {
-                let batch = self.inner.next()?.ok()?;
+                let batch = self.inner.next()?;
                 self.chunks_in += 1;
                 let empty = RecordBatch::new_empty(batch.schema());
                 self.chunks_out += 1;
@@ -7283,7 +7318,7 @@ mod tests {
         }
 
         let mut wrapped = AlwaysFalseFilter {
-            inner,
+            inner: drain_ok(inner).into_iter(),
             chunks_in: 0,
             chunks_out: 0,
         };
@@ -7657,8 +7692,7 @@ mod tests {
             .unwrap();
         let conv = buffer.reader_context.schema_handler.get_output_converter();
         let iter = new_buffered_test(buffer, required, requested, conv, DEFAULT_BATCH_SIZE);
-        let collected: std::result::Result<Vec<RecordBatch>, arrow_schema::ArrowError> =
-            iter.collect();
+        let collected: Result<Vec<RecordBatch>> = drain(iter).into_iter().collect();
         let err = collected.expect_err(
             "toasted log-only insert with no prior must fail loudly, not leak sentinel",
         );
@@ -7694,8 +7728,9 @@ mod tests {
             .unwrap();
         let conv2 = buffer2.reader_context.schema_handler.get_output_converter();
         let iter2 = new_buffered_test(buffer2, required2, requested2, conv2, DEFAULT_BATCH_SIZE);
-        let batches: Vec<RecordBatch> = iter2
-            .collect::<std::result::Result<Vec<RecordBatch>, arrow_schema::ArrowError>>()
+        let batches: Vec<RecordBatch> = drain(iter2)
+            .into_iter()
+            .collect::<Result<Vec<RecordBatch>>>()
             .expect("a clean (non-sentinel) log-only insert must drain without error");
         let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
         assert_eq!(rows, 1, "the real-value insert should emit exactly one row");

--- a/crates/core/src/file_group/reader_v2/buffer/key_based.rs
+++ b/crates/core/src/file_group/reader_v2/buffer/key_based.rs
@@ -1834,6 +1834,16 @@ impl HoodieFileGroupRecordBuffer for KeyBasedFileGroupRecordBuffer {
         self.pull_and_merge_next_base_batch(target_schema, BaseMatch::RecordKey)
     }
 
+    /// Merge one caller-supplied base batch. See
+    /// [`HoodieFileGroupRecordBuffer::merge_base_batch`].
+    fn merge_base_batch(
+        &mut self,
+        base: &RecordBatch,
+        target_schema: &SchemaRef,
+    ) -> Result<Option<RecordBatch>> {
+        self.merge_one_base_batch_kernel(base, target_schema, BaseMatch::RecordKey)
+    }
+
     /// Drain any log records that were never matched by a base row, as one
     /// final batch of inserts. Deletes are filtered out (they contribute
     /// no output rows). Idempotent: subsequent calls return `Ok(None)`.
@@ -2387,7 +2397,7 @@ mod tests {
             .unwrap();
         let conv = buffer.reader_context.schema_handler.get_output_converter();
         let iter = new_buffered_test(
-            Box::new(buffer),
+            buffer,
             required,
             requested.clone(),
             conv,
@@ -2483,7 +2493,7 @@ mod tests {
             .unwrap();
         let conv = buffer.reader_context.schema_handler.get_output_converter();
         let iter = new_buffered_test(
-            Box::new(buffer),
+            buffer,
             required,
             requested.clone(),
             conv,
@@ -2627,7 +2637,7 @@ mod tests {
             .unwrap();
         let conv = buffer.reader_context.schema_handler.get_output_converter();
         let iter = new_buffered_test(
-            Box::new(buffer),
+            buffer,
             required,
             requested.clone(),
             conv,
@@ -2984,7 +2994,7 @@ mod tests {
             .unwrap();
         let conv = buffer.reader_context.schema_handler.get_output_converter();
         let iter = new_buffered_test(
-            Box::new(buffer),
+            buffer,
             required,
             requested.clone(),
             conv,
@@ -5375,22 +5385,40 @@ mod tests {
     /// production concern (FFI timing/update-count reporting) the streaming-parity
     /// tests don't assert on, so it's defaulted here.
     fn new_buffered_test(
-        buffer: Box<dyn crate::file_group::reader_v2::buffer::HoodieFileGroupRecordBuffer>,
+        mut buffer: KeyBasedFileGroupRecordBuffer,
         merge_schema: SchemaRef,
         output_schema: SchemaRef,
         output_converter: Option<
             Box<dyn crate::file_group::reader_v2::output_converter::OutputConverter>,
         >,
-        batch_size: usize,
+        _batch_size: usize,
     ) -> FileGroupMergeIterator {
+        let base_source = take_base_source(&mut buffer, &merge_schema);
         FileGroupMergeIterator::new_buffered(
-            buffer,
+            Box::new(buffer),
+            base_source,
             merge_schema,
             output_schema,
             output_converter,
-            batch_size,
             new_stream_stats_handle(),
         )
+    }
+
+    /// Move the base source a test attached to the buffer into the iterator,
+    /// which is where production puts it: the iterator owns the pull, and the
+    /// buffer only merges a batch it is handed. A buffer with none set reads as
+    /// an empty base file rather than panicking, which is what a log-only file
+    /// group looks like.
+    fn take_base_source(
+        buffer: &mut KeyBasedFileGroupRecordBuffer,
+        schema: &SchemaRef,
+    ) -> Box<dyn arrow_array::RecordBatchReader + Send> {
+        buffer.base.base_file_source.take().unwrap_or_else(|| {
+            Box::new(arrow_array::RecordBatchIterator::new(
+                std::iter::empty(),
+                schema.clone(),
+            ))
+        })
     }
 
     /// Build the same buffer state used by `test_read_with_commit_time_ordering`
@@ -5430,14 +5458,7 @@ mod tests {
         schema: SchemaRef,
         batch_size: usize,
     ) -> Vec<RecordBatch> {
-        let it = FileGroupMergeIterator::new_buffered(
-            Box::new(buffer),
-            schema.clone(),
-            schema,
-            None,
-            batch_size,
-            new_stream_stats_handle(),
-        );
+        let it = new_buffered_test(buffer, schema.clone(), schema, None, batch_size);
         it.map(|r| r.unwrap()).collect()
     }
 
@@ -5620,12 +5641,14 @@ mod tests {
     fn stream_snapshots_update_stats_on_exhaustion() {
         let (buffer, schema) = build_commit_time_ordering_fixture();
         let stats = new_stream_stats_handle();
+        let mut buffer = buffer;
+        let base_source = take_base_source(&mut buffer, &schema);
         let it = FileGroupMergeIterator::new_buffered(
             Box::new(buffer),
+            base_source,
             schema.clone(),
             schema,
             None,
-            4096,
             stats.clone(),
         );
         let chunks: Vec<RecordBatch> = it.map(|r| r.unwrap()).collect();
@@ -5644,7 +5667,7 @@ mod tests {
     fn stream_matches_legacy_row_content() {
         let (buffer1, schema1) = build_commit_time_ordering_fixture();
         let it = new_buffered_test(
-            Box::new(buffer1),
+            buffer1,
             schema1.clone(),
             schema1.clone(),
             None,
@@ -5668,16 +5691,89 @@ mod tests {
     #[test]
     fn stream_schema_is_constructor_schema() {
         let (buffer, schema) = build_commit_time_ordering_fixture();
-        let it = FileGroupMergeIterator::new_buffered(
-            Box::new(buffer),
-            schema.clone(),
-            schema.clone(),
-            None,
-            1,
-            new_stream_stats_handle(),
-        );
+        let it = new_buffered_test(buffer, schema.clone(), schema.clone(), None, 1);
         use arrow_array::RecordBatchReader as _;
         assert_eq!(it.schema(), schema);
+    }
+
+    /// The log side of `build_commit_time_ordering_fixture`, with no base
+    /// source attached, so the same buffer can be driven either by the pull it
+    /// owns or by batches handed to it.
+    fn commit_time_ordering_log_side() -> KeyBasedFileGroupRecordBuffer {
+        let mut buffer =
+            build_key_based_buffer_with_delete_marker("COMMIT_TIME_ORDERING", "counter", "3");
+        buffer
+            .process_data_block(&mut make_data_block(
+                create_test_batch(&[("1", 2, 1), ("2", 1, 2), ("2", 1, 0)]),
+                "instant1",
+            ))
+            .unwrap();
+        buffer
+            .process_data_block(&mut make_data_block(
+                create_test_batch(&[("2", 1, 0), ("3", 1, 2), ("3", 3, 1)]),
+                "instant2",
+            ))
+            .unwrap();
+        buffer
+    }
+
+    /// Merging a batch the caller supplies must produce exactly what merging
+    /// the same batch pulled from the buffer's own source produces — including
+    /// the log-only drain that follows, since a merge that consumed different
+    /// log entries would show up there rather than in the merged batches.
+    ///
+    /// The two differ only in who owns the pull. If that changed the answer,
+    /// how the base file is read would be a correctness variable, which is the
+    /// whole premise of moving the pull out to an async caller.
+    #[test]
+    fn merge_base_batch_matches_the_source_owning_pull() {
+        let schema = create_test_schema();
+        // Two batches, so the pulling route crosses a batch boundary mid-merge
+        // rather than seeing the base file as one lump. Key "4" has no log
+        // entry at all: without it every base key would be superseded by a log
+        // record, and a buffer that merged nothing and drained everything would
+        // produce the same rows as one that merged correctly — the comparison
+        // could not tell the two apart.
+        let base = vec![
+            create_test_batch(&[("1", 1, 1), ("2", 1, 1)]),
+            create_test_batch(&[("3", 1, 1), ("4", 7, 7)]),
+        ];
+
+        // Route A: the buffer owns the source and pulls each batch itself.
+        let mut pulling = commit_time_ordering_log_side();
+        pulling.set_base_file_source(Box::new(arrow_array::RecordBatchIterator::new(
+            base.iter().cloned().map(Ok).collect::<Vec<_>>().into_iter(),
+            schema.clone(),
+        )));
+        let mut pulled: Vec<(String, i32, i64)> = Vec::new();
+        while let Some(b) = pulling.next_merged_base_batch(&schema).unwrap() {
+            pulled.extend(extract_records(&b));
+        }
+        while let Some(b) = pulling.drain_log_only_inserts(&schema).unwrap() {
+            pulled.extend(extract_records(&b));
+        }
+
+        // Route B: the caller owns the batches and hands them over one at a time.
+        let mut handed = commit_time_ordering_log_side();
+        let mut handed_rows: Vec<(String, i32, i64)> = Vec::new();
+        for b in &base {
+            if let Some(m) = handed.merge_base_batch(b, &schema).unwrap() {
+                handed_rows.extend(extract_records(&m));
+            }
+        }
+        while let Some(b) = handed.drain_log_only_inserts(&schema).unwrap() {
+            handed_rows.extend(extract_records(&b));
+        }
+
+        assert!(
+            pulled.iter().any(|(k, _, _)| k == "4"),
+            "the base-only key must reach the output, or this comparison cannot \
+             distinguish merging from draining"
+        );
+        assert_eq!(
+            handed_rows, pulled,
+            "who pulls the base batch must not change what the merge produces"
+        );
     }
 
     /// lazy base source: instead of `set_base_file_iterator(vec![...])`
@@ -5818,7 +5914,7 @@ mod tests {
         buffer.set_base_file_source(Box::new(empty_reader));
 
         let iter = new_buffered_test(
-            Box::new(buffer),
+            buffer,
             schema.clone(),
             schema.clone(),
             None,
@@ -5850,7 +5946,7 @@ mod tests {
         buffer.set_base_file_source(Box::new(reader));
 
         let iter = new_buffered_test(
-            Box::new(buffer),
+            buffer,
             schema.clone(),
             schema.clone(),
             None,
@@ -5883,7 +5979,7 @@ mod tests {
         buffer.set_base_file_source(Box::new(reader));
 
         let iter = new_buffered_test(
-            Box::new(buffer),
+            buffer,
             schema.clone(),
             schema.clone(),
             None,
@@ -5942,7 +6038,7 @@ mod tests {
         buffer.set_base_file_source(Box::new(reader));
 
         let iter = new_buffered_test(
-            Box::new(buffer),
+            buffer,
             schema.clone(),
             schema.clone(),
             None,
@@ -6152,7 +6248,7 @@ mod tests {
             schema.clone(),
         )));
         let iter = new_buffered_test(
-            Box::new(buffer),
+            buffer,
             schema.clone(),
             schema.clone(),
             None,
@@ -6185,7 +6281,7 @@ mod tests {
             schema.clone(),
         )));
         let iter = new_buffered_test(
-            Box::new(buffer),
+            buffer,
             schema.clone(),
             schema.clone(),
             None,
@@ -6304,7 +6400,7 @@ mod tests {
             schema.clone(),
         )));
         let iter = new_buffered_test(
-            Box::new(buffer),
+            buffer,
             schema.clone(),
             schema.clone(),
             None,
@@ -6603,7 +6699,7 @@ mod tests {
             schema.clone(),
         )));
         let iter = new_buffered_test(
-            Box::new(buffer),
+            buffer,
             schema.clone(),
             schema.clone(),
             None,
@@ -6638,7 +6734,7 @@ mod tests {
             schema.clone(),
         )));
         let iter = new_buffered_test(
-            Box::new(buffer),
+            buffer,
             schema.clone(),
             schema.clone(),
             None,
@@ -6678,7 +6774,7 @@ mod tests {
         buffer.set_base_file_source(Box::new(empty_reader));
 
         let iter = new_buffered_test(
-            Box::new(buffer),
+            buffer,
             schema.clone(),
             schema.clone(),
             None,
@@ -6765,7 +6861,7 @@ mod tests {
         let converter = Box::new(ProjectionConverter::new(&target_schema));
 
         let iter = new_buffered_test(
-            Box::new(buffer),
+            buffer,
             merge_schema.clone(),
             target_schema.clone(),
             Some(converter),
@@ -6824,7 +6920,7 @@ mod tests {
         buffer.set_base_file_source(Box::new(empty_reader));
 
         let iter = new_buffered_test(
-            Box::new(buffer),
+            buffer,
             bogus_schema.clone(),
             bogus_schema.clone(),
             None,
@@ -7019,7 +7115,7 @@ mod tests {
             .unwrap();
 
         let iter = new_buffered_test(
-            Box::new(buffer),
+            buffer,
             required_schema,
             requested_schema.clone(),
             output_converter,
@@ -7104,7 +7200,7 @@ mod tests {
         assert_eq!(buffer.size(), 0, "log map must be empty");
 
         let iter = new_buffered_test(
-            Box::new(buffer),
+            buffer,
             schema.clone(),
             schema.clone(),
             None,
@@ -7158,7 +7254,7 @@ mod tests {
         buffer.set_base_file_source(Box::new(reader));
 
         let inner = new_buffered_test(
-            Box::new(buffer),
+            buffer,
             schema.clone(),
             schema.clone(),
             None,
@@ -7249,7 +7345,7 @@ mod tests {
         buffer.set_base_file_source(Box::new(reader));
 
         let iter = new_buffered_test(
-            Box::new(buffer),
+            buffer,
             schema.clone(),
             schema.clone(),
             None,
@@ -7303,7 +7399,7 @@ mod tests {
         buffer.set_base_file_source(Box::new(reader));
 
         let iter = new_buffered_test(
-            Box::new(buffer),
+            buffer,
             schema.clone(),
             schema.clone(),
             None,
@@ -7349,7 +7445,7 @@ mod tests {
         buffer.set_base_file_source(Box::new(reader));
 
         let iter = new_buffered_test(
-            Box::new(buffer),
+            buffer,
             schema.clone(),
             schema.clone(),
             None,
@@ -7481,7 +7577,7 @@ mod tests {
             .unwrap();
         let conv = buffer.reader_context.schema_handler.get_output_converter();
         let iter = new_buffered_test(
-            Box::new(buffer),
+            buffer,
             required,
             requested.clone(),
             conv,
@@ -7560,13 +7656,7 @@ mod tests {
             .clone()
             .unwrap();
         let conv = buffer.reader_context.schema_handler.get_output_converter();
-        let iter = new_buffered_test(
-            Box::new(buffer),
-            required,
-            requested,
-            conv,
-            DEFAULT_BATCH_SIZE,
-        );
+        let iter = new_buffered_test(buffer, required, requested, conv, DEFAULT_BATCH_SIZE);
         let collected: std::result::Result<Vec<RecordBatch>, arrow_schema::ArrowError> =
             iter.collect();
         let err = collected.expect_err(
@@ -7603,13 +7693,7 @@ mod tests {
             .clone()
             .unwrap();
         let conv2 = buffer2.reader_context.schema_handler.get_output_converter();
-        let iter2 = new_buffered_test(
-            Box::new(buffer2),
-            required2,
-            requested2,
-            conv2,
-            DEFAULT_BATCH_SIZE,
-        );
+        let iter2 = new_buffered_test(buffer2, required2, requested2, conv2, DEFAULT_BATCH_SIZE);
         let batches: Vec<RecordBatch> = iter2
             .collect::<std::result::Result<Vec<RecordBatch>, arrow_schema::ArrowError>>()
             .expect("a clean (non-sentinel) log-only insert must drain without error");
@@ -7727,7 +7811,7 @@ mod tests {
             .unwrap();
         let conv = buffer.reader_context.schema_handler.get_output_converter();
         let iter = new_buffered_test(
-            Box::new(buffer),
+            buffer,
             required,
             requested.clone(),
             conv,

--- a/crates/core/src/file_group/reader_v2/buffer/key_based.rs
+++ b/crates/core/src/file_group/reader_v2/buffer/key_based.rs
@@ -5754,6 +5754,94 @@ mod tests {
         buffer
     }
 
+    /// Where the batch boundaries fall changes the ORDER of the merged output,
+    /// and this is the test that says so out loud.
+    ///
+    /// The kernel emits a batch as kept base rows first, then the log records
+    /// that replaced the rest. So a base delivered whole yields
+    /// `[all kept][all replaced]`, while the same base split in two yields
+    /// `[kept][replaced][kept][replaced]` — the same rows, a different sequence.
+    ///
+    /// It matters because both read entry points merge a row group at a time:
+    /// that is what makes their orders equal, and it is why nothing may collapse
+    /// the base on one path only. The property is invisible on a table where
+    /// every key is updated (no base row survives to be ordered against), which
+    /// is every MOR fixture in this repo and both benchmark datasets — hence a
+    /// hand-built mixed batch here.
+    #[test]
+    fn batch_boundaries_change_the_merged_row_order() {
+        let schema = create_test_schema();
+        // Log replaces "b" and "d" only; "a", "c", "e" survive from the base.
+        // Counters avoid 3, which this fixture treats as a delete marker.
+        let mut whole =
+            build_key_based_buffer_with_delete_marker("COMMIT_TIME_ORDERING", "counter", "3");
+        let mut split =
+            build_key_based_buffer_with_delete_marker("COMMIT_TIME_ORDERING", "counter", "3");
+        for buffer in [&mut whole, &mut split] {
+            buffer
+                .process_data_block(&mut make_data_block(
+                    create_test_batch(&[("b", 20, 5), ("d", 40, 5)]),
+                    "instant1",
+                ))
+                .unwrap();
+        }
+
+        let all = create_test_batch(&[
+            ("a", 10, 1),
+            ("b", 11, 1),
+            ("c", 12, 1),
+            ("d", 13, 1),
+            ("e", 14, 1),
+        ]);
+        let first = create_test_batch(&[("a", 10, 1), ("b", 11, 1), ("c", 12, 1)]);
+        let second = create_test_batch(&[("d", 13, 1), ("e", 14, 1)]);
+
+        // In ROW order. `extract_records` sorts by key, which would make this
+        // test assert nothing about the very thing it exists to pin.
+        let keys_of = |b: &RecordBatch| -> Vec<String> {
+            let col = b
+                .column(0)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("key column");
+            (0..b.num_rows())
+                .map(|i| col.value(i).to_string())
+                .collect()
+        };
+
+        let mut whole_rows: Vec<String> = Vec::new();
+        if let Some(b) = whole.merge_base_batch(&all, &schema).unwrap() {
+            whole_rows.extend(keys_of(&b));
+        }
+        let mut split_rows: Vec<String> = Vec::new();
+        for b in [&first, &second] {
+            if let Some(m) = split.merge_base_batch(b, &schema).unwrap() {
+                split_rows.extend(keys_of(&m));
+            }
+        }
+
+        assert_eq!(
+            whole_rows,
+            vec!["a", "c", "e", "b", "d"],
+            "a whole base batch emits the surviving base rows, then the replacements"
+        );
+        assert_eq!(
+            split_rows,
+            vec!["a", "c", "b", "e", "d"],
+            "a split base interleaves them per batch"
+        );
+
+        let mut w = whole_rows.clone();
+        let mut sp = split_rows.clone();
+        w.sort();
+        sp.sort();
+        assert_eq!(w, sp, "the same rows either way - only the order differs");
+        assert_ne!(
+            whole_rows, split_rows,
+            "if these ever match, this test has stopped pinning anything"
+        );
+    }
+
     /// Merging a batch the caller supplies must produce exactly what merging
     /// the same batch pulled from the buffer's own source produces — including
     /// the log-only drain that follows, since a merge that consumed different

--- a/crates/core/src/file_group/reader_v2/buffer/key_based.rs
+++ b/crates/core/src/file_group/reader_v2/buffer/key_based.rs
@@ -3923,6 +3923,104 @@ mod tests {
         (recs, spilled)
     }
 
+    /// How long one `merge_base_batch` call blocks when the merge map has
+    /// spilled, which is the number that decides whether the merge needs
+    /// `spawn_blocking`.
+    ///
+    /// The probe is not per row: a spilled key is reconstructed from a whole
+    /// spilled Arrow batch (`SPILL_BATCH_ROWS` records), the RocksDB read is one
+    /// `get` per such batch, and the last `SPILL_BATCH_CACHE` of them are cached
+    /// decoded. So the cost per merged base batch is set by how many *distinct*
+    /// spill batches its keys touch, and whether they fit the cache.
+    ///
+    /// Two orders are measured because they differ by exactly that: base keys
+    /// ascending touch spill batches one at a time (cache-friendly), while base
+    /// keys strided across the whole key space touch a new spill batch almost
+    /// every row and evict continuously. The strided figure is the one a
+    /// `spawn_blocking` decision has to be made against.
+    ///
+    /// Ignored: a measurement, not an assertion. Run with
+    /// `cargo test -p hudi-core --release --lib spilled_merge_blocking_duration -- --ignored --nocapture`.
+    #[cfg(feature = "spill-rocksdb")]
+    #[test]
+    #[ignore = "measurement, not an assertion"]
+    fn spilled_merge_blocking_duration() {
+        use std::time::Instant;
+
+        // Enough distinct keys to span far more spill batches than the decoded
+        // cache holds, so a scattered probe order really does evict.
+        const KEYS: usize = 50_000;
+        // 1024 is what a real chunk holds: `base_read_options` never sets a
+        // parquet batch size, so arrow-rs's default applies. 8192 is an upper
+        // bound for what a caller that raised it would see.
+        const CHUNK_SIZES: [usize; 2] = [1_024, 8_192];
+
+        let build = |budget: &[(&str, &str)]| {
+            let mut buffer =
+                build_key_based_buffer_with_reader_config("COMMIT_TIME_ORDERING", budget);
+            let rows: Vec<(String, i32, i64)> = (0..KEYS)
+                .map(|i| (format!("k{i:06}"), i as i32, 1))
+                .collect();
+            // In chunks, so the map spills progressively as a real scan does.
+            for chunk in rows.chunks(4096) {
+                let refs: Vec<(&str, i32, i64)> =
+                    chunk.iter().map(|(k, c, t)| (k.as_str(), *c, *t)).collect();
+                buffer
+                    .process_data_block(&mut make_data_block(create_test_batch(&refs), "i0"))
+                    .unwrap();
+            }
+            buffer
+        };
+
+        let schema = create_test_schema();
+
+        // The control matters as much as the measurement: the merge kernel is
+        // synchronous CPU work whether or not the map spilled, so without the
+        // no-spill baseline there is no way to tell how much of the blocking the
+        // spill is actually responsible for.
+        let spill_budget: &[(&str, &str)] = &[("hoodie.memory.merge.max.size", "1024")];
+        let no_budget: &[(&str, &str)] = &[];
+        for rows in CHUNK_SIZES {
+            // Ascending: consecutive keys, so one spilled batch is exhausted
+            // before the next is touched.
+            let ascending: Vec<String> = (0..rows).map(|i| format!("k{i:06}")).collect();
+            // Spread across the whole key space, so consecutive base rows land in
+            // different spilled batches and evict each other from the decoded
+            // cache.
+            let scattered: Vec<String> = (0..rows)
+                .map(|i| format!("k{:06}", (i * 7919) % KEYS))
+                .collect();
+
+            for (tier, budget) in [("no-spill", no_budget), ("spilled", spill_budget)] {
+                for (order, keys) in [("ascending", &ascending), ("scattered", &scattered)] {
+                    let mut buffer = build(budget);
+                    let spilled = buffer.base.records.spill_fired();
+                    assert_eq!(
+                        spilled,
+                        tier == "spilled",
+                        "the {tier} leg must{} spill",
+                        if tier == "spilled" { "" } else { " not" }
+                    );
+                    let refs: Vec<(&str, i32, i64)> =
+                        keys.iter().map(|k| (k.as_str(), 0i32, 0i64)).collect();
+                    let base = create_test_batch(&refs);
+
+                    let start = Instant::now();
+                    let merged = buffer.merge_base_batch(&base, &schema).unwrap();
+                    let elapsed = start.elapsed();
+
+                    let rows_out = merged.map(|b| b.num_rows()).unwrap_or(0);
+                    println!(
+                        "[spill-blocking] {rows:5} rows | {tier:8} | {order:9} -> {:>12?} \
+                         ({rows_out} out, {:.2} us/row)",
+                        elapsed,
+                        elapsed.as_secs_f64() * 1e6 / rows as f64,
+                    );
+                }
+            }
+        }
+    }
+
     /// A churn workload under a `merge.max.size` low enough
     /// to force spilling produces output BYTE-IDENTICAL to the no-spill baseline,
     /// AND the spill actually fires. This is the unit-level equivalent of the

--- a/crates/core/src/file_group/reader_v2/buffer/key_based.rs
+++ b/crates/core/src/file_group/reader_v2/buffer/key_based.rs
@@ -1403,9 +1403,9 @@ impl HoodieFileGroupRecordBuffer for KeyBasedFileGroupRecordBuffer {
         // Mirrors Java: getRecordsIterator → getEngineRecordIterator
         //   → readRecordsFromBlockPayload → inflate → deserializeRecords → deflate
         let decode_start = std::time::Instant::now();
-        // Upstream fetches a lazy block's content here. This crate's log file
-        // reader returns blocks with their content already read, so there is
-        // nothing to fetch and the take below finds it present.
+        // Upstream fetches a lazy block's content here. Pass 3 loads it for every
+        // admitted block before dispatch, so there is nothing left to fetch and
+        // the take below finds it present.
         self.base.stage_decode_ms += decode_start.elapsed().as_millis() as u64;
 
         if let LogBlockContent::Records(record_batches) = std::mem::take(&mut block.content) {
@@ -1570,9 +1570,9 @@ impl HoodieFileGroupRecordBuffer for KeyBasedFileGroupRecordBuffer {
     /// `process_next_deleted_record` for each.
     fn process_delete_block(&mut self, block: &mut LogBlock) -> Result<()> {
         let decode_start = std::time::Instant::now();
-        // Upstream fetches a lazy block's content here. This crate's log file
-        // reader returns blocks with their content already read, so there is
-        // nothing to fetch and the take below finds it present.
+        // Upstream fetches a lazy block's content here. Pass 3 loads it for every
+        // admitted block before dispatch, so there is nothing left to fetch and
+        // the take below finds it present.
         self.base.stage_decode_ms += decode_start.elapsed().as_millis() as u64;
 
         if let LogBlockContent::Records(record_batches) = std::mem::take(&mut block.content) {

--- a/crates/core/src/file_group/reader_v2/buffer/mod.rs
+++ b/crates/core/src/file_group/reader_v2/buffer/mod.rs
@@ -285,6 +285,25 @@ pub trait HoodieFileGroupRecordBuffer: Send + std::fmt::Debug {
     /// batch from the source).
     fn next_merged_base_batch(&mut self, target_schema: &SchemaRef) -> Result<Option<RecordBatch>>;
 
+    /// Merge one base-file batch against the in-buffer log map.
+    ///
+    /// The same work [`Self::next_merged_base_batch`] does, minus the pull: the
+    /// caller supplies the batch. That split is what lets the base file be read
+    /// asynchronously while the merge itself stays synchronous — the buffer
+    /// holds no source, so nothing it owns has to be awaited.
+    ///
+    /// `Ok(None)` means this batch contributed no rows (empty input, or every
+    /// row lost to a log delete). It does **not** mean the base is exhausted:
+    /// only the caller, who owns the source, knows that.
+    ///
+    /// `target_schema` is the schema the returned batch must conform to, as in
+    /// [`Self::next_merged_base_batch`].
+    fn merge_base_batch(
+        &mut self,
+        base: &RecordBatch,
+        target_schema: &SchemaRef,
+    ) -> Result<Option<RecordBatch>>;
+
     /// Drain remaining log-only records (keys never matched by any base row)
     /// as merged inserts. Returns `Ok(None)` if no log-only inserts remain
     /// (delete-only or fully consumed by base merge).

--- a/crates/core/src/file_group/reader_v2/buffer/mod.rs
+++ b/crates/core/src/file_group/reader_v2/buffer/mod.rs
@@ -173,14 +173,14 @@ pub trait HoodieFileGroupRecordBuffer: Send + std::fmt::Debug {
     /// Snapshot the insert / update / delete counts the buffer's
     /// `UpdateProcessor` has accumulated so far.
     ///
-    /// With streaming output, the [`FileGroupMergeIterator`] drives
+    /// With streaming output, the [`FileGroupMergeStream`] drives
     /// `has_next/next` and the update processor increments these counters as a
     /// side effect; after the stream is exhausted the iterator reads them back
     /// through this accessor instead of through `merge_and_collect_with_stats`
     /// (which consumes the buffer). Defaults to zero for buffers that don't
     /// track update stats.
     ///
-    /// [`FileGroupMergeIterator`]: crate::file_group::reader_v2::merge_iterator::FileGroupMergeIterator
+    /// [`FileGroupMergeStream`]: crate::file_group::reader_v2::merge_iterator::FileGroupMergeStream
     fn update_stats_snapshot(&self) -> UpdateStats {
         UpdateStats::default()
     }

--- a/crates/core/src/file_group/reader_v2/buffer/position_based.rs
+++ b/crates/core/src/file_group/reader_v2/buffer/position_based.rs
@@ -591,6 +591,31 @@ impl HoodieFileGroupRecordBuffer for PositionBasedFileGroupRecordBuffer {
             .pull_and_merge_next_base_batch(target_schema, base_match)
     }
 
+    /// Merge one caller-supplied base batch. See
+    /// [`HoodieFileGroupRecordBuffer::merge_base_batch`].
+    ///
+    /// The hybrid strategy is refused rather than quietly merged the ordinary
+    /// way. It resolves position-only deletes row by row against a source this
+    /// method does not have, so answering without it would drop deletes and
+    /// return rows that should not exist. Nothing sets `needs_hybrid_strategy`
+    /// today; this is here so switching it on fails loudly instead.
+    fn merge_base_batch(
+        &mut self,
+        base: &RecordBatch,
+        target_schema: &SchemaRef,
+    ) -> Result<Option<RecordBatch>> {
+        if self.needs_hybrid_strategy {
+            return Err(CoreError::Unsupported(
+                "the position buffer fell back to the hybrid strategy, which resolves \
+                 position-only deletes row by row and has no batch-at-a-time form"
+                    .to_string(),
+            ));
+        }
+        let base_match = self.base_match();
+        self.inner
+            .merge_one_base_batch_kernel(base, target_schema, base_match)
+    }
+
     fn drain_log_only_inserts(&mut self, target_schema: &SchemaRef) -> Result<Option<RecordBatch>> {
         self.inner.drain_log_only_inserts(target_schema)
     }

--- a/crates/core/src/file_group/reader_v2/buffer/record_buffer.rs
+++ b/crates/core/src/file_group/reader_v2/buffer/record_buffer.rs
@@ -47,13 +47,11 @@ use std::vec::IntoIter;
 /// - `buffered_record_merger` — for delta merge (log-vs-log) and final merge (base-vs-log)
 /// - `update_processor` — strategy for processing updates during merge iteration
 /// - `base_file_source` / `current_base_batch` / `base_row_idx` — lazy
-///   counterpart of Java's `baseFileIterator`. The lazy source replaced the
-///   eagerly-loaded `Vec<RecordBatch>` with a `RecordBatchReader` so the
-///   merge loop pulls one parquet row-group at a time. For tests and the
-///   `read()` back-compat path, the source is just a `RecordBatchIterator`
-///   wrapping a pre-built Vec; for the FFI streaming path, it is a
-///   `ParquetSyncReader`. The current batch is interned into an `Arc` so
-///   base records become zero-copy `BatchRef`s into the streamed batch.
+///   counterpart of Java's `baseFileIterator`, and used only by the row-wise
+///   legacy path (`has_next`/`next`/`merge_and_collect_with_stats`) and the
+///   tests that drive it. The batch-at-a-time merge the reader uses is handed
+///   each base batch by its caller and holds no source. The current batch is
+///   interned into an `Arc` so base records become zero-copy `BatchRef`s.
 /// - `next_record` — Java's `nextRecord` (the lookahead for has_next/next pattern)
 pub struct FileGroupRecordBuffer {
     /// The per-key records map. Mirrors Java's `ExternalSpillableMap`: keeps
@@ -81,9 +79,11 @@ pub struct FileGroupRecordBuffer {
     ///
     /// A3 — the base file is pulled one parquet row-group at a
     /// time from this `RecordBatchReader` instead of being eagerly collected
-    /// and concatenated into a `Vec<RecordBatch>`. For tests and the `read()`
-    /// back-compat path the source is a `RecordBatchIterator` over a pre-built
-    /// vec; for the FFI streaming path (`open()`) it is a `ParquetSyncReader`.
+    /// and concatenated into a `Vec<RecordBatch>`.
+    ///
+    /// Only the row-wise legacy path reads it — `has_next`/`next` and
+    /// `merge_and_collect_with_stats`, plus the tests that drive them. The
+    /// reader's own path merges a batch it is handed, so it sets nothing here.
     pub base_file_source: Option<Box<dyn RecordBatchReader + Send>>,
 
     /// The current base file batch being iterated, interned into a single
@@ -278,8 +278,8 @@ impl FileGroupRecordBuffer {
             };
             match source.next() {
                 None => {
-                    // Stream exhausted; release source so a future call
-                    // doesn't re-block_on a closed stream.
+                    // Source exhausted; release it so a later call cannot pull
+                    // from a reader that has already ended.
                     self.current_base_batch = None;
                     self.base_file_source = None;
                     return Ok(None);

--- a/crates/core/src/file_group/reader_v2/engine.rs
+++ b/crates/core/src/file_group/reader_v2/engine.rs
@@ -416,13 +416,17 @@ impl HoodieFileGroupReader {
     /// Stream the merged output.
     ///
     /// [`Self::read`] returns the whole file group as one batch, so peak memory
-    /// tracks the base file. This reads the base file one row group at a time
-    /// instead, merging and emitting a chunk per group.
+    /// tracks the base file. This reads the base file one bounded batch at a
+    /// time instead (`MERGE_CHUNK_ROWS` rows), merging and emitting a chunk
+    /// per batch.
     ///
     /// Demand-driven: nothing is merged until the consumer asks for it, so the
     /// memory this adds over the merge map is one chunk. The previous shape ran
     /// the merge on a blocking thread behind a depth-1 channel to get the same
     /// bound; a `Stream` has it by construction.
+    ///
+    /// Single-use: takes the output converter and, for MOR, moves the record
+    /// buffer into the returned stream. Reading again needs a new reader.
     pub(crate) async fn open_stream(
         &mut self,
     ) -> Result<futures::stream::BoxStream<'static, Result<RecordBatch>>> {
@@ -436,11 +440,13 @@ impl HoodieFileGroupReader {
     /// `RecordBatch`.
     ///
     /// Same merge as [`Self::open_stream`], collected into one batch. Both
-    /// entry points merge the base a row group at a time and therefore return
+    /// entry points merge the base a batch at a time and therefore return
     /// the same row sequence; this one just concatenates the chunks.
+    /// Single-use, like [`Self::open_stream`].
     pub async fn read(&mut self) -> Result<RecordBatch> {
-        // Stage timing (perf harness): the base file open plus, here, its whole
-        // decode — `collapse_base` drives the stream to completion.
+        // Stage timing (perf harness): only the open, same as `open_stream` —
+        // the decode happens lazily while `collect_into_one_batch` drives the
+        // stream, so it lands in the merge loop rather than in `base_read_ms`.
         let base = profile_once!(self.read_stats.base_read_ms, self.base_file_source().await)?;
         let batch = self
             .init_record_iterators(base)
@@ -684,10 +690,10 @@ impl HoodieFileGroupReader {
     /// Open the base file as a stream of batches, with the schema they carry.
     ///
     /// One shape for every caller: the base file is read asynchronously, one
-    /// row group at a time, and the whole file is never resident. A caller that
-    /// needs it as a single batch collapses it afterwards
-    /// ([`Self::collapse_base`]) — that is a choice about chunking, not about
-    /// what is safe to call from where.
+    /// bounded batch at a time, and the whole file is never resident. A caller
+    /// that needs it as a single batch collapses it afterwards (`read()` does,
+    /// via `collect_into_one_batch`) — that is a choice about chunking, not
+    /// about what is safe to call from where.
     ///
     /// Returns an empty stream when the input split has no base file (log-only
     /// file group), and when the instant range excludes this base file: the
@@ -834,7 +840,7 @@ impl HoodieFileGroupReader {
         }
 
         // Open the base file as a stream. The whole file never lives in memory;
-        // one row group does. The (CoW-gated) RowFilter is threaded through the
+        // one batch does. The (CoW-gated) RowFilter is threaded through the
         // intersection read so row groups can be pruned via column-index stats
         // (the builder resolves predicate columns by name and returns None when
         // any referenced column is absent — safe even for evolved/added cols).

--- a/crates/core/src/file_group/reader_v2/engine.rs
+++ b/crates/core/src/file_group/reader_v2/engine.rs
@@ -37,7 +37,7 @@ use crate::file_group::reader_v2::buffered_record_converter::BufferedRecordConve
 use crate::file_group::reader_v2::input_split::InputSplit;
 use crate::file_group::reader_v2::iterator_mode::IteratorMode;
 use crate::file_group::reader_v2::merge_iterator::{
-    FileGroupMergeIterator, StreamStatsHandle, new_stream_stats_handle,
+    FileGroupMergeStream, StreamStatsHandle, new_stream_stats_handle,
 };
 use crate::file_group::reader_v2::output_converter::OutputConverter;
 use crate::file_group::reader_v2::profiling::profile_once;
@@ -48,6 +48,7 @@ use crate::file_group::reader_v2::schema_handler::FileGroupReaderSchemaHandler;
 use crate::storage::{RowFilterBuilder, Storage};
 use arrow_array::RecordBatch;
 use arrow_schema::SchemaRef;
+use futures::{StreamExt, TryStreamExt};
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -101,7 +102,7 @@ pub struct HoodieFileGroupReader {
     // ── Mutable state (populated during read) ──────────────────────────
     // NOTE: the record buffer and base-file batches are not stored on the
     // reader — they are local to `init_record_iterators` and owned by the
-    // returned `FileGroupMergeIterator` for the rest of the read.
+    // returned `FileGroupMergeStream` for the rest of the read.
     /// Optional converter for projecting/transforming output records.
     /// Mirrors Java's `Option<UnaryOperator<T>> outputConverter`.
     output_converter: Option<Box<dyn OutputConverter>>,
@@ -109,7 +110,7 @@ pub struct HoodieFileGroupReader {
     /// Read statistics accumulator.
     read_stats: HoodieReadStats,
 
-    /// Stage-timing sink shared with the [`FileGroupMergeIterator`] returned by
+    /// Stage-timing sink shared with the [`FileGroupMergeStream`] returned by
     /// [`Self::open`]. The streaming iterator
     /// owns the buffer once `open()` returns, so the merge-phase timings
     /// (final_merge_ms, output_build_ms) and the update-processor
@@ -133,7 +134,7 @@ pub struct HoodieFileGroupReader {
     // visible to (a) the base parquet read here, and (b) the parquet log
     // block decoder in `file_group::log_file::content::Decoder`. The gate
     // (CoW || mor_pk_safe) lives at the use sites; this file's gate is at
-    // `make_base_file_source` below.
+    // `base_file_source` below.
 }
 
 /// Base-file read options carrying an optional pushdown predicate, and the
@@ -156,6 +157,28 @@ fn base_read_options(
         options = options.with_row_index_column(ROW_INDEX_TEMPORARY_COLUMN_NAME);
     }
     options
+}
+
+/// A base file as the merge consumes it: batches, plus the schema they carry.
+///
+/// The schema travels with the stream because a `Stream` has no `schema()` the
+/// way a `RecordBatchReader` does, and the merge needs it before the first
+/// batch arrives — to derive the merge schema, and to describe a base file that
+/// yields no batches at all.
+struct BaseSource {
+    schema: SchemaRef,
+    batches: crate::file_group::reader_v2::merge_iterator::BaseBatchStream,
+}
+
+impl BaseSource {
+    /// A base file that contributes nothing: no base file at all, or one the
+    /// instant range excludes.
+    fn empty(schema: SchemaRef) -> Self {
+        Self {
+            schema,
+            batches: futures::stream::empty().boxed(),
+        }
+    }
 }
 
 /// `schema` without the internal row-position column.
@@ -358,29 +381,6 @@ impl HoodieFileGroupReader {
     // Main read API (mirrors Java's getClosableIterator / getBufferedRecordIterator)
     // =========================================================================
 
-    /// Driven by the test harness and the FFI surface; `FileGroupReader` reaches the
-    /// engine through `adapter` instead.
-    #[allow(dead_code)]
-    /// Open the file group and return a streaming iterator over the merged
-    /// output. This is the modern entry point matching Java's
-    /// `getClosableIterator()` semantics.
-    ///
-    /// Async work — base file decode + log file scan + buffer population —
-    /// runs once, here. The returned [`FileGroupMergeIterator`] is then a
-    /// purely synchronous [`arrow_array::RecordBatchReader`] that emits one
-    /// chunk per `next()` (default chunk size [`DEFAULT_BATCH_SIZE`] rows).
-    ///
-    /// This is single-use: it consumes the output_converter and (for MOR)
-    /// hands the buffer to the iterator. Re-opening requires constructing a
-    /// new `HoodieFileGroupReader`.
-    pub async fn open(&mut self) -> Result<FileGroupMergeIterator> {
-        // streaming mode — the base file is held as a lazy reader that does a
-        // per-batch `block_on` against the runtime handle it was built with. The
-        // caller MUST consume the returned iterator from a synchronous context
-        // (e.g. the FFI driver), never from inside another tokio runtime.
-        self.init_record_iterators(/* streaming */ true).await
-    }
-
     /// The reader for this slice's base file format.
     ///
     /// Built per call rather than held: the format comes from the reader
@@ -396,74 +396,48 @@ impl HoodieFileGroupReader {
         Ok(create_base_file_reader(&self.storage, &format)?)
     }
 
-    /// Stream the merged output to an async caller.
+    /// Stream the merged output.
     ///
     /// [`Self::read`] returns the whole file group as one batch, so peak memory
     /// tracks the base file. This reads the base file one row group at a time
-    /// instead.
+    /// instead, merging and emitting a chunk per group.
     ///
-    /// The merge loop is synchronous and has to block on the base stream, which
-    /// is only legal off the async worker threads. So it runs on a
-    /// blocking-pool thread and hands batches back over a channel; the caller
-    /// gets an ordinary stream and never sees the blocking.
-    ///
-    /// The channel holds one batch. That lets the producer decode row group
-    /// N+1 while the consumer works on N, while bounding the extra memory to a
-    /// single row group — a deeper channel would multiply peak memory by its
-    /// depth, which is what streaming is meant to avoid.
-    pub(crate) async fn open_blocking_stream(
+    /// Demand-driven: nothing is merged until the consumer asks for it, so the
+    /// memory this adds over the merge map is one chunk. The previous shape ran
+    /// the merge on a blocking thread behind a depth-1 channel to get the same
+    /// bound; a `Stream` has it by construction.
+    pub(crate) async fn open_stream(
         &mut self,
     ) -> Result<futures::stream::BoxStream<'static, Result<RecordBatch>>> {
-        use futures::StreamExt;
-
-        let iter = self.init_record_iterators(/* streaming */ true).await?;
-
-        let (tx, rx) = tokio::sync::mpsc::channel::<Result<RecordBatch>>(1);
-        tokio::task::spawn_blocking(move || {
-            for batch in iter {
-                let item = batch.map_err(CoreError::ArrowError);
-                // A send error means the consumer dropped the stream; stop
-                // rather than decoding row groups nobody will take.
-                if tx.blocking_send(item).is_err() {
-                    break;
-                }
-            }
-        });
-
-        Ok(futures::stream::unfold(rx, |mut rx| async move {
-            rx.recv().await.map(|item| (item, rx))
-        })
-        .boxed())
+        // Stage timing (perf harness): opening the base file. Only the open —
+        // the per-row-group decode is paid lazily, inside the merge.
+        let base = profile_once!(self.read_stats.base_read_ms, self.base_file_source().await)?;
+        Ok(self.init_record_iterators(base).await?.into_stream())
     }
 
     /// Read the file group and return the merged output as a single
-    /// `RecordBatch`. Internally uses the same merge code path as
-    /// [`Self::open`] but with **eager** base file decode — the parquet
-    /// stream is drained async during this method's async body, then the
-    /// resulting `Vec<RecordBatch>` is wrapped in a sync
-    /// `RecordBatchIterator` for the merge loop. That makes the merge
-    /// iterator safe to consume from async callers (no nested block_on).
+    /// `RecordBatch`.
     ///
-    /// New consumers that can use a sync iterator should prefer
-    /// [`Self::open`] for true streaming.
+    /// Same merge as [`Self::open_stream`], but the base file is collapsed to
+    /// one batch first, so the merge emits a single chunk and the rows come back
+    /// in the order this entry point has always returned them. See
+    /// [`Self::collapse_base`].
     pub async fn read(&mut self) -> Result<RecordBatch> {
-        // Eager mode — the base parquet stream is drained
-        // async during `init_record_iterators` (streaming=false), so the
-        // returned iterator's `next()` is pure in-memory work and can be driven
-        // from an async caller (no nested `block_on`). `open()` (streaming=true)
-        // instead holds a lazy `ParquetSyncReader` for true streaming peak
-        // memory, but requires a sync consumer (the FFI driver).
+        // Stage timing (perf harness): the base file open plus, here, its whole
+        // decode — `collapse_base` drives the stream to completion.
+        let base = profile_once!(
+            self.read_stats.base_read_ms,
+            Self::collapse_base(self.base_file_source().await?).await
+        )?;
         let batch = self
-            .init_record_iterators(/* streaming */ false)
+            .init_record_iterators(base)
             .await?
-            .collect_into_one_batch()?;
-        // The streaming iterator accumulated the merge-phase
-        // timings + insert/update/delete counts into the shared `stream_stats`
-        // while `collect_into_one_batch` drove it to exhaustion. Drain them back
-        // into `self.read_stats` so `read_stats()`-based callers (fg-bench,
-        // tests, reader_v1) observe the same stats the pre-streaming `read()`
-        // surfaced. (The FFI `open()` path does not read these back — Velox
-        // consumes the stream directly.)
+            .collect_into_one_batch()
+            .await?;
+        // The merge accumulated the merge-phase timings + insert/update/delete
+        // counts into the shared `stream_stats` while `collect_into_one_batch`
+        // drove it to exhaustion. Drain them back into `self.read_stats` so
+        // `read_stats()`-based callers (fg-bench, tests, reader_v1) observe them.
         self.drain_stream_stats();
         Ok(batch)
     }
@@ -484,33 +458,21 @@ impl HoodieFileGroupReader {
     }
 
     /// Initialize record iterators: read base file + scan/merge log files,
-    /// hand state to a [`FileGroupMergeIterator`].
+    /// hand state to a [`FileGroupMergeStream`].
     ///
     /// Mirrors Java's `HoodieFileGroupReader.initRecordIterators()`. The
     /// fast path (no log files = CoW / empty) returns an `Eager` iterator
     /// over the base file source; the MOR path returns a `Buffered`
     /// iterator that drives `buffer.has_next() / buffer.next()` in chunks.
     ///
-    /// The `streaming` flag controls how the base file is read:
-    /// - `true` — lazy `ParquetSyncReader` (one row group per
-    ///   `next()`; does `block_on` per call → sync-context only).
-    /// - `false` — async drain into `Vec<RecordBatch>`, wrap in
-    ///   `RecordBatchIterator` (no `block_on`; safe from async callers).
-    ///
-    /// `apply_instant_range_filter` requires a materialised Vec today, so
-    /// streaming mode falls back to eager when an instant range is active
-    /// (rare; a per-batch variant of the filter is not yet implemented).
-    ///
     /// ```text
     /// initRecordIterators()
-    ///   ├─ make_base_file_source(streaming)
     ///   └─ recordBufferLoader.getRecordBuffer(...)
-    ///        → recordBuffer.set_base_file_source(...)
-    ///        → FileGroupMergeIterator::new_buffered(...)
+    ///        → FileGroupMergeStream::new_buffered(...)
     /// ```
-    async fn init_record_iterators(&mut self, streaming: bool) -> Result<FileGroupMergeIterator> {
+    async fn init_record_iterators(&mut self, base: BaseSource) -> Result<FileGroupMergeStream> {
         log::debug!(
-            "[HoodieFileGroupReader] initRecordIterators: partition={} base_file={} log_files={} streaming={streaming}",
+            "[HoodieFileGroupReader] initRecordIterators: partition={} base_file={} log_files={}",
             self.input_split.partition_path,
             self.input_split
                 .base_file_path
@@ -519,28 +481,17 @@ impl HoodieFileGroupReader {
             self.input_split.log_file_paths.len(),
         );
 
-        // Step 1: Open the base file source.
-        //   - streaming=true:  a lazy `ParquetSyncReader` — one parquet
-        //     row-group per `RecordBatchReader::next` call. The whole base
-        //     file never lives in memory at once.
-        //   - streaming=false (or instant-range filter active, which still
-        //     needs a materialised Vec): drain async into a `Vec<RecordBatch>`,
-        //     optionally instant-range-filter it, wrap in a `RecordBatchIterator`.
-        // Stage timing (perf harness): base parquet open + (eager) read.
-        // In streaming mode this only covers the open; the per-row-group decode
-        // cost is paid lazily inside the merge loop's `next_base_row` pulls.
-        let base_source = profile_once!(
-            self.read_stats.base_read_ms,
-            self.make_base_file_source(streaming).await
-        )?;
-        let base_source_schema = base_source.schema();
+        let BaseSource {
+            schema: base_source_schema,
+            batches: base_source,
+        } = base;
         log::debug!(
-            "[HoodieFileGroupReader] makeBaseFileSource: schema_cols={} streaming={streaming}",
+            "[HoodieFileGroupReader] base file source: schema_cols={}",
             base_source_schema.fields().len(),
         );
 
         // The post-projection output schema is the same regardless of
-        // CoW vs MOR — used as the iterator's RecordBatchReader::schema().
+        // CoW vs MOR — it is the schema every emitted chunk carries.
         let output_converter = self.output_converter.take();
         let post_projection_schema = output_converter.as_ref().map(|c| c.target_schema());
 
@@ -549,10 +500,9 @@ impl HoodieFileGroupReader {
         if self.input_split.is_base_only() {
             log::debug!("[HoodieFileGroupReader] no log files → Eager iterator");
 
-            // The base source exposes its (post-projection) schema via
-            // `RecordBatchReader::schema()` without forcing a row-group
-            // decode. For a log-only Eager FG the source is
-            // an empty `RecordBatchIterator` carrying the required schema.
+            // The schema travels with the source, so it is known without
+            // forcing a row-group decode. A log-only file group's source is
+            // empty and carries the required schema.
             let merge_schema: SchemaRef = if let Some(rs) = &self.schema_handler.required_schema {
                 rs.clone()
             } else {
@@ -564,7 +514,7 @@ impl HoodieFileGroupReader {
             // per-chunk output_build_ms (concat is gone — each base batch flows
             // through the converter as its own chunk) into `stream_stats`, which
             // `read()` drains back into `self.read_stats`.
-            return Ok(FileGroupMergeIterator::new_eager(
+            return Ok(FileGroupMergeStream::new_eager(
                 base_source,
                 output_schema,
                 output_converter,
@@ -599,7 +549,7 @@ impl HoodieFileGroupReader {
         // gave up partway through is visible (the buffer flips its own type when
         // it falls back, and nothing else records it); and every entry point goes
         // through here, so the streaming read is covered too — reporting from
-        // `read()` alone left `open_blocking_stream` silent.
+        // `read()` alone left the streaming entry point silent.
         crate::file_group::reader_v2::gaps::report_for_read(
             &self.reader_context,
             &self.reader_parameters,
@@ -618,9 +568,8 @@ impl HoodieFileGroupReader {
             self.read_stats.total_rollback_blocks,
         );
 
-        // Step 4: Determine merge_schema BEFORE handing the source to the
-        // buffer. Schema is available via `RecordBatchReader::schema()`
-        // without forcing a row-group decode.
+        // Step 4: Determine merge_schema. The base source's schema travels
+        // with it, so this needs no row-group decode.
         let merge_schema: SchemaRef = if let Some(rs) = &self.schema_handler.required_schema {
             rs.clone()
         } else if self.input_split.base_file_path.is_some() {
@@ -669,7 +618,7 @@ impl HoodieFileGroupReader {
             .expect("stream_stats mutex poisoned")
             .merge_map_peak_entries = record_buffer.merge_map_peak_entries();
 
-        Ok(FileGroupMergeIterator::new_buffered(
+        Ok(FileGroupMergeStream::new_buffered(
             record_buffer,
             base_source,
             merge_schema,
@@ -679,23 +628,6 @@ impl HoodieFileGroupReader {
         ))
     }
 
-    /// Open the base file as a `RecordBatchReader` source.
-    ///
-    /// - `streaming=true`: returns a lazy [`ParquetSyncReader`] over the
-    ///   parquet file. One row group per `RecordBatchReader::next` call.
-    ///   Sync iteration uses `block_on(stream.next())` against the runtime
-    ///   handle it was built with — caller MUST be in sync context.
-    /// - `streaming=false` (or instant range present — see note): drains
-    ///   the parquet stream into a `Vec<RecordBatch>` async, optionally
-    ///   applies the instant range filter, and wraps the Vec in a
-    ///   `RecordBatchIterator` (no `block_on` at iteration time → safe
-    ///   to consume from async callers).
-    ///
-    /// Returns an **empty** `RecordBatchIterator` (no rows) when the
-    /// input split has no base file (log-only file group).
-    ///
-    /// Mirrors Java's `HoodieFileGroupReader.makeBaseFileIterator()`,
-    /// adapted for the Rust streaming/eager split.
     /// Whether this read should merge base + log records by base-file row
     /// position (rather than by record key). Mirrors Java
     /// `HoodieFileGroupReader`'s `setShouldMergeUseRecordPosition`:
@@ -736,30 +668,37 @@ impl HoodieFileGroupReader {
         )
     }
 
-    async fn make_base_file_source(
-        &mut self,
-        streaming: bool,
-    ) -> Result<Box<dyn arrow_array::RecordBatchReader + Send>> {
+    /// Open the base file as a stream of batches, with the schema they carry.
+    ///
+    /// One shape for every caller: the base file is read asynchronously, one
+    /// row group at a time, and the whole file is never resident. A caller that
+    /// needs it as a single batch collapses it afterwards
+    /// ([`Self::collapse_base`]) — that is a choice about chunking, not about
+    /// what is safe to call from where.
+    ///
+    /// Returns an empty stream when the input split has no base file (log-only
+    /// file group), and when the instant range excludes this base file: the
+    /// range is a per-file decision, so it is settled here rather than by
+    /// reading the file and discarding its rows.
+    ///
+    /// Mirrors Java's `HoodieFileGroupReader.makeBaseFileIterator()`.
+    async fn base_file_source(&mut self) -> Result<BaseSource> {
         let Some(path) = self.input_split.base_file_path.clone() else {
             // Log-only file group — empty base. Use the required_schema
-            // as the reader's reported schema when available; otherwise
-            // empty schema (the buffer's reader_schema fallback handles
-            // schema selection downstream).
+            // as the reported schema when available; otherwise an empty
+            // schema (the buffer's reader_schema fallback handles schema
+            // selection downstream).
             let schema = self
                 .schema_handler
                 .required_schema
                 .clone()
                 .unwrap_or_else(|| Arc::new(arrow_schema::Schema::empty()));
-            let empty = arrow_array::RecordBatchIterator::new(
-                std::iter::empty::<std::result::Result<RecordBatch, arrow_schema::ArrowError>>(),
-                schema,
-            );
-            return Ok(Box::new(empty));
+            return Ok(BaseSource::empty(schema));
         };
 
         if self.buffered_record_converter.is_none() {
             log::debug!(
-                "[HoodieFileGroupReader] make_base_file_source: no bufferedRecordConverter set \
+                "[HoodieFileGroupReader] base_file_source: no bufferedRecordConverter set \
                  (batch-level read does not require per-record conversion)"
             );
         }
@@ -795,12 +734,10 @@ impl HoodieFileGroupReader {
         // schema (`base_read_schema` = required + row-index).
         let use_position = self.use_record_position();
 
-        // No projection schema → fall back to the unprojected eager helper
-        // (rare; FFI always supplies a required_schema). Streaming variant
-        // of the unprojected helper is not exposed yet — eager Vec here.
-        // The instant-range filter (if active) must still be applied on this
-        // path — it gates the base file by its commit instant regardless of
-        // projection, so every branch of this method honors it.
+        // No projection schema → fall back to the unprojected helper (rare; FFI
+        // always supplies a required_schema). It reads the file as one batch,
+        // because its schema is only known once the file has been read, so the
+        // instant-range decision below cannot be made before reading it.
         let Some(required_schema) = self.schema_handler.required_schema.clone() else {
             let batch = self
                 .base_file_reader()?
@@ -812,17 +749,13 @@ impl HoodieFileGroupReader {
                     ))
                 })?;
             let schema = batch.schema();
-            let mut batches = vec![batch];
-            if self.reader_context.instant_range.is_some() {
-                let pre: usize = batches.iter().map(|b| b.num_rows()).sum();
-                batches = self.apply_instant_range_filter(batches)?;
-                let post: usize = batches.iter().map(|b| b.num_rows()).sum();
-                log::debug!(
-                    "[HoodieFileGroupReader] applyInstantRangeFilter (unprojected): {pre} → {post} rows"
-                );
+            if !self.base_file_in_range()? {
+                return Ok(BaseSource::empty(schema));
             }
-            let iter = arrow_array::RecordBatchIterator::new(batches.into_iter().map(Ok), schema);
-            return Ok(Box::new(iter));
+            return Ok(BaseSource {
+                schema: schema.clone(),
+                batches: futures::stream::once(async move { Ok(batch) }).boxed(),
+            });
         };
 
         // Schema-evolution intersection (Java parity:
@@ -831,10 +764,8 @@ impl HoodieFileGroupReader {
         //   2. ask parquet only for the INTERSECTION (in the file's own types);
         //   3. project to required per batch: null-fill added columns, cast
         //      promotions (float→double string-mediated so it is value-exact).
-        // Step 3 is applied PER ROW-GROUP so it works identically on the eager
-        // (drain-then-project) and streaming (`ProjectingBatchReader`) paths —
-        // Every base batch the merge interleaves must already be in
-        // `required_schema`.
+        // Step 3 is applied PER ROW-GROUP, so every base batch the merge
+        // interleaves is already in `required_schema`.
         let file_schema = self
             .base_file_reader()?
             .read_stream(&path, BaseFileReadOptions::new())
@@ -862,7 +793,7 @@ impl HoodieFileGroupReader {
         let present_len = present.len();
         let intersection: arrow_schema::SchemaRef = Arc::new(arrow_schema::Schema::new(present));
         log::debug!(
-            "[base-file-evolution] path={} file_cols={} required_cols={} intersect_cols={} streaming={streaming}",
+            "[base-file-evolution] path={} file_cols={} required_cols={} intersect_cols={}",
             path,
             file_schema.fields().len(),
             required_schema.fields().len(),
@@ -882,103 +813,82 @@ impl HoodieFileGroupReader {
             required_schema.clone()
         };
 
-        // Fallback to eager when the instant-range filter is active — the
-        // filter currently needs a materialised Vec. A streaming per-batch
-        // variant is not implemented yet.
-        let instant_range_active = self.reader_context.instant_range.is_some();
-        // Streaming reads the base file one row group at a time, but the merge
-        // loop is synchronous, so it has to block on the stream. That is only
-        // safe off the async worker threads — `open_blocking_stream` is the one
-        // caller that arranges it, and it is the only one that passes
-        // `streaming = true`. The instant-range filter still forces eager: it
-        // needs the batches materialized to filter them.
-        let force_eager = !streaming || instant_range_active;
-
-        if force_eager {
-            // Async drain to the intersection, evolve to `required_schema`,
-            // apply the instant-range filter, wrap the Vec. the
-            // (CoW-gated) RowFilter is threaded through the intersection read so
-            // row groups can be pruned via column-index stats (the builder
-            // resolves predicate columns by name and returns None when any
-            // referenced column is absent — safe even for evolved/added cols).
-            let raw = self
-                .base_file_reader()?
-                .read_data(
-                    &path,
-                    base_read_options(row_filter.clone(), use_position)
-                        .with_projection(intersection.fields().iter().map(|f| f.name())),
-                )
-                .await
-                .map_err(|e| {
-                    CoreError::ReadFileSliceError(format!(
-                        "Failed to read base file '{path}' with projection: {e:?}"
-                    ))
-                })?;
-            let evolved =
-                crate::schema::batch_evolution::project_batch_to_schema(&raw, &base_read_schema)?;
-            let mut batches = vec![evolved];
-            if instant_range_active {
-                let pre: usize = batches.iter().map(|b| b.num_rows()).sum();
-                batches = self.apply_instant_range_filter(batches)?;
-                let post: usize = batches.iter().map(|b| b.num_rows()).sum();
-                log::debug!("[HoodieFileGroupReader] applyInstantRangeFilter: {pre} → {post} rows");
-            }
-            let iter = arrow_array::RecordBatchIterator::new(
-                batches.into_iter().map(Ok),
-                base_read_schema,
-            );
-            Ok(Box::new(iter))
-        } else {
-            // Open the base file as a stream and adapt it back to the iterator
-            // the merge loop wants. The whole file never lives in memory; one
-            // row group does.
-            let base_stream = self
-                .base_file_reader()?
-                .read_stream(
-                    &path,
-                    base_read_options(row_filter.clone(), use_position)
-                        .with_projection(intersection.fields().iter().map(|f| f.name())),
-                )
-                .await
-                .map_err(|e| {
-                    CoreError::ReadFileSliceError(format!(
-                        "Failed to open base file stream '{path}': {e:?}"
-                    ))
-                })?;
-
-            let handle = tokio::runtime::Handle::try_current().map_err(|_| {
-                CoreError::Unsupported(
-                    "A streaming base file read needs a tokio runtime to block on.".to_string(),
-                )
-            })?;
-            let evolve_to = base_read_schema.clone();
-            let evolved = futures::StreamExt::map(base_stream.into_stream(), move |b| match b {
-                Ok(batch) => {
-                    crate::schema::batch_evolution::project_batch_to_schema(&batch, &evolve_to)
-                }
-                Err(e) => Err(CoreError::from(e)),
-            });
-
-            Ok(Box::new(BlockingBatchReader {
-                schema: base_read_schema,
-                stream: futures::StreamExt::boxed(evolved),
-                handle,
-            }))
+        // The instant range excludes whole base files, and the decision needs
+        // only the file's commit instant, so it is made before opening rather
+        // than by reading every row and dropping them.
+        if !self.base_file_in_range()? {
+            return Ok(BaseSource::empty(base_read_schema));
         }
+
+        // Open the base file as a stream. The whole file never lives in memory;
+        // one row group does. The (CoW-gated) RowFilter is threaded through the
+        // intersection read so row groups can be pruned via column-index stats
+        // (the builder resolves predicate columns by name and returns None when
+        // any referenced column is absent — safe even for evolved/added cols).
+        let base_stream = self
+            .base_file_reader()?
+            .read_stream(
+                &path,
+                base_read_options(row_filter.clone(), use_position)
+                    .with_projection(intersection.fields().iter().map(|f| f.name())),
+            )
+            .await
+            .map_err(|e| {
+                CoreError::ReadFileSliceError(format!(
+                    "Failed to open base file stream '{path}': {e:?}"
+                ))
+            })?;
+
+        let evolve_to = base_read_schema.clone();
+        let evolved = futures::StreamExt::map(base_stream.into_stream(), move |b| match b {
+            Ok(batch) => {
+                crate::schema::batch_evolution::project_batch_to_schema(&batch, &evolve_to)
+            }
+            Err(e) => Err(CoreError::from(e)),
+        });
+
+        Ok(BaseSource {
+            schema: base_read_schema,
+            batches: evolved.boxed(),
+        })
     }
 
-    // NOTE: the FileGroupMergeIterator owns the OutputConverter and applies
-    // it per emitted chunk in its `Iterator::next()`. The reader's
-    // `output_converter` field only lives up to
-    // `open()`, which takes ownership and hands it to the iterator.
+    /// Collapse a base source into a single batch.
+    ///
+    /// [`Self::read`] returns the file group as one `RecordBatch`, and merging
+    /// the base one row group at a time would interleave kept base rows with
+    /// log-side replacements per group instead of emitting all of the former
+    /// then all of the latter. The rows are the same either way and Hudi
+    /// promises no order, but the two are not the same sequence, so the
+    /// single-batch API keeps the shape it has always returned.
+    async fn collapse_base(base: BaseSource) -> Result<BaseSource> {
+        let BaseSource { schema, batches } = base;
+        let collected: Vec<RecordBatch> = batches.try_collect().await?;
+        let batches = match collected.len() {
+            0 => futures::stream::empty().boxed(),
+            1 => {
+                let only = collected.into_iter().next().expect("length checked");
+                futures::stream::once(async move { Ok(only) }).boxed()
+            }
+            _ => {
+                let one = arrow::compute::concat_batches(&schema, &collected).map_err(|e| {
+                    CoreError::ReadFileSliceError(format!(
+                        "Failed to concatenate the base file's row groups: {e}"
+                    ))
+                })?;
+                futures::stream::once(async move { Ok(one) }).boxed()
+            }
+        };
+        Ok(BaseSource { schema, batches })
+    }
 
-    /// Filter a base file's rows by the instant range, at the **file level**.
+    /// Whether this slice's base file is inside the read's instant range.
     ///
     /// A Hudi base file belongs to exactly one commit instant — encoded in its
     /// file name (`<fileId>_<writeToken>_<commit>.<ext>`) and surfaced as
-    /// [`InputSplit::base_file_commit_time`]. So every row in the file shares that
-    /// one instant, and the range test is a single per-file decision: keep the
-    /// whole file or drop it.
+    /// [`InputSplit::base_file_commit_time`]. So every row in the file shares
+    /// that one instant, and the range test is a single per-file decision: keep
+    /// the whole file or drop it.
     ///
     /// This mirrors the Java reader. `HoodieFileGroupReader` only applies
     /// `applyInstantRangeFilter` when `getInstantRange().isPresent()` (empty on a
@@ -994,15 +904,14 @@ impl HoodieFileGroupReader {
     /// (`hoodie.populate.meta.fields=false`) persist a NULL `_hoodie_commit_time`,
     /// so every base row would be masked out and the read would silently return
     /// 0 rows even though the file's own instant is in range.
-    fn apply_instant_range_filter(&self, batches: Vec<RecordBatch>) -> Result<Vec<RecordBatch>> {
-        let instant_range = match &self.reader_context.instant_range {
-            Some(range) => range,
-            None => return Ok(batches),
+    fn base_file_in_range(&self) -> Result<bool> {
+        let Some(instant_range) = &self.reader_context.instant_range else {
+            return Ok(true);
         };
 
         // Skip filtering for metadata table (mirrors Java line 356).
         if crate::util::path::is_metadata_table_path(&self.reader_context.table_path) {
-            return Ok(batches);
+            return Ok(true);
         }
 
         // Production: the FFI sets `base_file_commit_time`. Fall back to parsing it
@@ -1016,20 +925,24 @@ impl HoodieFileGroupReader {
         });
 
         let timezone = self.reader_context.timezone();
-        if Self::base_file_in_instant_range(file_commit_time.as_deref(), instant_range, &timezone)?
-        {
-            Ok(batches)
-        } else {
+        let keep = Self::base_file_in_instant_range(
+            file_commit_time.as_deref(),
+            instant_range,
+            &timezone,
+        )?;
+        if !keep {
             log::debug!(
-                "[HoodieFileGroupReader] applyInstantRangeFilter: base file commit {file_commit_time:?} \
-                 outside instant range — excluding the whole base file"
+                "[HoodieFileGroupReader] base file commit {file_commit_time:?} outside the \
+                 instant range — excluding the whole base file"
             );
-            // Whole base file excluded (inflight / rolled-back commit). The caller
-            // wraps the result Vec in a RecordBatchIterator carrying an explicit
-            // schema, so an empty Vec is a correct 0-row base source.
-            Ok(Vec::new())
         }
+        Ok(keep)
     }
+
+    // NOTE: the FileGroupMergeStream owns the OutputConverter and applies
+    // it per emitted chunk in its `Iterator::next()`. The reader's
+    // `output_converter` field only lives up to
+    // `open()`, which takes ownership and hands it to the iterator.
 
     /// Best-effort parse of a base file's commit instant from its path
     /// (`…/<fileId>_<writeToken>_<commit>.<ext>`). Fallback for when
@@ -1252,38 +1165,6 @@ impl HoodieFileGroupReaderBuilder {
     }
 }
 
-/// Pulls an async base file stream from a synchronous caller, one batch per
-/// `next()`.
-///
-/// The merge loop is synchronous, so a streaming base file has to be turned
-/// back into an iterator somewhere. Doing that means blocking on the stream,
-/// which is only legal off the async worker threads — so this must be driven
-/// from a blocking-pool thread, which is what
-/// [`FileGroupReader::open_blocking_stream`] arranges. Driving it from a worker
-/// would deadlock.
-struct BlockingBatchReader {
-    schema: SchemaRef,
-    stream: futures::stream::BoxStream<'static, Result<RecordBatch>>,
-    handle: tokio::runtime::Handle,
-}
-
-impl Iterator for BlockingBatchReader {
-    type Item = std::result::Result<RecordBatch, arrow_schema::ArrowError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        use futures::StreamExt;
-        self.handle
-            .block_on(self.stream.next())
-            .map(|r| r.map_err(|e| arrow_schema::ArrowError::ExternalError(Box::new(e))))
-    }
-}
-
-impl arrow_array::RecordBatchReader for BlockingBatchReader {
-    fn schema(&self) -> SchemaRef {
-        self.schema.clone()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1388,6 +1269,26 @@ mod tests {
         writer.close().unwrap();
     }
 
+    /// As [`write_parquet_file`], but capping the row-group size so the file has
+    /// several of them. A base file with one row group cannot tell a reader that
+    /// keeps every group from one that keeps the first.
+    fn write_parquet_file_in_row_groups(
+        dir: &std::path::Path,
+        name: &str,
+        batch: &RecordBatch,
+        rows_per_group: usize,
+    ) {
+        use parquet::arrow::ArrowWriter;
+        use parquet::file::properties::WriterProperties;
+        let props = WriterProperties::builder()
+            .set_max_row_group_size(rows_per_group)
+            .build();
+        let file = std::fs::File::create(dir.join(name)).unwrap();
+        let mut writer = ArrowWriter::try_new(file, batch.schema(), Some(props)).unwrap();
+        writer.write(batch).unwrap();
+        writer.close().unwrap();
+    }
+
     /// Build a `HoodieFileGroupReader` rooted at `dir`, with a base file at
     /// `base_name` and `required` set as the `required_schema` driving the read.
     async fn test_file_group_reader_for_base_file(
@@ -1421,19 +1322,17 @@ mod tests {
         )
         .unwrap();
 
-        // Drive make_base_file_source with the exact required schema under test,
+        // Drive base_file_source with the exact required schema under test,
         // bypassing prepare_required_schema's meta/key-field augmentation.
         reader.schema_handler.required_schema = Some(required);
         reader
     }
 
-    /// Drain a base-file source reader into one concatenated `RecordBatch`,
-    /// asserting it reports the requested schema. Shared by the eager + streaming
-    /// schema-evolution tests.
-    fn drain_base_source(source: Box<dyn arrow_array::RecordBatchReader + Send>) -> RecordBatch {
-        use arrow_array::RecordBatchReader as _;
-        let schema = source.schema();
-        let batches: Vec<RecordBatch> = source.map(|r| r.unwrap()).collect();
+    /// Drain a base file source into one concatenated `RecordBatch`, under the
+    /// schema the source reports.
+    async fn drain_base_source(source: BaseSource) -> RecordBatch {
+        let BaseSource { schema, batches } = source;
+        let batches: Vec<RecordBatch> = batches.map(|r| r.unwrap()).collect().await;
         if batches.is_empty() {
             RecordBatch::new_empty(schema)
         } else {
@@ -1446,18 +1345,12 @@ mod tests {
     /// widened, float→double value-exact. Mirrors Java's HoodieParquetFileFormatHelper.
     ///
     /// Runs against BOTH base-file source modes —
-    /// `streaming=false` (eager drain + per-batch evolve) and `streaming=true`
-    /// (lazy `ParquetSyncReader` + `ProjectingBatchReader` per row-group) — to
-    /// prove the streaming path enforces the same schema evolution as the eager
-    /// path. The two outputs must be byte-identical.
-    ///
-    /// This is a plain `#[test]` (NOT `#[tokio::test]`): the streaming source is
-    /// a `ParquetSyncReader` that does `block_on(stream.next())` per row-group,
-    /// which panics if driven from inside an async runtime. Async setup runs on
-    /// the test's own runtime and we then drain from a sync context — mirroring
-    /// the FFI driver's `open()` → sync `get_next` call shape.
+    /// Runs against the base source as the merge sees it and against its
+    /// collapsed single-batch form — the shape `read()` merges — to prove the
+    /// evolution is applied per row group and does not depend on how the base is
+    /// chunked. The two outputs must be byte-identical.
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_make_base_file_source_schema_on_write_evolution() {
+    async fn test_base_file_source_schema_on_write_evolution() {
         use arrow_array::{Float32Array, Int32Array};
         // -- write a parquet base file with OLD schema --
         let tmp = tempfile::tempdir().unwrap();
@@ -1508,35 +1401,27 @@ mod tests {
             assert!(out.column(3).is_null(0), "added column null-filled");
         };
 
-        // Open both base-file sources with async setup; the eager one is
-        // drained here and the streaming one on a blocking-pool thread below.
-        let req = required.clone();
+        // One base source shape now. Compare it against its collapsed form -
+        // the shape `read()` merges - so the row-group path and the
+        // single-batch path are still pinned to each other.
         let dir = tmp.path().to_path_buf();
-        let (eager_src, stream_src) = async {
-            let mut reader =
-                test_file_group_reader_for_base_file(&dir, base_name, req.clone()).await;
-            let eager_src = reader.make_base_file_source(false).await.unwrap();
-            let mut reader2 =
-                test_file_group_reader_for_base_file(&dir, base_name, req.clone()).await;
-            let stream_src = reader2.make_base_file_source(true).await.unwrap();
-            (eager_src, stream_src)
-        }
+        let mut reader =
+            test_file_group_reader_for_base_file(&dir, base_name, required.clone()).await;
+        let streamed = drain_base_source(reader.base_file_source().await.unwrap()).await;
+        assert_evolved(&streamed);
+
+        let mut reader2 =
+            test_file_group_reader_for_base_file(&dir, base_name, required.clone()).await;
+        let collapsed = drain_base_source(
+            HoodieFileGroupReader::collapse_base(reader2.base_file_source().await.unwrap())
+                .await
+                .unwrap(),
+        )
         .await;
-
-        // Eager path (streaming=false): async drain + per-batch evolve.
-        let eager_out = drain_base_source(eager_src);
-        assert_evolved(&eager_out);
-
-        // The streaming source blocks on its base stream, so it has to be
-        // drained off the worker threads — the same contract every real caller
-        // honors via `open_blocking_stream`.
-        let stream_out = tokio::task::spawn_blocking(move || drain_base_source(stream_src))
-            .await
-            .unwrap();
-        assert_evolved(&stream_out);
+        assert_evolved(&collapsed);
         assert_eq!(
-            eager_out, stream_out,
-            "streaming base source must produce byte-identical output to the eager path"
+            streamed, collapsed,
+            "collapsing the base to one batch must not change what it decodes to"
         );
     }
 
@@ -1549,7 +1434,7 @@ mod tests {
     /// on both the eager and streaming sources, which open the parquet file
     /// through different calls and could disagree.
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_make_base_file_source_carries_row_positions_for_position_merge() {
+    async fn test_base_file_source_carries_row_positions_for_position_merge() {
         use arrow_array::{Int32Array, Int64Array};
 
         let tmp = tempfile::tempdir().unwrap();
@@ -1594,7 +1479,7 @@ mod tests {
         };
 
         let mut positional = build(true).await;
-        let eager = drain_base_source(positional.make_base_file_source(false).await.unwrap());
+        let eager = drain_base_source(positional.base_file_source().await.unwrap()).await;
         let positions = eager
             .column_by_name(ROW_INDEX_TEMPORARY_COLUMN_NAME)
             .expect("position merge needs the row-position column on the base source")
@@ -1603,21 +1488,8 @@ mod tests {
             .expect("row positions are Int64");
         assert_eq!(positions.values(), &[0, 1, 2]);
 
-        let mut positional_streaming = build(true).await;
-        let streaming_source = positional_streaming
-            .make_base_file_source(true)
-            .await
-            .unwrap();
-        let streamed = tokio::task::spawn_blocking(move || drain_base_source(streaming_source))
-            .await
-            .unwrap();
-        assert_eq!(
-            streamed, eager,
-            "the streaming base source must carry the same positions as the eager one"
-        );
-
         let mut keyed = build(false).await;
-        let without = drain_base_source(keyed.make_base_file_source(false).await.unwrap());
+        let without = drain_base_source(keyed.base_file_source().await.unwrap()).await;
         assert_eq!(
             without.schema(),
             required,
@@ -1656,8 +1528,8 @@ mod tests {
 
         let mut reader =
             test_file_group_reader_for_base_file(tmp.path(), base_name, required.clone()).await;
-        let source = reader.make_base_file_source(false).await.unwrap();
-        let out = drain_base_source(source);
+        let source = reader.base_file_source().await.unwrap();
+        let out = drain_base_source(source).await;
         assert_eq!(out.schema(), required);
         let id = out.column(1).as_any().downcast_ref::<Int32Array>().unwrap();
         assert!(
@@ -1674,7 +1546,7 @@ mod tests {
     // ════════════════════════════════════════════════════════════════════
     // builder routes `with_row_filter_builder` and
     // `with_mor_pk_safe` onto the shared `reader_context` so both the base
-    // parquet read site (this file's `make_base_file_source`) and the
+    // parquet read site (this file's `base_file_source`) and the
     // parquet log block decoder (`file_group::log_file::content::Decoder`)
     // see the same gating decision.
     //
@@ -1992,14 +1864,71 @@ mod tests {
         );
     }
 
-    /// The streaming path must return exactly what the eager one does. It reads
-    /// the base file a row group at a time instead of whole, which is a memory
-    /// difference, not a data one — so any divergence here is a bug rather than
-    /// a tradeoff.
+    /// Every row group of the base file reaches the output, on both entry
+    /// points.
     ///
-    /// Multi-threaded flavor on purpose: the merge loop blocks on the base
-    /// stream from a blocking-pool thread, which needs worker threads still
-    /// available to drive it.
+    /// `read()` collapses the base to one batch before merging, and a collapse
+    /// that kept only the first row group would return fewer rows and raise
+    /// nothing — the exact shape of silent data loss this path must not have.
+    /// No other test can see it: every base file elsewhere in the suite fits in
+    /// a single row group, so keeping one group and keeping all of them look
+    /// identical. The stream side asserts more than one chunk, which is what
+    /// proves the fixture really has several groups.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_every_base_row_group_reaches_the_output() {
+        let tmp = tempfile::tempdir().unwrap();
+        let schema = Arc::new(arrow_schema::Schema::new(vec![arrow_schema::Field::new(
+            "id",
+            arrow_schema::DataType::Int32,
+            true,
+        )]));
+        let ids: Vec<i32> = (0..40).collect();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(arrow_array::Int32Array::from(ids.clone()))],
+        )
+        .unwrap();
+        let base_name = "many-groups.parquet";
+        write_parquet_file_in_row_groups(tmp.path(), base_name, &batch, 10);
+
+        let read_ids = |b: &RecordBatch| -> Vec<i32> {
+            b.column(0)
+                .as_any()
+                .downcast_ref::<arrow_array::Int32Array>()
+                .unwrap()
+                .values()
+                .to_vec()
+        };
+
+        let mut eager =
+            test_file_group_reader_for_base_file(tmp.path(), base_name, schema.clone()).await;
+        let one = eager.read().await.unwrap();
+        assert_eq!(
+            read_ids(&one),
+            ids,
+            "read() must return every row of every row group"
+        );
+
+        let mut streamed =
+            test_file_group_reader_for_base_file(tmp.path(), base_name, schema.clone()).await;
+        let mut stream = streamed.open_stream().await.unwrap();
+        let mut chunks = 0usize;
+        let mut got: Vec<i32> = Vec::new();
+        while let Some(b) = stream.next().await {
+            chunks += 1;
+            got.extend(read_ids(&b.unwrap()));
+        }
+        assert!(
+            chunks > 1,
+            "the fixture must span several row groups for this test to mean anything, got {chunks}"
+        );
+        assert_eq!(got, ids, "the streamed read must return every row too");
+    }
+
+    /// The streaming path must return exactly what the single-batch one does.
+    /// It merges the base file a row group at a time instead of whole, which is
+    /// a memory and chunking difference, not a data one — so any divergence in
+    /// the rows is a bug rather than a tradeoff.
     #[tokio::test(flavor = "multi_thread")]
     async fn streaming_and_eager_reads_agree() {
         use futures::StreamExt;
@@ -2029,18 +1958,44 @@ mod tests {
 
         let mut stream_reader =
             test_file_group_reader_for_base_file(tmp.path(), base_name, schema.clone()).await;
-        let mut stream = stream_reader.open_blocking_stream().await.unwrap();
-        let mut streamed_rows = 0usize;
-        let mut streamed_batches = 0usize;
+        let mut stream = stream_reader.open_stream().await.unwrap();
+        let mut streamed: Vec<RecordBatch> = Vec::new();
         while let Some(b) = stream.next().await {
-            streamed_rows += b.unwrap().num_rows();
-            streamed_batches += 1;
+            streamed.push(b.unwrap());
         }
-
-        assert_eq!(streamed_rows, eager.num_rows());
         assert!(
-            streamed_batches > 0,
+            !streamed.is_empty(),
             "the stream yielded nothing; it should emit at least one batch"
+        );
+
+        // Row content, not just a count. Counting alone passes for a stream that
+        // returns the right number of wrong rows, which is the failure a merge
+        // rewrite actually produces. Sorted, because the two entry points chunk
+        // the base differently and Hudi promises no row order.
+        let render = |batches: &[RecordBatch]| -> Vec<String> {
+            let mut out: Vec<String> = batches
+                .iter()
+                .flat_map(|b| {
+                    (0..b.num_rows()).map(move |r| {
+                        (0..b.num_columns())
+                            .map(|c| {
+                                format!(
+                                    "{:?}",
+                                    arrow::util::display::array_value_to_string(b.column(c), r)
+                                )
+                            })
+                            .collect::<Vec<_>>()
+                            .join("|")
+                    })
+                })
+                .collect();
+            out.sort();
+            out
+        };
+        assert_eq!(
+            render(&streamed),
+            render(std::slice::from_ref(&eager)),
+            "the streamed read must return the same rows as the single-batch read"
         );
     }
 }

--- a/crates/core/src/file_group/reader_v2/engine.rs
+++ b/crates/core/src/file_group/reader_v2/engine.rs
@@ -137,6 +137,22 @@ pub struct HoodieFileGroupReader {
     // `base_file_source` below.
 }
 
+/// Rows per base batch handed to the merge, and therefore per merged chunk.
+///
+/// Load-bearing rather than cosmetic: merging a chunk is synchronous work on the
+/// task that polls the stream, and its cost is linear in the chunk's rows. On
+/// this machine, one merge of a 1024-row chunk against a 50k-key log map takes
+/// 0.4-1.1 ms, and 5.7-6.1 ms once the merge map has spilled to disk; at 8192
+/// rows those become 2.8 ms and ~40 ms. So the chunk size is what bounds how long
+/// a single poll occupies its executor, and it is set here rather than inherited.
+///
+/// 1024 is what `parquet` already defaults to, so this pins today's behaviour
+/// instead of changing it. Pinned because the bound is silent if it moves: a
+/// larger default upstream would multiply the blocking above with nothing
+/// failing. Measured by `spilled_merge_blocking_duration` (ignored; run with
+/// `--release --ignored --nocapture`).
+const MERGE_CHUNK_ROWS: usize = 1024;
+
 /// Base-file read options carrying an optional pushdown predicate, and the
 /// row-position column when the merge is by position.
 ///
@@ -150,6 +166,7 @@ fn base_read_options(
     use_record_position: bool,
 ) -> BaseFileReadOptions {
     let mut options = BaseFileReadOptions::new();
+    options = options.with_batch_size(MERGE_CHUNK_ROWS);
     if let Some(row_filter) = row_filter {
         options = options.with_row_filter(row_filter);
     }
@@ -1832,6 +1849,68 @@ mod tests {
         assert!(
             reader.reader_context.can_push_row_filter(),
             "CoW path always pushes regardless of mor_pk_safe"
+        );
+    }
+
+    /// A merged chunk is bounded, and the bound is the reader's, not the base
+    /// file's layout.
+    ///
+    /// Merging a chunk is synchronous work on the task that polls the stream and
+    /// its cost is linear in the chunk's rows, so an unbounded chunk is an
+    /// unbounded poll. The fixture puts 5000 rows in a single row group: if the
+    /// chunk followed the file's layout, one chunk would carry all 5000 and one
+    /// poll would do five times the work `MERGE_CHUNK_ROWS` allows for.
+    ///
+    /// The direct assertion on the option is deliberate. The bound currently
+    /// agrees with what `parquet` defaults to, so no output-level test can tell
+    /// the pin from the default — but a caller that passed a larger batch size
+    /// through here (making `hoodie.read.stream.batch_size` effective on the
+    /// merge path, say) would multiply every poll's cost, and this is what says
+    /// so out loud.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_a_merged_chunk_is_bounded_by_the_readers_own_batch_size() {
+        assert_eq!(
+            base_read_options(None, false).batch_size,
+            Some(MERGE_CHUNK_ROWS),
+            "the base read must ask for the merge's chunk bound rather than inherit one"
+        );
+
+        let tmp = tempfile::tempdir().unwrap();
+        let schema = Arc::new(arrow_schema::Schema::new(vec![arrow_schema::Field::new(
+            "id",
+            arrow_schema::DataType::Int32,
+            true,
+        )]));
+        let rows = 5_000;
+        let ids: Vec<i32> = (0..rows).collect();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(arrow_array::Int32Array::from(ids.clone()))],
+        )
+        .unwrap();
+        let base_name = "one-big-group.parquet";
+        // One row group holding every row, so the file's layout cannot be what
+        // bounds the chunk.
+        write_parquet_file_in_row_groups(tmp.path(), base_name, &batch, rows as usize);
+
+        let mut reader =
+            test_file_group_reader_for_base_file(tmp.path(), base_name, schema.clone()).await;
+        let mut stream = reader.open_stream().await.unwrap();
+        let mut sizes: Vec<usize> = Vec::new();
+        let mut total = 0usize;
+        while let Some(b) = stream.next().await {
+            let b = b.unwrap();
+            sizes.push(b.num_rows());
+            total += b.num_rows();
+        }
+        assert_eq!(total, rows as usize, "every row must still come back");
+        assert!(
+            sizes.iter().all(|n| *n <= MERGE_CHUNK_ROWS),
+            "every chunk must respect the bound, got {sizes:?}"
+        );
+        assert!(
+            sizes.len() > 1,
+            "5000 rows cannot arrive in one chunk under a {MERGE_CHUNK_ROWS}-row bound"
         );
     }
 

--- a/crates/core/src/file_group/reader_v2/engine.rs
+++ b/crates/core/src/file_group/reader_v2/engine.rs
@@ -48,7 +48,7 @@ use crate::file_group::reader_v2::schema_handler::FileGroupReaderSchemaHandler;
 use crate::storage::{RowFilterBuilder, Storage};
 use arrow_array::RecordBatch;
 use arrow_schema::SchemaRef;
-use futures::{StreamExt, TryStreamExt};
+use futures::StreamExt;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -418,17 +418,13 @@ impl HoodieFileGroupReader {
     /// Read the file group and return the merged output as a single
     /// `RecordBatch`.
     ///
-    /// Same merge as [`Self::open_stream`], but the base file is collapsed to
-    /// one batch first, so the merge emits a single chunk and the rows come back
-    /// in the order this entry point has always returned them. See
-    /// [`Self::collapse_base`].
+    /// Same merge as [`Self::open_stream`], collected into one batch. Both
+    /// entry points merge the base a row group at a time and therefore return
+    /// the same row sequence; this one just concatenates the chunks.
     pub async fn read(&mut self) -> Result<RecordBatch> {
         // Stage timing (perf harness): the base file open plus, here, its whole
         // decode — `collapse_base` drives the stream to completion.
-        let base = profile_once!(
-            self.read_stats.base_read_ms,
-            Self::collapse_base(self.base_file_source().await?).await
-        )?;
+        let base = profile_once!(self.read_stats.base_read_ms, self.base_file_source().await)?;
         let batch = self
             .init_record_iterators(base)
             .await?
@@ -851,35 +847,6 @@ impl HoodieFileGroupReader {
             schema: base_read_schema,
             batches: evolved.boxed(),
         })
-    }
-
-    /// Collapse a base source into a single batch.
-    ///
-    /// [`Self::read`] returns the file group as one `RecordBatch`, and merging
-    /// the base one row group at a time would interleave kept base rows with
-    /// log-side replacements per group instead of emitting all of the former
-    /// then all of the latter. The rows are the same either way and Hudi
-    /// promises no order, but the two are not the same sequence, so the
-    /// single-batch API keeps the shape it has always returned.
-    async fn collapse_base(base: BaseSource) -> Result<BaseSource> {
-        let BaseSource { schema, batches } = base;
-        let collected: Vec<RecordBatch> = batches.try_collect().await?;
-        let batches = match collected.len() {
-            0 => futures::stream::empty().boxed(),
-            1 => {
-                let only = collected.into_iter().next().expect("length checked");
-                futures::stream::once(async move { Ok(only) }).boxed()
-            }
-            _ => {
-                let one = arrow::compute::concat_batches(&schema, &collected).map_err(|e| {
-                    CoreError::ReadFileSliceError(format!(
-                        "Failed to concatenate the base file's row groups: {e}"
-                    ))
-                })?;
-                futures::stream::once(async move { Ok(one) }).boxed()
-            }
-        };
-        Ok(BaseSource { schema, batches })
     }
 
     /// Whether this slice's base file is inside the read's instant range.
@@ -1401,28 +1368,15 @@ mod tests {
             assert!(out.column(3).is_null(0), "added column null-filled");
         };
 
-        // One base source shape now. Compare it against its collapsed form -
-        // the shape `read()` merges - so the row-group path and the
-        // single-batch path are still pinned to each other.
+        // The evolution is applied per row group, so draining the source and
+        // concatenating must give the same rows as reading it whole would - the
+        // property `read()` relies on now that it collects the merged chunks
+        // rather than collapsing the base first.
         let dir = tmp.path().to_path_buf();
         let mut reader =
             test_file_group_reader_for_base_file(&dir, base_name, required.clone()).await;
         let streamed = drain_base_source(reader.base_file_source().await.unwrap()).await;
         assert_evolved(&streamed);
-
-        let mut reader2 =
-            test_file_group_reader_for_base_file(&dir, base_name, required.clone()).await;
-        let collapsed = drain_base_source(
-            HoodieFileGroupReader::collapse_base(reader2.base_file_source().await.unwrap())
-                .await
-                .unwrap(),
-        )
-        .await;
-        assert_evolved(&collapsed);
-        assert_eq!(
-            streamed, collapsed,
-            "collapsing the base to one batch must not change what it decodes to"
-        );
     }
 
     /// A base source feeding a position-based merge carries the row-position

--- a/crates/core/src/file_group/reader_v2/engine.rs
+++ b/crates/core/src/file_group/reader_v2/engine.rs
@@ -374,11 +374,10 @@ impl HoodieFileGroupReader {
     /// hands the buffer to the iterator. Re-opening requires constructing a
     /// new `HoodieFileGroupReader`.
     pub async fn open(&mut self) -> Result<FileGroupMergeIterator> {
-        // streaming mode — the base file is held as a lazy
-        // `ParquetSyncReader` that does per-batch `block_on` against
-        // OBJECT_STORE_RUNTIME. The caller MUST consume the returned
-        // iterator from a synchronous context (e.g. the FFI driver),
-        // never from inside another tokio runtime.
+        // streaming mode — the base file is held as a lazy reader that does a
+        // per-batch `block_on` against the runtime handle it was built with. The
+        // caller MUST consume the returned iterator from a synchronous context
+        // (e.g. the FFI driver), never from inside another tokio runtime.
         self.init_record_iterators(/* streaming */ true).await
     }
 
@@ -706,8 +705,8 @@ impl HoodieFileGroupReader {
     ///
     /// - `streaming=true`: returns a lazy [`ParquetSyncReader`] over the
     ///   parquet file. One row group per `RecordBatchReader::next` call.
-    ///   Sync iteration uses `block_on(stream.next())` against
-    ///   `OBJECT_STORE_RUNTIME` — caller MUST be in sync context.
+    ///   Sync iteration uses `block_on(stream.next())` against the runtime
+    ///   handle it was built with — caller MUST be in sync context.
     /// - `streaming=false` (or instant range present — see note): drains
     ///   the parquet stream into a `Vec<RecordBatch>` async, optionally
     ///   applies the instant range filter, and wraps the Vec in a
@@ -1477,7 +1476,7 @@ mod tests {
     /// This is a plain `#[test]` (NOT `#[tokio::test]`): the streaming source is
     /// a `ParquetSyncReader` that does `block_on(stream.next())` per row-group,
     /// which panics if driven from inside an async runtime. Async setup runs on
-    /// `OBJECT_STORE_RUNTIME` then we drain from this sync context — mirroring
+    /// the test's own runtime and we then drain from a sync context — mirroring
     /// the FFI driver's `open()` → sync `get_next` call shape.
     #[tokio::test(flavor = "multi_thread")]
     async fn test_make_base_file_source_schema_on_write_evolution() {

--- a/crates/core/src/file_group/reader_v2/engine.rs
+++ b/crates/core/src/file_group/reader_v2/engine.rs
@@ -37,7 +37,7 @@ use crate::file_group::reader_v2::buffered_record_converter::BufferedRecordConve
 use crate::file_group::reader_v2::input_split::InputSplit;
 use crate::file_group::reader_v2::iterator_mode::IteratorMode;
 use crate::file_group::reader_v2::merge_iterator::{
-    DEFAULT_BATCH_SIZE, FileGroupMergeIterator, StreamStatsHandle, new_stream_stats_handle,
+    FileGroupMergeIterator, StreamStatsHandle, new_stream_stats_handle,
 };
 use crate::file_group::reader_v2::output_converter::OutputConverter;
 use crate::file_group::reader_v2::profiling::profile_once;
@@ -590,7 +590,7 @@ impl HoodieFileGroupReader {
             )
             .await?;
 
-        let mut record_buffer = load_result.record_buffer;
+        let record_buffer = load_result.record_buffer;
         self.valid_block_instants = load_result.valid_block_instants;
 
         // Anything this read expects that is quietly not done, said once, before
@@ -648,14 +648,12 @@ impl HoodieFileGroupReader {
 
         let output_schema = post_projection_schema.unwrap_or_else(|| merge_schema.clone());
 
-        // Step 5: Hand the base source to the buffer + return the streaming
-        // iterator. The iterator owns the buffer from here on; the reader's
-        // role ends.
-        record_buffer.set_base_file_source(base_source);
-        log::debug!(
-            "[HoodieFileGroupReader] set base file source on buffer, \
-             returning Buffered iterator (batch_size={DEFAULT_BATCH_SIZE})"
-        );
+        // Step 5: return the streaming iterator, which owns both the buffer and
+        // the base source from here on; the reader's role ends. The source is
+        // the iterator's rather than the buffer's because only its holder can
+        // say when the base is exhausted, and because the base file is the one
+        // part of the merge that has to be read rather than computed.
+        log::debug!("[HoodieFileGroupReader] returning Buffered iterator");
 
         // Step 6: Hand the buffer to a Buffered streaming iterator. The
         // iterator owns the buffer and drives `has_next/next` per chunk; it
@@ -671,34 +669,14 @@ impl HoodieFileGroupReader {
             .expect("stream_stats mutex poisoned")
             .merge_map_peak_entries = record_buffer.merge_map_peak_entries();
 
-        // Chunk size: honor `hoodie.read.stream.batch_size` from the reader
-        // config, falling back to DEFAULT_BATCH_SIZE when unset/unparseable.
-        let batch_size = self.stream_batch_size();
-
         Ok(FileGroupMergeIterator::new_buffered(
             record_buffer,
+            base_source,
             merge_schema,
             output_schema,
             output_converter,
-            batch_size,
             self.stream_stats.clone(),
         ))
-    }
-
-    /// Resolve the streaming chunk size from `hoodie.read.stream.batch_size`
-    /// on the reader config, defaulting to [`DEFAULT_BATCH_SIZE`] when the key
-    /// is absent or unparseable.
-    ///
-    /// The key lives on `reader_context.hoodie_reader_config` (the same map the
-    /// buffer loader reads `hoodie.datasource.merge.type` from). Mirrors Java's
-    /// chunked `getClosableIterator` batch sizing.
-    fn stream_batch_size(&self) -> usize {
-        self.reader_context
-            .hoodie_reader_config
-            .get(crate::config::read::HudiReadConfig::StreamBatchSize.as_ref())
-            .and_then(|v| v.parse::<usize>().ok())
-            .filter(|&n| n > 0)
-            .unwrap_or(DEFAULT_BATCH_SIZE)
     }
 
     /// Open the base file as a `RecordBatchReader` source.

--- a/crates/core/src/file_group/reader_v2/engine.rs
+++ b/crates/core/src/file_group/reader_v2/engine.rs
@@ -986,6 +986,23 @@ impl HoodieFileGroupReader {
     /// Java-parity accessors; the adapter reads the stats it needs off the returned
     /// value.
     #[allow(dead_code)]
+    /// The stats this read accumulated.
+    ///
+    /// Complete after [`Self::read`], which folds the merge-phase counters back
+    /// in once the merge is exhausted. **After [`Self::open_stream`] the
+    /// merge-phase counters read zero** - `final_merge_ms`, `output_build_ms`,
+    /// `merge_map_peak_entries` and the insert/update/delete counts accumulate
+    /// into the shared `stream_stats` handle as the stream is consumed, and
+    /// nothing folds them back, because the caller owns the stream and the
+    /// reader cannot know when it ended. The scan-phase counters (log blocks,
+    /// log records, corrupt blocks, rollbacks, base read) are populated on both
+    /// paths.
+    ///
+    /// Worth stating because the gap is silent and reads as data: a streaming
+    /// read of a fixture with five deletes reports `num_deletes: 0` while
+    /// returning exactly the same rows as the eager read that reports five. No
+    /// production caller reads these - only the test harness and the benchmark
+    /// do - but that is precisely where a zero would be believed.
     pub fn read_stats(&self) -> &HoodieReadStats {
         &self.read_stats
     }

--- a/crates/core/src/file_group/reader_v2/engine.rs
+++ b/crates/core/src/file_group/reader_v2/engine.rs
@@ -1875,11 +1875,20 @@ mod tests {
     /// so out loud.
     #[tokio::test(flavor = "multi_thread")]
     async fn test_a_merged_chunk_is_bounded_by_the_readers_own_batch_size() {
-        assert_eq!(
-            base_read_options(None, false).batch_size,
-            Some(MERGE_CHUNK_ROWS),
-            "the base read must ask for the merge's chunk bound rather than inherit one"
-        );
+        // Every argument combination must carry the pin: the position-merge
+        // read (row-index column attached) and the filtered read bound their
+        // polls by the same argument as the plain one, so a refactor that
+        // branched the builder per arm must not lose it on any branch.
+        for use_position in [false, true] {
+            for filter in [None, Some(make_row_filter_builder())] {
+                assert_eq!(
+                    base_read_options(filter, use_position).batch_size,
+                    Some(MERGE_CHUNK_ROWS),
+                    "the base read must ask for the merge's chunk bound rather than \
+                     inherit one (use_position={use_position})"
+                );
+            }
+        }
 
         let tmp = tempfile::tempdir().unwrap();
         let schema = Arc::new(arrow_schema::Schema::new(vec![arrow_schema::Field::new(
@@ -1917,6 +1926,160 @@ mod tests {
         assert!(
             sizes.len() > 1,
             "5000 rows cannot arrive in one chunk under a {MERGE_CHUNK_ROWS}-row bound"
+        );
+    }
+
+    /// Build a reader over a base file plus one real log file, so the read
+    /// takes the Buffered (merge) path rather than the Eager one. The reader
+    /// schema is the single `_hoodie_record_key` column, which is enough to
+    /// decode the shipped log fixtures and extract keys on both sides.
+    async fn test_file_group_reader_for_merged_slice(
+        dir: &std::path::Path,
+        base_name: &str,
+        log_name: &str,
+        required: SchemaRef,
+    ) -> HoodieFileGroupReader {
+        let base_path = dir.to_str().unwrap().to_string();
+        let hudi_configs = Arc::new(HudiConfigs::new([(
+            HudiTableConfig::BasePath.as_ref(),
+            base_path,
+        )]));
+        let storage = Storage::new(Arc::new(HashMap::new()), hudi_configs).unwrap();
+
+        let input_split = InputSplit::new(
+            Some(base_name.to_string()),
+            None,
+            vec![log_name.to_string()],
+            String::new(),
+        );
+
+        let mut reader_context = ReaderContext::empty();
+        reader_context.latest_commit_time =
+            crate::file_group::reader_v2::MAX_INSTANT_TIME.to_string();
+        reader_context.merge_mode = "COMMIT_TIME_ORDERING".to_string();
+        // Set on purpose: the knob is documented to size base-file-only slices
+        // and to have NO effect on a merged slice. The chunk assertions in the
+        // test below are what hold that, rather than a one-off measurement.
+        reader_context.hoodie_reader_config.insert(
+            crate::config::read::HudiReadConfig::StreamBatchSize
+                .as_ref()
+                .to_string(),
+            "8192".to_string(),
+        );
+        reader_context.rebuild_record_context(String::new());
+        // The log scan decodes blocks and builds the delete context through the
+        // context's own schema handler, so it needs the prepared one.
+        let mut handler =
+            crate::file_group::reader_v2::schema_handler::FileGroupReaderSchemaHandler::new()
+                .with_table_schema(required.clone())
+                .with_data_schema(required.clone());
+        handler
+            .prepare_required_schema(
+                true,
+                &["_hoodie_record_key".to_string()],
+                &[],
+                &reader_context.table_config,
+                false,
+                "COMMIT_TIME_ORDERING",
+            )
+            .unwrap();
+        reader_context.schema_handler = handler;
+
+        let mut reader = HoodieFileGroupReader::new(
+            Arc::new(reader_context),
+            storage,
+            input_split,
+            ReaderParameters::default(),
+            None,
+            None,
+        )
+        .unwrap();
+        reader.schema_handler.required_schema = Some(required);
+        reader
+    }
+
+    /// The chunk bound on the path it exists for: a slice WITH log files.
+    ///
+    /// `test_a_merged_chunk_is_bounded_by_the_readers_own_batch_size` above
+    /// drives the Eager (base-only) arm, so it pins the option and the base
+    /// read but never the Buffered state machine. This one merges a 5000-row
+    /// single-row-group base against a real delete-block log file, so every
+    /// chunk it observes came out of `merge_base_batch`: a state machine that
+    /// coalesced source batches, or a base read that lost the bound only on
+    /// the merge route, fails here and nowhere else.
+    ///
+    /// The fixture's delete keys are trips UUIDs and the base keys are
+    /// synthetic, so nothing matches: every base row survives, the drain has
+    /// nothing to emit, and the chunk cadence is exactly what the machine
+    /// produced. `hoodie.read.stream.batch_size=8192` is set in the reader
+    /// config on purpose — the knob must have no effect on a merged slice.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_the_chunk_bound_holds_on_a_slice_with_log_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let log_name = ".6d3d1d6e-2298-4080-a0c1-494877d6f40a-0_20250618054711154.log.1_0-26-85";
+        let fixture = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/data/log_files/valid_log_delete")
+            .join(log_name);
+        std::fs::copy(&fixture, tmp.path().join(log_name)).unwrap();
+
+        let schema = Arc::new(arrow_schema::Schema::new(vec![arrow_schema::Field::new(
+            "_hoodie_record_key",
+            arrow_schema::DataType::Utf8,
+            false,
+        )]));
+        let base_rows: usize = 5_000;
+        let keys: Vec<String> = (0..base_rows).map(|i| format!("base-{i:05}")).collect();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(arrow_array::StringArray::from(
+                keys.iter().map(String::as_str).collect::<Vec<_>>(),
+            ))],
+        )
+        .unwrap();
+        let base_name = "one-big-group.parquet";
+        // One row group holding every row, so the file's layout cannot be what
+        // bounds the chunk.
+        write_parquet_file_in_row_groups(tmp.path(), base_name, &batch, base_rows);
+
+        let mut eager = test_file_group_reader_for_merged_slice(
+            tmp.path(),
+            base_name,
+            log_name,
+            schema.clone(),
+        )
+        .await;
+        let expected_total = eager.read().await.unwrap().num_rows();
+        assert_eq!(
+            expected_total, base_rows,
+            "no fixture delete key may collide with a synthetic base key"
+        );
+
+        let mut reader = test_file_group_reader_for_merged_slice(
+            tmp.path(),
+            base_name,
+            log_name,
+            schema.clone(),
+        )
+        .await;
+        let mut stream = reader.open_stream().await.unwrap();
+        let mut sizes: Vec<usize> = Vec::new();
+        while let Some(b) = stream.next().await {
+            sizes.push(b.unwrap().num_rows());
+        }
+        assert_eq!(
+            sizes.iter().sum::<usize>(),
+            expected_total,
+            "the streamed merge must return the same rows as the eager read"
+        );
+        assert!(
+            sizes.iter().all(|n| *n <= MERGE_CHUNK_ROWS),
+            "every merged chunk must respect the bound, got {sizes:?}"
+        );
+        assert!(
+            sizes.len() >= base_rows / MERGE_CHUNK_ROWS,
+            "{base_rows} base rows cannot arrive in {} chunk(s) under a \
+             {MERGE_CHUNK_ROWS}-row bound: {sizes:?}",
+            sizes.len()
         );
     }
 

--- a/crates/core/src/file_group/reader_v2/log_record_reader.rs
+++ b/crates/core/src/file_group/reader_v2/log_record_reader.rs
@@ -652,13 +652,32 @@ impl BaseHoodieLogRecordReader {
         hudi_configs: &crate::config::HudiConfigs,
         blocks: &[LogBlock],
     ) -> Result<HashMap<usize, bytes::Bytes>> {
-        use crate::file_group::log_file::log_block::DeferredContent;
-
         let budget = crate::storage::reader::stream_window_size(hudi_configs)
             .map_err(crate::error::CoreError::ReadLogFileError)?;
 
         // Group by file, preserving first-seen order so the requests go out in
         // the order the blocks will be consumed.
+        let mut fetched: HashMap<usize, bytes::Bytes> = HashMap::new();
+        for batch in Self::plan_content_batches(blocks, budget) {
+            Self::fetch_batch(blocks, &batch, &mut fetched).await?;
+        }
+        Ok(fetched)
+    }
+
+    /// Group the admitted blocks' content reads into batches, in issue order.
+    ///
+    /// Separated from the fetching so the two rules that matter can be tested
+    /// without any I/O: batches never span files, because a `LogBlockFetcher`
+    /// reads one file, and a batch stops before it would exceed `budget`, which
+    /// is what keeps peak memory near the one-block-at-a-time property the
+    /// header walk buys. A block bigger than the budget still goes out alone
+    /// rather than being split, since its content has to be whole to decode.
+    ///
+    /// Blocks that carry no content, or nothing deferred, are left out: they
+    /// have nothing to fetch.
+    fn plan_content_batches(blocks: &[LogBlock], budget: u64) -> Vec<Vec<usize>> {
+        use crate::file_group::log_file::log_block::DeferredContent;
+
         let mut by_file: Vec<(object_store::path::Path, Vec<usize>)> = Vec::new();
         for (idx, block) in blocks.iter().enumerate() {
             if !matches!(
@@ -677,32 +696,29 @@ impl BaseHoodieLogRecordReader {
             }
         }
 
-        let mut fetched: HashMap<usize, bytes::Bytes> = HashMap::new();
+        let mut batches: Vec<Vec<usize>> = Vec::new();
         for (_, idxs) in by_file {
             let mut batch: Vec<usize> = Vec::new();
             let mut batch_bytes: u64 = 0;
             for idx in idxs {
-                let location = blocks[idx]
+                let len = blocks[idx]
                     .deferred_content
                     .as_ref()
                     .expect("filtered above to blocks with deferred content")
                     .location
-                    .clone();
-                // A single block larger than the budget still goes out alone
-                // rather than being split: its content has to be whole to decode.
-                if !batch.is_empty() && batch_bytes + location.content_length > budget {
-                    Self::fetch_batch(blocks, &batch, &mut fetched).await?;
-                    batch.clear();
+                    .content_length;
+                if !batch.is_empty() && batch_bytes + len > budget {
+                    batches.push(std::mem::take(&mut batch));
                     batch_bytes = 0;
                 }
-                batch_bytes += location.content_length;
+                batch_bytes += len;
                 batch.push(idx);
             }
             if !batch.is_empty() {
-                Self::fetch_batch(blocks, &batch, &mut fetched).await?;
+                batches.push(batch);
             }
         }
-        Ok(fetched)
+        batches
     }
 
     /// Issue one batched read for `batch` and record the bytes against each index.
@@ -822,6 +838,98 @@ mod tests {
     use crate::file_group::reader_v2::MAX_INSTANT_TIME;
 
     // ── Helpers ──────────────────────────────────────────────────────────
+
+    /// A block with deferred content of `len` bytes in `file`, for planning tests.
+    fn block_with_content(file: &str, position: u64, len: u64) -> LogBlock {
+        use crate::file_group::log_file::log_block::{DeferredContent, LogBlockContentLocation};
+        use crate::storage::reader::LogBlockFetcher;
+
+        let mut block = make_data_block("20250101000000000");
+        block.deferred_content = Some(DeferredContent {
+            location: LogBlockContentLocation {
+                content_position: position,
+                content_length: len,
+            },
+            fetcher: LogBlockFetcher::new(
+                std::sync::Arc::new(object_store::memory::InMemory::new()),
+                object_store::path::Path::from(file),
+            ),
+        });
+        block
+    }
+
+    /// A batch stops before it would exceed the budget. Without this the prefetch
+    /// reads a whole slice's admitted content at once, which hands back the peak
+    /// memory the header walk was added to bound.
+    #[test]
+    fn test_plan_content_batches_stops_at_the_byte_budget() {
+        let blocks = vec![
+            block_with_content("a.log", 0, 40),
+            block_with_content("a.log", 40, 40),
+            block_with_content("a.log", 80, 40),
+        ];
+        assert_eq!(
+            BaseHoodieLogRecordReader::plan_content_batches(&blocks, 100),
+            vec![vec![0, 1], vec![2]],
+            "two blocks fit in 100 bytes, the third starts a new batch"
+        );
+        assert_eq!(
+            BaseHoodieLogRecordReader::plan_content_batches(&blocks, 1_000),
+            vec![vec![0, 1, 2]],
+            "a budget above the total is one batch"
+        );
+    }
+
+    /// A block bigger than the whole budget still goes out, alone. Content has to
+    /// be whole to decode, so splitting it is not an option and skipping it would
+    /// lose data.
+    #[test]
+    fn test_plan_content_batches_sends_an_oversized_block_alone() {
+        let blocks = vec![
+            block_with_content("a.log", 0, 10),
+            block_with_content("a.log", 10, 5_000),
+            block_with_content("a.log", 5_010, 10),
+        ];
+        assert_eq!(
+            BaseHoodieLogRecordReader::plan_content_batches(&blocks, 100),
+            vec![vec![0], vec![1], vec![2]],
+            "the oversized block neither merges with its neighbours nor disappears"
+        );
+    }
+
+    /// Batches never span files: a fetcher reads one file, so mixing them would
+    /// read the wrong bytes for every range after the first.
+    #[test]
+    fn test_plan_content_batches_never_span_files() {
+        let blocks = vec![
+            block_with_content("a.log", 0, 10),
+            block_with_content("b.log", 0, 10),
+            block_with_content("a.log", 10, 10),
+        ];
+        let batches = BaseHoodieLogRecordReader::plan_content_batches(&blocks, 1_000);
+        assert_eq!(
+            batches,
+            vec![vec![0, 2], vec![1]],
+            "a.log's two blocks batch together, b.log's stays separate"
+        );
+    }
+
+    /// Command and corrupt blocks have no content to fetch, and a block whose
+    /// content is already present has nothing deferred.
+    #[test]
+    fn test_plan_content_batches_skips_blocks_with_nothing_to_fetch() {
+        let blocks = vec![
+            make_rollback_block("20250101000000000", "20241231000000000"),
+            make_corrupt_block(),
+            make_data_block("20250101000000000"),
+            block_with_content("a.log", 0, 10),
+        ];
+        assert_eq!(
+            BaseHoodieLogRecordReader::plan_content_batches(&blocks, 1_000),
+            vec![vec![3]],
+            "only the block with deferred content is planned"
+        );
+    }
 
     /// The prefetch must actually return bytes for the admitted blocks. Output is
     /// identical whether or not it does, because Pass 3 falls back to fetching

--- a/crates/core/src/file_group/reader_v2/log_record_reader.rs
+++ b/crates/core/src/file_group/reader_v2/log_record_reader.rs
@@ -546,19 +546,19 @@ impl BaseHoodieLogRecordReader {
         if !pass2.current_instant_log_blocks.is_empty() && !skip_processing_blocks {
             log::debug!("Merging the final data blocks");
             // Oldest first, matching the pop_back the deque was built for. Taking
-            // the order up front is what lets the content be fetched in batches:
-            // the I/O happens here, in async code, and Pass 3 below then does no
-            // I/O at all. Keeping the two apart also keeps the scan future `Send`,
-            // which it would not be if the record buffer were held across an await.
+            // the order up front is what lets the content be fetched a window at a
+            // time: the fetch happens in async code and the merge under it is
+            // synchronous, because the record buffer's `process_data_block` is a
+            // sync trait method and cannot await.
             let mut ordered: Vec<LogBlock> =
                 Vec::with_capacity(pass2.current_instant_log_blocks.len());
             while let Some(block) = pass2.current_instant_log_blocks.pop_back() {
                 ordered.push(block);
             }
-            let fetched = Self::prefetch_admitted_content(&hudi_configs, &ordered).await?;
             profile_once!(
                 self.merge_insert_ms,
-                self.process_queued_blocks_for_instant(ordered, fetched)
+                self.fetch_and_merge_windows(&hudi_configs, &mut ordered)
+                    .await
             )?;
         }
 
@@ -625,60 +625,89 @@ impl BaseHoodieLogRecordReader {
         &self.valid_block_instants
     }
 
-    /// Mirrors Java's `processQueuedBlocksForInstant(Deque<HoodieLogBlock>, ...)`.
+    /// Fetch and merge the admitted blocks, one window at a time.
     ///
-    /// Drains the deque from the back (oldest→newest via `pop_back`/`pollLast`).
-    /// Dispatches each block to the record buffer — the buffer is responsible for
-    /// inflating, extracting records, and deflating (matching Java's design where
-    /// `processQueuedBlocksForInstant` does NOT call `inflate()`).
-    /// Fetch the content of every admitted block, batched per file.
+    /// Peak content residency is one window rather than the slice's whole
+    /// admitted content: a window's bytes are dropped before the next window is
+    /// fetched. Fetching everything up front would hand back the bound the
+    /// header walk was added to buy — on a slice with a gigabyte of admitted log
+    /// content, every byte of it would be resident before the first record was
+    /// merged. The budget is `hoodie.memory.dfs.buffer.max.size`, the same knob
+    /// that bounds how much of a log file the header walk holds.
     ///
-    /// The gates have already chosen the set, so every range is known before any
-    /// byte is read. `get_ranges` coalesces ranges that sit close together, so a
-    /// run of adjacent blocks costs one round trip instead of one each; reading
-    /// them one at a time is the same bytes and many more round trips, which is
-    /// what dominates on object storage.
-    ///
-    /// Batches are bounded by a byte budget rather than issued all at once. The
-    /// header walk exists so a discarded block costs nothing and a kept one costs
-    /// only its own content; fetching every block up front would hand that back
-    /// and make peak memory the size of the slice's admitted log content. The
-    /// budget is `hoodie.memory.dfs.buffer.max.size`, already the knob for how
-    /// much of a log file may be resident at once.
-    ///
-    /// Returns the bytes keyed by position in `blocks`. A block absent from the
-    /// map has nothing deferred and decodes on its own.
-    async fn prefetch_admitted_content(
+    /// The fetch is the only await here, and the record buffer is borrowed only
+    /// inside the synchronous merge below it, so nothing is held across it.
+    async fn fetch_and_merge_windows(
+        &mut self,
         hudi_configs: &crate::config::HudiConfigs,
-        blocks: &[LogBlock],
-    ) -> Result<HashMap<usize, bytes::Bytes>> {
+        ordered: &mut [LogBlock],
+    ) -> Result<()> {
         let budget = crate::storage::reader::stream_window_size(hudi_configs)
             .map_err(crate::error::CoreError::ReadLogFileError)?;
+        let decoder = self.block_decoder();
+        let windows = Self::plan_content_windows(ordered, budget);
+        log::debug!(
+            "[Pass3] {} block(s) to merge in {} window(s), budget {budget} bytes",
+            ordered.len(),
+            windows.len(),
+        );
 
-        // Group by file, preserving first-seen order so the requests go out in
-        // the order the blocks will be consumed.
-        let mut fetched: HashMap<usize, bytes::Bytes> = HashMap::new();
-        for batch in Self::plan_content_batches(blocks, budget) {
-            Self::fetch_batch(blocks, &batch, &mut fetched).await?;
+        let mut block_num = 0u64;
+        let mut cursor = 0usize;
+        for window in windows {
+            let mut fetched: HashMap<usize, bytes::Bytes> = HashMap::new();
+            Self::fetch_window(ordered, &window, &mut fetched).await?;
+            // Merge everything up to and including this window's last block, so
+            // blocks with nothing to fetch (command, corrupt, already-decoded)
+            // keep their place in the oldest-first order.
+            let through = *window
+                .last()
+                .expect("plan_content_windows never emits an empty window");
+            self.merge_blocks(
+                ordered,
+                cursor..=through,
+                &mut fetched,
+                &decoder,
+                &mut block_num,
+            )?;
+            cursor = through + 1;
+            // `fetched` drops here: the next window is fetched against a fresh budget.
         }
-        Ok(fetched)
+        if cursor < ordered.len() {
+            let mut none = HashMap::new();
+            let last = ordered.len() - 1;
+            self.merge_blocks(ordered, cursor..=last, &mut none, &decoder, &mut block_num)?;
+        }
+        Ok(())
     }
 
-    /// Group the admitted blocks' content reads into batches, in issue order.
+    /// Group the admitted blocks' content reads into windows, in consumption order.
     ///
-    /// Separated from the fetching so the two rules that matter can be tested
-    /// without any I/O: batches never span files, because a `LogBlockFetcher`
-    /// reads one file, and a batch stops before it would exceed `budget`, which
-    /// is what keeps peak memory near the one-block-at-a-time property the
-    /// header walk buys. A block bigger than the budget still goes out alone
-    /// rather than being split, since its content has to be whole to decode.
+    /// A window is a run of *consecutive* blocks that share a file and whose
+    /// content fits the budget. Consecutiveness is what makes a window safe to
+    /// fetch and merge before the next one is fetched: Pass 3 merges oldest-first
+    /// and a later block overwrites an earlier one for the same key, so a plan
+    /// that reordered blocks would change the merged result. Grouping by file
+    /// first is enough for a bulk prefetch, whose result is keyed by index and
+    /// consumed in the caller's order, but it cannot be interleaved with merging
+    /// for exactly that reason.
+    ///
+    /// Windows never span files, because a `LogBlockFetcher` reads one file. A
+    /// window stops before it would exceed `budget`; a block bigger than the
+    /// budget still goes out alone rather than being split, since its content
+    /// has to be whole to decode.
     ///
     /// Blocks that carry no content, or nothing deferred, are left out: they
-    /// have nothing to fetch.
-    fn plan_content_batches(blocks: &[LogBlock], budget: u64) -> Vec<Vec<usize>> {
+    /// have nothing to fetch. They are still merged in order — see
+    /// [`Self::fetch_and_merge_windows`], which walks the gaps between windows.
+    fn plan_content_windows(blocks: &[LogBlock], budget: u64) -> Vec<Vec<usize>> {
         use crate::file_group::log_file::log_block::DeferredContent;
 
-        let mut by_file: Vec<(object_store::path::Path, Vec<usize>)> = Vec::new();
+        let mut windows: Vec<Vec<usize>> = Vec::new();
+        let mut current: Vec<usize> = Vec::new();
+        let mut current_file: Option<&object_store::path::Path> = None;
+        let mut current_bytes: u64 = 0;
+
         for (idx, block) in blocks.iter().enumerate() {
             if !matches!(
                 block.block_type,
@@ -686,43 +715,39 @@ impl BaseHoodieLogRecordReader {
             ) {
                 continue;
             }
-            let Some(DeferredContent { fetcher, .. }) = block.deferred_content.as_ref() else {
+            let Some(DeferredContent { fetcher, location }) = block.deferred_content.as_ref()
+            else {
                 continue;
             };
-            let location = fetcher.location().clone();
-            match by_file.iter_mut().find(|(path, _)| *path == location) {
-                Some((_, idxs)) => idxs.push(idx),
-                None => by_file.push((location, vec![idx])),
-            }
-        }
+            let len = location.content_length;
+            let file = fetcher.location();
 
-        let mut batches: Vec<Vec<usize>> = Vec::new();
-        for (_, idxs) in by_file {
-            let mut batch: Vec<usize> = Vec::new();
-            let mut batch_bytes: u64 = 0;
-            for idx in idxs {
-                let len = blocks[idx]
-                    .deferred_content
-                    .as_ref()
-                    .expect("filtered above to blocks with deferred content")
-                    .location
-                    .content_length;
-                if !batch.is_empty() && batch_bytes + len > budget {
-                    batches.push(std::mem::take(&mut batch));
-                    batch_bytes = 0;
-                }
-                batch_bytes += len;
-                batch.push(idx);
+            let spans_files = current_file.is_some_and(|f| f != file);
+            let over_budget = !current.is_empty() && current_bytes.saturating_add(len) > budget;
+            if spans_files || over_budget {
+                windows.push(std::mem::take(&mut current));
+                current_bytes = 0;
+                current_file = None;
             }
-            if !batch.is_empty() {
-                batches.push(batch);
+            if current.is_empty() {
+                current_file = Some(file);
             }
+            current_bytes = current_bytes.saturating_add(len);
+            current.push(idx);
         }
-        batches
+        if !current.is_empty() {
+            windows.push(current);
+        }
+        windows
     }
 
-    /// Issue one batched read for `batch` and record the bytes against each index.
-    async fn fetch_batch(
+    /// Issue one batched read for `window` and record the bytes against each index.
+    ///
+    /// `get_ranges` coalesces ranges that sit close together, so a run of
+    /// adjacent blocks costs one round trip instead of one each; reading them one
+    /// at a time is the same bytes and many more round trips, which is what
+    /// dominates on object storage.
+    async fn fetch_window(
         blocks: &[LogBlock],
         batch: &[usize],
         out: &mut HashMap<usize, bytes::Bytes>,
@@ -778,21 +803,14 @@ impl BaseHoodieLogRecordReader {
         }
     }
 
-    fn process_queued_blocks_for_instant(
-        &mut self,
-        ordered: Vec<LogBlock>,
-        mut fetched: HashMap<usize, bytes::Bytes>,
-    ) -> Result<()> {
-        log::debug!(
-            "[Pass3] processQueuedBlocksForInstant: {} blocks to process (oldest first), {} \
-             prefetched",
-            ordered.len(),
-            fetched.len(),
-        );
-        let mut block_num = 0u64;
-        // The same settings the sweep would have decoded with, so an inflated
-        // block is identical to one that was read eagerly.
-        let block_decoder = crate::file_group::log_file::content::Decoder::new(Arc::new(
+    /// The decoder Pass 3 inflates a window's blocks with.
+    ///
+    /// The same settings the sweep would have decoded with, so an inflated block
+    /// is identical to one that was read eagerly. Built once per scan rather than
+    /// per window: it carries the row filter and reader schema, neither of which
+    /// varies by block.
+    fn block_decoder(&self) -> crate::file_group::log_file::content::Decoder {
+        crate::file_group::log_file::content::Decoder::new(Arc::new(
             crate::config::HudiConfigs::new(self.reader_context.table_config.clone()),
         ))
         .with_row_filter(if self.reader_context.can_push_row_filter() {
@@ -805,22 +823,42 @@ impl BaseHoodieLogRecordReader {
                 .schema_handler
                 .reader_schema_json
                 .clone(),
-        );
+        )
+    }
 
-        for (idx, mut block) in ordered.into_iter().enumerate() {
-            block_num += 1;
+    /// Merge `range` of the queued blocks, oldest first.
+    ///
+    /// Mirrors Java's `processQueuedBlocksForInstant` over one window's worth of
+    /// the deque. `fetched` holds the bytes for the blocks in this window only,
+    /// keyed by their position in `ordered`; each is removed as it is decoded so
+    /// the window's memory is released across the merge rather than at the end.
+    ///
+    /// Synchronous, and must stay so: the record buffer's `process_data_block` is
+    /// a sync trait method, which is why the fetch happens in
+    /// [`Self::fetch_and_merge_windows`] above rather than here.
+    fn merge_blocks(
+        &mut self,
+        ordered: &mut [LogBlock],
+        range: std::ops::RangeInclusive<usize>,
+        fetched: &mut HashMap<usize, bytes::Bytes>,
+        block_decoder: &crate::file_group::log_file::content::Decoder,
+        block_num: &mut u64,
+    ) -> Result<()> {
+        for idx in range {
+            let block = &mut ordered[idx];
+            *block_num += 1;
             let instant_time = block.instant_time().unwrap_or("unknown").to_string();
             log::debug!(
                 "[Pass3] block #{block_num}: type={:?} instant={instant_time}",
                 block.block_type,
             );
 
-            // Read this block's content now that it is known to be admitted. A
+            // Decode this block's content now that it is known to be admitted. A
             // block that already has content passes straight through.
             match block.block_type {
                 BlockType::AvroData | BlockType::ParquetData | BlockType::Delete => {
-                    if let Some(bytes) = Self::queued_block_content(&block, fetched.remove(&idx))? {
-                        block.decode_fetched(&block_decoder, bytes)?;
+                    if let Some(bytes) = Self::queued_block_content(block, fetched.remove(&idx))? {
+                        block.decode_fetched(block_decoder, bytes)?;
                     }
                 }
                 _ => {}
@@ -828,14 +866,14 @@ impl BaseHoodieLogRecordReader {
 
             match block.block_type {
                 BlockType::AvroData | BlockType::ParquetData => {
-                    self.record_buffer.process_data_block(&mut block)?;
+                    self.record_buffer.process_data_block(block)?;
                     log::debug!(
                         "[Pass3] after processing data block #{block_num}: buffer size={}",
                         self.record_buffer.size(),
                     );
                 }
                 BlockType::Delete => {
-                    self.record_buffer.process_delete_block(&mut block)?;
+                    self.record_buffer.process_delete_block(block)?;
                 }
                 BlockType::Corrupted => {
                     log::warn!("Found corrupt block not rolled back");
@@ -883,19 +921,19 @@ mod tests {
     /// reads a whole slice's admitted content at once, which hands back the peak
     /// memory the header walk was added to bound.
     #[test]
-    fn test_plan_content_batches_stops_at_the_byte_budget() {
+    fn test_plan_content_windows_stops_at_the_byte_budget() {
         let blocks = vec![
             block_with_content("a.log", 0, 40),
             block_with_content("a.log", 40, 40),
             block_with_content("a.log", 80, 40),
         ];
         assert_eq!(
-            BaseHoodieLogRecordReader::plan_content_batches(&blocks, 100),
+            BaseHoodieLogRecordReader::plan_content_windows(&blocks, 100),
             vec![vec![0, 1], vec![2]],
             "two blocks fit in 100 bytes, the third starts a new batch"
         );
         assert_eq!(
-            BaseHoodieLogRecordReader::plan_content_batches(&blocks, 1_000),
+            BaseHoodieLogRecordReader::plan_content_windows(&blocks, 1_000),
             vec![vec![0, 1, 2]],
             "a budget above the total is one batch"
         );
@@ -905,40 +943,74 @@ mod tests {
     /// be whole to decode, so splitting it is not an option and skipping it would
     /// lose data.
     #[test]
-    fn test_plan_content_batches_sends_an_oversized_block_alone() {
+    fn test_plan_content_windows_sends_an_oversized_block_alone() {
         let blocks = vec![
             block_with_content("a.log", 0, 10),
             block_with_content("a.log", 10, 5_000),
             block_with_content("a.log", 5_010, 10),
         ];
         assert_eq!(
-            BaseHoodieLogRecordReader::plan_content_batches(&blocks, 100),
+            BaseHoodieLogRecordReader::plan_content_windows(&blocks, 100),
             vec![vec![0], vec![1], vec![2]],
             "the oversized block neither merges with its neighbours nor disappears"
         );
     }
 
-    /// Batches never span files: a fetcher reads one file, so mixing them would
+    /// Windows never span files: a fetcher reads one file, so mixing them would
     /// read the wrong bytes for every range after the first.
+    ///
+    /// A file change therefore closes the window even when the budget is nowhere
+    /// near spent, and the two `a.log` blocks do **not** regroup across the
+    /// `b.log` block between them. Regrouping them would be free bytes-wise and
+    /// wrong: the window is merged before the next one is fetched, so a plan that
+    /// pulled block 2 forward would merge it before block 1 and let an older
+    /// write win. See `test_plan_content_windows_follow_consumption_order`.
     #[test]
-    fn test_plan_content_batches_never_span_files() {
+    fn test_plan_content_windows_never_span_files() {
         let blocks = vec![
             block_with_content("a.log", 0, 10),
             block_with_content("b.log", 0, 10),
             block_with_content("a.log", 10, 10),
         ];
-        let batches = BaseHoodieLogRecordReader::plan_content_batches(&blocks, 1_000);
+        let windows = BaseHoodieLogRecordReader::plan_content_windows(&blocks, 1_000);
         assert_eq!(
-            batches,
-            vec![vec![0, 2], vec![1]],
-            "a.log's two blocks batch together, b.log's stays separate"
+            windows,
+            vec![vec![0], vec![1], vec![2]],
+            "each file change closes the window; order is never traded for batching"
+        );
+    }
+
+    /// Windows must be emitted in the order Pass 3 merges them.
+    ///
+    /// Pass 3 merges oldest-first, and with COMMIT_TIME_ORDERING a later block
+    /// overwrites an earlier one for the same key. Because each window is fetched
+    /// and merged before the next is fetched, a planner that grouped by file
+    /// first — correct for a bulk prefetch, whose result is keyed by index —
+    /// would merge a slice's interleaved log files out of order and let the wrong
+    /// record win.
+    #[test]
+    fn test_plan_content_windows_follow_consumption_order() {
+        // Instant-major order across two log files: A, B, A, B.
+        let blocks = vec![
+            block_with_content("a.log", 0, 10),
+            block_with_content("b.log", 0, 10),
+            block_with_content("a.log", 10, 10),
+            block_with_content("b.log", 10, 10),
+        ];
+        // A budget far above the total, so any difference is grouping, not budget.
+        let windows = BaseHoodieLogRecordReader::plan_content_windows(&blocks, u64::MAX);
+        let flat: Vec<usize> = windows.into_iter().flatten().collect();
+        assert_eq!(
+            flat,
+            vec![0, 1, 2, 3],
+            "windows must visit blocks in consumption order; got {flat:?}"
         );
     }
 
     /// Command and corrupt blocks have no content to fetch, and a block whose
     /// content is already present has nothing deferred.
     #[test]
-    fn test_plan_content_batches_skips_blocks_with_nothing_to_fetch() {
+    fn test_plan_content_windows_skips_blocks_with_nothing_to_fetch() {
         let blocks = vec![
             make_rollback_block("20250101000000000", "20241231000000000"),
             make_corrupt_block(),
@@ -946,7 +1018,7 @@ mod tests {
             block_with_content("a.log", 0, 10),
         ];
         assert_eq!(
-            BaseHoodieLogRecordReader::plan_content_batches(&blocks, 1_000),
+            BaseHoodieLogRecordReader::plan_content_windows(&blocks, 1_000),
             vec![vec![3]],
             "only the block with deferred content is planned"
         );
@@ -1032,9 +1104,13 @@ mod tests {
             .count();
         assert_eq!(admitted, 2, "the doubled fixture must offer two blocks");
 
-        let fetched = BaseHoodieLogRecordReader::prefetch_admitted_content(&configs, &blocks)
-            .await
-            .unwrap();
+        let budget = crate::storage::reader::stream_window_size(&configs).unwrap();
+        let mut fetched: HashMap<usize, bytes::Bytes> = HashMap::new();
+        for window in BaseHoodieLogRecordReader::plan_content_windows(&blocks, budget) {
+            BaseHoodieLogRecordReader::fetch_window(&blocks, &window, &mut fetched)
+                .await
+                .unwrap();
+        }
         assert_eq!(
             fetched.len(),
             admitted,

--- a/crates/core/src/file_group/reader_v2/log_record_reader.rs
+++ b/crates/core/src/file_group/reader_v2/log_record_reader.rs
@@ -505,7 +505,7 @@ impl BaseHoodieLogRecordReader {
                 let mut reader =
                     LogFileReader::new_streaming(hudi_configs.clone(), self.storage.clone(), path)
                         .await?;
-                let blocks = reader.read_all_blocks_metadata_only()?;
+                let blocks = reader.read_all_blocks_metadata_only().await?;
                 self.total_log_files += 1;
                 all_blocks.extend(blocks);
             }
@@ -754,6 +754,30 @@ impl BaseHoodieLogRecordReader {
         Ok(())
     }
 
+    /// Which bytes a queued block decodes from, given what the prefetch
+    /// returned for it. `None` means it needs none: it already holds content.
+    ///
+    /// The prefetch admits exactly the block types Pass 3 decodes, so a block
+    /// holding neither fetched bytes nor content of its own never recorded where
+    /// to read it from. That is refused rather than passed on as a silently
+    /// empty block. Answering it here, instead of having the block fetch its own
+    /// bytes, is what keeps Pass 3 free of I/O and therefore synchronous.
+    fn queued_block_content(
+        block: &LogBlock,
+        fetched: Option<bytes::Bytes>,
+    ) -> Result<Option<bytes::Bytes>> {
+        match fetched {
+            Some(bytes) => Ok(Some(bytes)),
+            None if !block.content.is_empty() => Ok(None),
+            None => Err(crate::error::CoreError::LogBlockError(format!(
+                "no content was fetched for the {:?} block at instant {}, and it carries none: \
+                 nothing recorded where to read it from",
+                block.block_type,
+                block.instant_time().unwrap_or("unknown"),
+            ))),
+        }
+    }
+
     fn process_queued_blocks_for_instant(
         &mut self,
         ordered: Vec<LogBlock>,
@@ -795,11 +819,8 @@ impl BaseHoodieLogRecordReader {
             // block that already has content passes straight through.
             match block.block_type {
                 BlockType::AvroData | BlockType::ParquetData | BlockType::Delete => {
-                    match fetched.remove(&idx) {
-                        Some(bytes) => block.decode_fetched(&block_decoder, bytes)?,
-                        // No prefetch for this block: it was already decoded, or
-                        // the eager reader produced it and nothing was deferred.
-                        None => block.load_content(&block_decoder)?,
+                    if let Some(bytes) = Self::queued_block_content(&block, fetched.remove(&idx))? {
+                        block.decode_fetched(&block_decoder, bytes)?;
                     }
                 }
                 _ => {}
@@ -931,10 +952,44 @@ mod tests {
         );
     }
 
-    /// The prefetch must actually return bytes for the admitted blocks. Output is
-    /// identical whether or not it does, because Pass 3 falls back to fetching
-    /// per block, so nothing else in the suite can tell the difference: without
-    /// this the whole batching path could be dead and every test would pass.
+    /// A queued block with nothing prefetched and no content of its own is
+    /// refused. Pass 3 does no I/O, so a block that recorded nowhere to read
+    /// from cannot be recovered there — passing it on would drop its records
+    /// silently, which is exactly what a reader must never do.
+    #[test]
+    fn test_a_queued_block_with_neither_bytes_nor_content_is_refused() {
+        use crate::file_group::record_batches::RecordBatches;
+
+        let block = make_data_block("20250101000000000");
+        let prefetched = bytes::Bytes::from_static(b"content");
+        assert_eq!(
+            BaseHoodieLogRecordReader::queued_block_content(&block, Some(prefetched.clone()))
+                .unwrap(),
+            Some(prefetched),
+            "prefetched bytes are what the block decodes from"
+        );
+
+        let mut decoded = make_data_block("20250101000000000");
+        decoded.content = LogBlockContent::Records(RecordBatches::new());
+        assert_eq!(
+            BaseHoodieLogRecordReader::queued_block_content(&decoded, None).unwrap(),
+            None,
+            "a block that already holds content needs no bytes"
+        );
+
+        let err = BaseHoodieLogRecordReader::queued_block_content(&block, None)
+            .expect_err("a block with neither bytes nor content must be refused");
+        assert!(
+            err.to_string()
+                .contains("nothing recorded where to read it from"),
+            "the error must say why it cannot decode, got: {err}"
+        );
+    }
+
+    /// The prefetch must return bytes for every admitted block, keyed by that
+    /// block's own position. Pass 3 no longer fetches anything for itself, so a
+    /// block the prefetch misses is refused rather than read some other way —
+    /// this is what pins the keying that refusal rests on.
     #[tokio::test]
     async fn test_prefetch_returns_content_for_every_admitted_block() {
         use crate::config::HudiConfigs;
@@ -965,7 +1020,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let blocks = reader.read_all_blocks_metadata_only().unwrap();
+        let blocks = reader.read_all_blocks_metadata_only().await.unwrap();
         let admitted = blocks
             .iter()
             .filter(|b| {

--- a/crates/core/src/file_group/reader_v2/log_record_reader.rs
+++ b/crates/core/src/file_group/reader_v2/log_record_reader.rs
@@ -545,9 +545,20 @@ impl BaseHoodieLogRecordReader {
         // Mirrors Java: if (!currentInstantLogBlocks.isEmpty() && !skipProcessingBlocks) { ... }
         if !pass2.current_instant_log_blocks.is_empty() && !skip_processing_blocks {
             log::debug!("Merging the final data blocks");
+            // Oldest first, matching the pop_back the deque was built for. Taking
+            // the order up front is what lets the content be fetched in batches:
+            // the I/O happens here, in async code, and Pass 3 below then does no
+            // I/O at all. Keeping the two apart also keeps the scan future `Send`,
+            // which it would not be if the record buffer were held across an await.
+            let mut ordered: Vec<LogBlock> =
+                Vec::with_capacity(pass2.current_instant_log_blocks.len());
+            while let Some(block) = pass2.current_instant_log_blocks.pop_back() {
+                ordered.push(block);
+            }
+            let fetched = Self::prefetch_admitted_content(&hudi_configs, &ordered).await?;
             profile_once!(
                 self.merge_insert_ms,
-                self.process_queued_blocks_for_instant(&mut pass2.current_instant_log_blocks)
+                self.process_queued_blocks_for_instant(ordered, fetched)
             )?;
         }
 
@@ -620,13 +631,123 @@ impl BaseHoodieLogRecordReader {
     /// Dispatches each block to the record buffer — the buffer is responsible for
     /// inflating, extracting records, and deflating (matching Java's design where
     /// `processQueuedBlocksForInstant` does NOT call `inflate()`).
+    /// Fetch the content of every admitted block, batched per file.
+    ///
+    /// The gates have already chosen the set, so every range is known before any
+    /// byte is read. `get_ranges` coalesces ranges that sit close together, so a
+    /// run of adjacent blocks costs one round trip instead of one each; reading
+    /// them one at a time is the same bytes and many more round trips, which is
+    /// what dominates on object storage.
+    ///
+    /// Batches are bounded by a byte budget rather than issued all at once. The
+    /// header walk exists so a discarded block costs nothing and a kept one costs
+    /// only its own content; fetching every block up front would hand that back
+    /// and make peak memory the size of the slice's admitted log content. The
+    /// budget is `hoodie.memory.dfs.buffer.max.size`, already the knob for how
+    /// much of a log file may be resident at once.
+    ///
+    /// Returns the bytes keyed by position in `blocks`. A block absent from the
+    /// map has nothing deferred and decodes on its own.
+    async fn prefetch_admitted_content(
+        hudi_configs: &crate::config::HudiConfigs,
+        blocks: &[LogBlock],
+    ) -> Result<HashMap<usize, bytes::Bytes>> {
+        use crate::file_group::log_file::log_block::DeferredContent;
+
+        let budget = crate::storage::reader::stream_window_size(hudi_configs)
+            .map_err(crate::error::CoreError::ReadLogFileError)?;
+
+        // Group by file, preserving first-seen order so the requests go out in
+        // the order the blocks will be consumed.
+        let mut by_file: Vec<(object_store::path::Path, Vec<usize>)> = Vec::new();
+        for (idx, block) in blocks.iter().enumerate() {
+            if !matches!(
+                block.block_type,
+                BlockType::AvroData | BlockType::ParquetData | BlockType::Delete
+            ) {
+                continue;
+            }
+            let Some(DeferredContent { fetcher, .. }) = block.deferred_content.as_ref() else {
+                continue;
+            };
+            let location = fetcher.location().clone();
+            match by_file.iter_mut().find(|(path, _)| *path == location) {
+                Some((_, idxs)) => idxs.push(idx),
+                None => by_file.push((location, vec![idx])),
+            }
+        }
+
+        let mut fetched: HashMap<usize, bytes::Bytes> = HashMap::new();
+        for (_, idxs) in by_file {
+            let mut batch: Vec<usize> = Vec::new();
+            let mut batch_bytes: u64 = 0;
+            for idx in idxs {
+                let location = blocks[idx]
+                    .deferred_content
+                    .as_ref()
+                    .expect("filtered above to blocks with deferred content")
+                    .location
+                    .clone();
+                // A single block larger than the budget still goes out alone
+                // rather than being split: its content has to be whole to decode.
+                if !batch.is_empty() && batch_bytes + location.content_length > budget {
+                    Self::fetch_batch(blocks, &batch, &mut fetched).await?;
+                    batch.clear();
+                    batch_bytes = 0;
+                }
+                batch_bytes += location.content_length;
+                batch.push(idx);
+            }
+            if !batch.is_empty() {
+                Self::fetch_batch(blocks, &batch, &mut fetched).await?;
+            }
+        }
+        Ok(fetched)
+    }
+
+    /// Issue one batched read for `batch` and record the bytes against each index.
+    async fn fetch_batch(
+        blocks: &[LogBlock],
+        batch: &[usize],
+        out: &mut HashMap<usize, bytes::Bytes>,
+    ) -> Result<()> {
+        use crate::file_group::log_file::log_block::DeferredContent;
+
+        let Some(DeferredContent { fetcher, .. }) = blocks[batch[0]].deferred_content.as_ref()
+        else {
+            return Ok(());
+        };
+        let ranges: Vec<std::ops::Range<u64>> = batch
+            .iter()
+            .map(|idx| {
+                let loc = &blocks[*idx]
+                    .deferred_content
+                    .as_ref()
+                    .expect("filtered above to blocks with deferred content")
+                    .location;
+                loc.content_position..loc.content_position + loc.content_length
+            })
+            .collect();
+        let bytes = fetcher
+            .read_contents(&ranges)
+            .await
+            .map_err(crate::error::CoreError::ReadLogFileError)?;
+        for (idx, b) in batch.iter().zip(bytes) {
+            out.insert(*idx, b);
+        }
+        Ok(())
+    }
+
     fn process_queued_blocks_for_instant(
         &mut self,
-        log_blocks: &mut VecDeque<LogBlock>,
+        ordered: Vec<LogBlock>,
+        mut fetched: HashMap<usize, bytes::Bytes>,
     ) -> Result<()> {
         log::debug!(
-            "[Pass3] processQueuedBlocksForInstant: {} blocks to process (pop_back = oldest first)",
-            log_blocks.len(),
+            "[Pass3] processQueuedBlocksForInstant: {} blocks to process (oldest first), {} \
+             prefetched",
+            ordered.len(),
+            fetched.len(),
         );
         let mut block_num = 0u64;
         // The same settings the sweep would have decoded with, so an inflated
@@ -646,7 +767,7 @@ impl BaseHoodieLogRecordReader {
                 .clone(),
         );
 
-        while let Some(mut block) = log_blocks.pop_back() {
+        for (idx, mut block) in ordered.into_iter().enumerate() {
             block_num += 1;
             let instant_time = block.instant_time().unwrap_or("unknown").to_string();
             log::debug!(
@@ -658,7 +779,12 @@ impl BaseHoodieLogRecordReader {
             // block that already has content passes straight through.
             match block.block_type {
                 BlockType::AvroData | BlockType::ParquetData | BlockType::Delete => {
-                    block.load_content(&block_decoder)?;
+                    match fetched.remove(&idx) {
+                        Some(bytes) => block.decode_fetched(&block_decoder, bytes)?,
+                        // No prefetch for this block: it was already decoded, or
+                        // the eager reader produced it and nothing was deferred.
+                        None => block.load_content(&block_decoder)?,
+                    }
                 }
                 _ => {}
             }
@@ -696,6 +822,75 @@ mod tests {
     use crate::file_group::reader_v2::MAX_INSTANT_TIME;
 
     // ── Helpers ──────────────────────────────────────────────────────────
+
+    /// The prefetch must actually return bytes for the admitted blocks. Output is
+    /// identical whether or not it does, because Pass 3 falls back to fetching
+    /// per block, so nothing else in the suite can tell the difference: without
+    /// this the whole batching path could be dead and every test would pass.
+    #[tokio::test]
+    async fn test_prefetch_returns_content_for_every_admitted_block() {
+        use crate::config::HudiConfigs;
+        use crate::storage::Storage;
+        use crate::storage::util::parse_uri;
+        use std::path::PathBuf;
+
+        // Two concatenated copies of a one-block fixture: a valid two-block file,
+        // and the smallest input for which a batch is a batch.
+        let dir = PathBuf::from("tests/data/log_files/valid_log_avro_data");
+        let file_name =
+            ".ff32ab89-5ad0-4968-83b4-89a34c95d32f-0_20250316025816068.log.1_0-54-122".to_string();
+        let one = std::fs::read(std::fs::canonicalize(&dir).unwrap().join(&file_name)).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let mut doubled = one.clone();
+        doubled.extend_from_slice(&one);
+        std::fs::write(tmp.path().join(&file_name), &doubled).unwrap();
+
+        let configs = HudiConfigs::new(std::collections::HashMap::<String, String>::new());
+        let storage =
+            Storage::new_with_base_url(parse_uri(tmp.path().to_str().unwrap()).unwrap()).unwrap();
+        let mut reader = crate::file_group::log_file::reader::LogFileReader::new_streaming(
+            std::sync::Arc::new(HudiConfigs::new(
+                std::collections::HashMap::<String, String>::new(),
+            )),
+            storage,
+            &file_name,
+        )
+        .await
+        .unwrap();
+        let blocks = reader.read_all_blocks_metadata_only().unwrap();
+        let admitted = blocks
+            .iter()
+            .filter(|b| {
+                matches!(
+                    b.block_type,
+                    BlockType::AvroData | BlockType::ParquetData | BlockType::Delete
+                ) && b.deferred_content.is_some()
+            })
+            .count();
+        assert_eq!(admitted, 2, "the doubled fixture must offer two blocks");
+
+        let fetched = BaseHoodieLogRecordReader::prefetch_admitted_content(&configs, &blocks)
+            .await
+            .unwrap();
+        assert_eq!(
+            fetched.len(),
+            admitted,
+            "every admitted block must come back with its content prefetched"
+        );
+        for (idx, bytes) in &fetched {
+            let expected = blocks[*idx]
+                .deferred_content
+                .as_ref()
+                .unwrap()
+                .location
+                .content_length;
+            assert_eq!(
+                bytes.len() as u64,
+                expected,
+                "block {idx} must get exactly its own range"
+            );
+        }
+    }
 
     /// Create a data block with given instant time and a tag for identification.
     fn make_data_block(instant_time: &str) -> LogBlock {

--- a/crates/core/src/file_group/reader_v2/log_record_reader.rs
+++ b/crates/core/src/file_group/reader_v2/log_record_reader.rs
@@ -493,42 +493,19 @@ impl BaseHoodieLogRecordReader {
         let hudi_configs = Arc::new(crate::config::HudiConfigs::new(
             self.reader_context.table_config.clone(),
         ));
-        let unbounded_range =
-            InstantRange::new(self.reader_context.timezone(), None, None, false, true);
         profile_once!(self.log_block_read_ms, {
             for path in &self.log_file_paths.clone() {
-                // The sweep reads each log file whole, so blocks arrive with
-                // their content already read — same block set as a bounded
-                // sweep, more memory, but no more than the existing read path
-                // already uses. The bounded-window streaming tier
-                // (`LogFileReader::new_streaming` +
-                // `read_all_blocks_metadata_only`) walks headers only and lets
-                // each admitted block fetch its content in Pass 3; it is not
-                // wired here yet. The range is left unbounded so
-                // the gates below decide what is admitted, rather than filtering
-                // twice with different rules.
-                // A log record can update a row, so a predicate may only be
-                // evaluated before the merge when the merge cannot change its
-                // answer. Log blocks exist only on merge-on-read, so the gate
-                // reduces to a predicate over primary keys, which are immutable
-                // across upserts. Anything else is left for the post-merge
-                // filter.
-                let row_filter = if self.reader_context.can_push_row_filter() {
-                    self.reader_context.row_filter_builder.clone()
-                } else {
-                    None
-                };
+                // Walk headers only, out of a bounded fetch window. Passes 1 and 2
+                // read nothing but a block's header, so the gates below decide what
+                // is admitted before any content is fetched or decoded, and Pass 3
+                // reads each admitted block's own content. A block the gates discard
+                // therefore costs no bytes and cannot fail the read by being
+                // undecodable. No instant range is applied here: the gates decide,
+                // rather than filtering twice with different rules.
                 let mut reader =
-                    LogFileReader::new(hudi_configs.clone(), self.storage.clone(), path)
-                        .await?
-                        .with_row_filter(row_filter)
-                        .with_reader_schema(
-                            self.reader_context
-                                .schema_handler
-                                .reader_schema_json
-                                .clone(),
-                        );
-                let blocks = reader.read_all_blocks(&unbounded_range)?;
+                    LogFileReader::new_streaming(hudi_configs.clone(), self.storage.clone(), path)
+                        .await?;
+                let blocks = reader.read_all_blocks_metadata_only()?;
                 self.total_log_files += 1;
                 all_blocks.extend(blocks);
             }

--- a/crates/core/src/file_group/reader_v2/merge_iterator.rs
+++ b/crates/core/src/file_group/reader_v2/merge_iterator.rs
@@ -1113,6 +1113,81 @@ mod tests {
         assert_eq!(chunks.len(), 2, "the merge stops after the error");
     }
 
+    /// The two properties that make this a stream rather than a differently-
+    /// shaped batch read, neither of which any output-level assertion can see.
+    ///
+    /// **Lazy.** Asking for one chunk must pull one base batch, not the whole
+    /// base file. A merge that collected the base up front would return exactly
+    /// the same rows in exactly the same order, so row and order assertions
+    /// cannot distinguish it - only counting the pulls can.
+    ///
+    /// **No thread hand-off.** The merge must run on the task that polls it. The
+    /// shape this replaced moved the whole merge loop onto a blocking-pool
+    /// thread and fed batches back through a channel, which also produced the
+    /// right rows; the observable difference is which thread the base pull
+    /// happens on. Asserted on a `current_thread` runtime, where the polling
+    /// task and the test share one thread, so a hand-off shows up as a different
+    /// thread id.
+    #[tokio::test]
+    async fn merge_stream_is_lazy_and_polls_on_the_callers_thread() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let schema = small_schema();
+        let pulls = Arc::new(AtomicUsize::new(0));
+        let pull_threads = Arc::new(std::sync::Mutex::new(Vec::<std::thread::ThreadId>::new()));
+
+        let (p, t) = (pulls.clone(), pull_threads.clone());
+        let base = futures::stream::iter(vec![
+            Ok(batch(schema.clone(), &["a"], &[1])),
+            Ok(batch(schema.clone(), &["b"], &[2])),
+            Ok(batch(schema.clone(), &["c"], &[3])),
+        ])
+        .inspect(move |_| {
+            p.fetch_add(1, Ordering::SeqCst);
+            t.lock().unwrap().push(std::thread::current().id());
+        })
+        .boxed();
+
+        let mut merge = FileGroupMergeStream::new_buffered(
+            MockBuffer::boxed(vec![], UpdateStats::default()),
+            base,
+            schema.clone(),
+            schema,
+            None,
+            new_stream_stats_handle(),
+        );
+
+        // One chunk asked for, one base batch read.
+        let first = merge.next_chunk().await.expect("a first chunk").unwrap();
+        assert_eq!(rows(&first), vec![("a".to_string(), 1)]);
+        assert_eq!(
+            pulls.load(Ordering::SeqCst),
+            1,
+            "one chunk must cost one base batch; a merge that pre-collected the \
+             base would read all three and still return this same chunk"
+        );
+
+        // ...and the rest only when asked for.
+        let second = merge.next_chunk().await.expect("a second chunk").unwrap();
+        assert_eq!(rows(&second), vec![("b".to_string(), 2)]);
+        assert_eq!(pulls.load(Ordering::SeqCst), 2, "still one pull per chunk");
+
+        while merge.next_chunk().await.is_some() {}
+        assert_eq!(
+            pulls.load(Ordering::SeqCst),
+            3,
+            "the whole base is read once"
+        );
+
+        let here = std::thread::current().id();
+        let threads = pull_threads.lock().unwrap();
+        assert!(
+            threads.iter().all(|t| *t == here),
+            "the base pull must happen on the polling task's own thread; saw {threads:?} \
+             from {here:?}, which means the merge was handed to another thread"
+        );
+    }
+
     // ---- Error/termination spine ----
 
     /// A buffer whose `has_next` always errors — pins the iterator's

--- a/crates/core/src/file_group/reader_v2/merge_iterator.rs
+++ b/crates/core/src/file_group/reader_v2/merge_iterator.rs
@@ -19,60 +19,54 @@
 
 //! Streaming output for the file-group reader.
 //!
-//! The Java reader's `getClosableIterator()` returns a lazy iterator that
-//! emits merged rows in chunks. `FileGroupMergeIterator` does the same — it
-//! emits one merged chunk per `next()`, so the consumer (Velox
-//! `HudiSplitReader::next()`) can free each chunk before the next is built,
-//! instead of holding the entire merged `RecordBatch` resident at once.
+//! The Java reader's `getClosableIterator()` returns a lazy iterator that emits
+//! merged rows in chunks. [`FileGroupMergeStream`] does the same thing
+//! asynchronously: one merged chunk per `next_chunk`, so a consumer can free
+//! each chunk before the next is built instead of holding the whole merged
+//! result resident.
 //!
-//! [`FileGroupMergeIterator`] is the streaming bridge:
-//! a synchronous [`RecordBatchReader`] that emits one merged chunk per
-//! `next()`. The async I/O (base file decode, log scan) happens once in
-//! `HoodieFileGroupReader::open()`; from then on the iterator is pure
-//! in-memory work (HashMap lookups + Arrow slicing). This matches the
-//! FFI's `FFI_ArrowArrayStream` shape directly — no per-chunk `block_on`.
+//! Demand-driven, so the memory it adds over the merge map is one chunk. The
+//! only await is the base-file pull; the merge kernel, the drain and the output
+//! projection are synchronous work over data already in memory.
 //!
 //! ## Two source modes
 //!
-//! - [`MergeSource::Eager`] — used for the no-merge fast path (CoW or empty
-//!   FG): the base file batches are already materialised, no log scan ran,
-//!   no buffer was built. The iterator just yields each pre-computed batch
-//!   through the [`OutputConverter`].
-//! - [`MergeSource::Buffered`] — the MOR merge path: drives
-//!   `buffer.has_next() / buffer.next()` until `batch_size` rows have
-//!   accumulated, calls [`records_to_batch`] to build the chunk, applies
-//!   the converter, and returns it.
+//! - [`MergeSource::Eager`] — the no-merge path (CoW, or a file group with no
+//!   log files): no log scan ran and no buffer was built, so each base batch
+//!   passes through the [`OutputConverter`] as its own chunk.
+//! - [`MergeSource::Buffered`] — the MOR merge path: pull a base batch, merge it
+//!   against the log map, emit the result; once the base is exhausted, drain the
+//!   log-only inserts. One chunk per non-empty base batch, plus the drain.
 //!
 //! ## Schema lifecycle
 //!
-//! `RecordBatchReader::schema()` must report the schema callers will see in
-//! every batch — so the iterator stores the **post-projection** schema. When
-//! an [`OutputConverter`] is present, that comes from
-//! `OutputConverter::target_schema()`. Otherwise it equals the merge schema
-//! (= base file schema, or required_schema if set), determined in
-//! `HoodieFileGroupReader::open()`.
-//!
-//! ## Default batch size
-//!
-//! [`DEFAULT_BATCH_SIZE`] = 4096 rows, matching Velox's typical operator
-//! batch size. The Velox `HudiSplitReader::next(uint64_t size, ...)` API
-//! exposes a requested size parameter; a follow-up will plumb that through
-//! the FFI. For now the iterator uses its constructor-time `batch_size`.
+//! Every emitted chunk carries the **post-projection** schema: the
+//! [`OutputConverter`]'s `target_schema()` when one is configured, otherwise the
+//! merge schema (the base file's schema, or `required_schema` when set). It is
+//! settled when the stream is built, before any chunk is produced.
 
 use crate::Result;
 use crate::error::CoreError;
 use crate::file_group::reader_v2::buffer::HoodieFileGroupRecordBuffer;
 use crate::file_group::reader_v2::output_converter::OutputConverter;
-use arrow_array::{RecordBatch, RecordBatchIterator, RecordBatchReader};
-use arrow_schema::{ArrowError, SchemaRef};
+use arrow_array::RecordBatch;
+use arrow_schema::SchemaRef;
+use futures::StreamExt;
+use futures::stream::BoxStream;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
-/// Default chunk size (rows) emitted by [`FileGroupMergeIterator`].
+/// A base file delivered one batch at a time.
 ///
-/// Matches Velox's typical operator batch size; matches Spark Hudi's
-/// `hoodie.parquet.batchsize.default`. Used as the fallback when
-/// `hoodie.read.stream.batch_size` is unset/unparseable.
+/// The base file is the only part of a merge that has to be read rather than
+/// computed, so it is the only part that is a stream.
+pub type BaseBatchStream = BoxStream<'static, Result<RecordBatch>>;
+
+/// Chunk size (rows) the log-only drain emits.
+///
+/// Matches Velox's typical operator batch size, and Spark Hudi's
+/// `hoodie.parquet.batchsize.default`. The merged base chunks are not sized by
+/// this: they follow the base file's own row-group cadence.
 pub const DEFAULT_BATCH_SIZE: usize = 4096;
 
 /// Stage stats the streaming iterator accumulates as it emits chunks.
@@ -116,19 +110,14 @@ pub fn new_stream_stats_handle() -> StreamStatsHandle {
     Arc::new(Mutex::new(StreamReadStats::default()))
 }
 
-/// Source of merged records for [`FileGroupMergeIterator`].
+/// Source of merged records for [`FileGroupMergeStream`].
 ///
 /// Variants reflect the two read shapes the FG reader supports:
 /// no-merge (CoW or empty FG) vs full MOR merge.
 enum MergeSource {
-    /// No-merge path: a `RecordBatchReader` that yields the base file
-    /// row-groups directly (lazy parquet stream wrapped as
-    /// `ParquetSyncReader`, or a `RecordBatchIterator` over a pre-built
-    /// `Vec<RecordBatch>` for tests / eager paths). One source batch =
-    /// one emitted chunk.
-    Eager {
-        source: Box<dyn RecordBatchReader + Send>,
-    },
+    /// No-merge path: the base file's batches, forwarded as they arrive. One
+    /// source batch becomes one emitted chunk.
+    Eager { source: BaseBatchStream },
 
     /// MOR merge path. Drives the buffer's vectorized
     /// `next_merged_base_batch` + `drain_log_only_inserts` methods:
@@ -143,7 +132,7 @@ enum MergeSource {
         /// the buffer: the buffer's job is to merge a batch, and only whoever
         /// holds the source can say when the base is exhausted. `None` once it
         /// is, or when the file group has no base file.
-        base_source: Option<Box<dyn RecordBatchReader + Send>>,
+        base_source: Option<BaseBatchStream>,
         /// Schema the merged chunks conform to (used as `target_schema`
         /// when reconciling base batches with nested-type child field
         /// name drift, and as the schema for `records_to_batch` when the
@@ -166,14 +155,13 @@ enum BufferedState {
 
 /// Streaming output for the file-group reader.
 ///
-/// Implements [`RecordBatchReader`] so it can be handed directly to
-/// `FFI_ArrowArrayStream::new` for the C++ side, or used as a regular
-/// `Iterator<Item = Result<RecordBatch, ArrowError>>` in Rust callers.
-pub struct FileGroupMergeIterator {
+/// Driven a chunk at a time with [`Self::next_chunk`], or turned into a
+/// `Stream` with [`Self::into_stream`] for a caller that wants to compose it.
+pub struct FileGroupMergeStream {
     source: MergeSource,
-    /// Schema reported via [`RecordBatchReader::schema`]. Equals the
-    /// `target_schema` of the optional [`OutputConverter`], or the merge
-    /// schema if no converter is configured.
+    /// The schema every emitted chunk carries: the optional
+    /// [`OutputConverter`]'s `target_schema`, or the merge schema when there is
+    /// no converter.
     output_schema: SchemaRef,
     output_converter: Option<Box<dyn OutputConverter>>,
     /// Sticky termination — once any `next()` errors or `Eager.cursor`
@@ -186,7 +174,7 @@ pub struct FileGroupMergeIterator {
     stream_stats: StreamStatsHandle,
 }
 
-impl std::fmt::Debug for FileGroupMergeIterator {
+impl std::fmt::Debug for FileGroupMergeStream {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let kind = match &self.source {
             MergeSource::Eager { .. } => "Eager(lazy)".to_string(),
@@ -201,7 +189,7 @@ impl std::fmt::Debug for FileGroupMergeIterator {
                 )
             }
         };
-        f.debug_struct("FileGroupMergeIterator")
+        f.debug_struct("FileGroupMergeStream")
             .field("source", &kind)
             .field("output_schema_cols", &self.output_schema.fields().len())
             .field("has_output_converter", &self.output_converter.is_some())
@@ -210,16 +198,16 @@ impl std::fmt::Debug for FileGroupMergeIterator {
     }
 }
 
-impl FileGroupMergeIterator {
-    /// Build an iterator over a `RecordBatchReader` base source (CoW / empty
-    /// path). One source batch becomes one emitted chunk (after the
-    /// optional `OutputConverter`).
+impl FileGroupMergeStream {
+    /// Build a merge that forwards the base file unchanged (CoW / empty path).
+    /// One source batch becomes one emitted chunk, after the optional
+    /// `OutputConverter`.
     ///
     /// `output_schema` is the schema that will appear on every emitted
     /// `RecordBatch` — must equal the converter's `target_schema` when one
     /// is supplied, or the source's schema otherwise.
     pub fn new_eager(
-        source: Box<dyn RecordBatchReader + Send>,
+        source: BaseBatchStream,
         output_schema: SchemaRef,
         output_converter: Option<Box<dyn OutputConverter>>,
         stream_stats: StreamStatsHandle,
@@ -244,13 +232,8 @@ impl FileGroupMergeIterator {
         output_converter: Option<Box<dyn OutputConverter>>,
         stream_stats: StreamStatsHandle,
     ) -> Self {
-        let source_schema = batches
-            .first()
-            .map(|b| b.schema())
-            .unwrap_or_else(|| output_schema.clone());
-        let iter = RecordBatchIterator::new(batches.into_iter().map(Ok), source_schema);
         Self::new_eager(
-            Box::new(iter),
+            futures::stream::iter(batches.into_iter().map(Ok)).boxed(),
             output_schema,
             output_converter,
             stream_stats,
@@ -261,11 +244,10 @@ impl FileGroupMergeIterator {
     ///
     /// `merge_schema` is the schema [`records_to_batch`] uses while
     /// concatenating BufferedRecords for a chunk (pre-projection).
-    /// `output_schema` is the post-projection schema reported via
-    /// [`RecordBatchReader::schema`].
+    /// `output_schema` is the post-projection schema every chunk carries.
     pub fn new_buffered(
         buffer: Box<dyn HoodieFileGroupRecordBuffer>,
-        base_source: Box<dyn RecordBatchReader + Send>,
+        base_source: BaseBatchStream,
         merge_schema: SchemaRef,
         output_schema: SchemaRef,
         output_converter: Option<Box<dyn OutputConverter>>,
@@ -330,14 +312,11 @@ impl FileGroupMergeIterator {
     /// (drives the iterator to completion and concatenates).
     ///
     /// Backs `HoodieFileGroupReader::read()`'s single-batch return type.
-    pub fn collect_into_one_batch(mut self) -> Result<RecordBatch> {
+    pub async fn collect_into_one_batch(mut self) -> Result<RecordBatch> {
         let output_schema = self.output_schema.clone();
         let mut chunks: Vec<RecordBatch> = Vec::new();
-        for next in &mut self {
-            let batch = next.map_err(|e| {
-                CoreError::ReadFileSliceError(format!("FileGroupMergeIterator yielded error: {e}"))
-            })?;
-            chunks.push(batch);
+        while let Some(next) = self.next_chunk().await {
+            chunks.push(next?);
         }
         if chunks.is_empty() {
             return Ok(RecordBatch::new_empty(output_schema));
@@ -352,21 +331,36 @@ impl FileGroupMergeIterator {
         })
     }
 
-    /// Apply the configured [`OutputConverter`] (if any) and convert the
-    /// internal `CoreError` into `ArrowError` for the
-    /// `RecordBatchReader::next` contract.
-    fn finish_chunk(&self, batch: RecordBatch) -> Result<RecordBatch, ArrowError> {
+    /// Apply the configured [`OutputConverter`], if any.
+    fn finish_chunk(&self, batch: RecordBatch) -> Result<RecordBatch> {
         match &self.output_converter {
-            Some(converter) => converter.apply(batch).map_err(core_to_arrow_err),
+            Some(converter) => converter.apply(batch),
             None => Ok(batch),
         }
     }
 }
 
-impl Iterator for FileGroupMergeIterator {
-    type Item = Result<RecordBatch, ArrowError>;
+impl FileGroupMergeStream {
+    /// The schema every emitted chunk carries, settled before any chunk is
+    /// produced. No production caller needs it — a consumer of the boxed stream
+    /// gets the schema from the table — but it is the invariant the projection
+    /// tests pin, so it is stated here rather than reached for through the
+    /// private field.
+    #[allow(dead_code)]
+    pub fn schema(&self) -> SchemaRef {
+        self.output_schema.clone()
+    }
 
-    fn next(&mut self) -> Option<Self::Item> {
+    /// Produce the next merged chunk, or `None` once the merge is complete.
+    ///
+    /// The only await is the base-file pull. Everything else — the merge
+    /// kernel, the drain, the output projection — is synchronous work on data
+    /// already in memory, so nothing here holds a lock or a borrow across the
+    /// await beyond the source itself.
+    ///
+    /// Sticky: after an error, or after the merge completes, every later call
+    /// returns `None`.
+    pub async fn next_chunk(&mut self) -> Option<Result<RecordBatch>> {
         if self.done {
             return None;
         }
@@ -380,127 +374,138 @@ impl Iterator for FileGroupMergeIterator {
         //   Ok(None)                                       — stream exhausted
         //   Err((e, merge_ms, build_ms))                   — terminal error
         type Chunk = (RecordBatch, u64, u64);
-        let produced: Result<Option<Chunk>, (CoreError, u64, u64)> = match &mut self.source {
-            MergeSource::Eager { source } => {
-                // One source batch = one emitted chunk. The
-                // source is a `RecordBatchReader` — lazy (`ParquetSyncReader`
-                // doing block_on per row-group) or eager (`RecordBatchIterator`
-                // over a Vec for tests / instant-range-filter fallback). The
-                // CoW / empty-FG no-merge path never materializes the whole
-                // base file; it pulls one row-group at a time.
-                match source.next() {
-                    None => Ok(None),
-                    // Eager has no merge work; build timing is the converter only.
-                    Some(Ok(batch)) => Ok(Some((batch, 0, 0))),
-                    Some(Err(e)) => Err((CoreError::ArrowError(e), 0, 0)),
+        let produced: std::result::Result<Option<Chunk>, (CoreError, u64, u64)> =
+            match &mut self.source {
+                MergeSource::Eager { source } => {
+                    // One source batch = one emitted chunk. The no-merge path
+                    // (CoW, or a file group with no log files) never
+                    // materialises the whole base file; it pulls one row group
+                    // at a time.
+                    match source.next().await {
+                        None => Ok(None),
+                        // Eager has no merge work; build timing is the converter only.
+                        Some(Ok(batch)) => Ok(Some((batch, 0, 0))),
+                        Some(Err(e)) => Err((e, 0, 0)),
+                    }
                 }
-            }
 
-            MergeSource::Buffered {
-                buffer,
-                base_source,
-                merge_schema,
-                state,
-            } => {
-                // Vectorized merge path: pull the next merged base
-                // batch, or drain log-only inserts, then hand it to the shared
-                // timing / projection / exhaustion tail below (Step 2) so the
-                // stream-stats timing is preserved. Loop to skip base
-                // chunks fully eliminated by log deletes.
-                let merge_start = Instant::now();
-                let mut chunk_err: Option<CoreError> = None;
-                let mut out_batch: Option<RecordBatch> = None;
-                loop {
-                    match state {
-                        BufferedState::BaseScanning => {
-                            // Pull first, merge second. Only the source knows
-                            // when the base is exhausted, so that is the only
-                            // thing that moves the state machine on to the
-                            // drain — a merge that yields no rows just means
-                            // this batch contributed none, and must not be read
-                            // as the end of the base file.
-                            let pulled = match base_source.as_mut() {
-                                None => None,
-                                Some(source) => match source.next() {
+                MergeSource::Buffered {
+                    buffer,
+                    base_source,
+                    merge_schema,
+                    state,
+                } => {
+                    // Vectorized merge path: pull the next base batch and merge
+                    // it, or drain log-only inserts, then hand the result to the
+                    // shared timing / projection / exhaustion tail below
+                    // (Step 2). Loop to skip base batches fully eliminated by
+                    // log deletes.
+                    //
+                    // Only the merge itself is timed. Timing the whole loop
+                    // would fold the base file's read latency into
+                    // `final_merge_ms`, which is meant to measure merging.
+                    let mut merge_ms = 0u64;
+                    let mut chunk_err: Option<CoreError> = None;
+                    let mut out_batch: Option<RecordBatch> = None;
+                    loop {
+                        match state {
+                            BufferedState::BaseScanning => {
+                                // Pull first, merge second. Only the source knows
+                                // when the base is exhausted, so that is the only
+                                // thing that moves the state machine on to the
+                                // drain — a merge that yields no rows just means
+                                // this batch contributed none, and must not be
+                                // read as the end of the base file.
+                                let pulled = match base_source.as_mut() {
+                                    None => None,
+                                    Some(source) => match source.next().await {
+                                        None => {
+                                            *base_source = None;
+                                            None
+                                        }
+                                        Some(b) => Some(b),
+                                    },
+                                };
+                                let base = match pulled {
                                     None => {
-                                        *base_source = None;
-                                        None
-                                    }
-                                    Some(b) => Some(b),
-                                },
-                            };
-                            let base = match pulled {
-                                None => {
-                                    // Base exhausted — drain log-only inserts
-                                    // on the next loop turn.
-                                    *state = BufferedState::DrainingLogInserts;
-                                    continue;
-                                }
-                                Some(Ok(b)) => b,
-                                Some(Err(e)) => {
-                                    // Drop the source: a failed read must not be
-                                    // resumed as if it had merely ended, which
-                                    // would truncate the output silently.
-                                    *base_source = None;
-                                    log::error!("[FileGroupMergeIterator] base file source: {e}");
-                                    chunk_err = Some(CoreError::ReadFileSliceError(format!(
-                                        "base file source error: {e}"
-                                    )));
-                                    break;
-                                }
-                            };
-                            if base.num_rows() == 0 {
-                                continue; // skip empty source batches
-                            }
-                            match buffer.merge_base_batch(&base, merge_schema) {
-                                Ok(Some(b)) => {
-                                    if b.num_rows() == 0 {
-                                        // All base rows in this source batch lost
-                                        // to a log delete — pull the next.
+                                        // Base exhausted — drain log-only inserts
+                                        // on the next loop turn.
+                                        *state = BufferedState::DrainingLogInserts;
                                         continue;
                                     }
-                                    out_batch = Some(b);
-                                    break;
+                                    Some(Ok(b)) => b,
+                                    Some(Err(e)) => {
+                                        // Drop the source: a failed read must not
+                                        // be resumed as if it had merely ended,
+                                        // which would truncate the output
+                                        // silently.
+                                        *base_source = None;
+                                        log::error!("[FileGroupMergeStream] base file source: {e}");
+                                        chunk_err = Some(CoreError::ReadFileSliceError(format!(
+                                            "base file source error: {e}"
+                                        )));
+                                        break;
+                                    }
+                                };
+                                if base.num_rows() == 0 {
+                                    continue; // skip empty source batches
                                 }
-                                Ok(None) => continue,
-                                Err(e) => {
-                                    chunk_err = Some(e);
-                                    break;
+                                let merge_start = Instant::now();
+                                let merged = buffer.merge_base_batch(&base, merge_schema);
+                                merge_ms = merge_ms
+                                    .saturating_add(merge_start.elapsed().as_millis() as u64);
+                                match merged {
+                                    Ok(Some(b)) => {
+                                        if b.num_rows() == 0 {
+                                            // All base rows in this source batch
+                                            // lost to a log delete — pull the next.
+                                            continue;
+                                        }
+                                        out_batch = Some(b);
+                                        break;
+                                    }
+                                    Ok(None) => continue,
+                                    Err(e) => {
+                                        chunk_err = Some(e);
+                                        break;
+                                    }
                                 }
                             }
-                        }
-                        BufferedState::DrainingLogInserts => {
-                            // drain_log_only_inserts is idempotent: it returns the
-                            // remaining log-only inserts once, then Ok(None).
-                            match buffer.drain_log_only_inserts(merge_schema) {
-                                Ok(Some(b)) if b.num_rows() > 0 => {
-                                    out_batch = Some(b);
-                                    break;
-                                }
-                                Ok(_) => break,
-                                Err(e) => {
-                                    chunk_err = Some(e);
-                                    break;
+                            BufferedState::DrainingLogInserts => {
+                                // drain_log_only_inserts is idempotent: it returns the
+                                // remaining log-only inserts once, then Ok(None).
+                                let drain_start = Instant::now();
+                                let drained = buffer.drain_log_only_inserts(merge_schema);
+                                merge_ms = merge_ms
+                                    .saturating_add(drain_start.elapsed().as_millis() as u64);
+                                match drained {
+                                    Ok(Some(b)) if b.num_rows() > 0 => {
+                                        out_batch = Some(b);
+                                        break;
+                                    }
+                                    Ok(_) => break,
+                                    Err(e) => {
+                                        chunk_err = Some(e);
+                                        break;
+                                    }
                                 }
                             }
                         }
                     }
-                }
-                let merge_ms = merge_start.elapsed().as_millis() as u64;
-                if let Some(e) = chunk_err {
-                    Err((e, merge_ms, 0))
-                } else if let Some(b) = out_batch {
-                    Ok(Some((b, merge_ms, 0)))
-                } else {
-                    // Exhausted. Record the merge probe time before the
-                    // exhaustion handler (Step 2) runs.
-                    if let Ok(mut s) = self.stream_stats.lock() {
-                        s.final_merge_ms = s.final_merge_ms.saturating_add(merge_ms);
+                    if let Some(e) = chunk_err {
+                        Err((e, merge_ms, 0))
+                    } else if let Some(b) = out_batch {
+                        Ok(Some((b, merge_ms, 0)))
+                    } else {
+                        // Exhausted. Record the merge probe time before the
+                        // exhaustion handler (Step 2) runs.
+                        if let Ok(mut s) = self.stream_stats.lock() {
+                            s.final_merge_ms = s.final_merge_ms.saturating_add(merge_ms);
+                        }
+                        Ok(None)
                     }
-                    Ok(None)
                 }
-            }
-        };
+            };
 
         // Step 2: the source borrow has ended — handle timing / projection /
         // exhaustion via `&self` helpers.
@@ -526,20 +531,21 @@ impl Iterator for FileGroupMergeIterator {
             Err((e, merge_ms, build_ms)) => {
                 self.done = true;
                 self.record_chunk_timing(merge_ms, build_ms);
-                Some(Err(core_to_arrow_err(e)))
+                Some(Err(e))
             }
         }
     }
-}
 
-impl RecordBatchReader for FileGroupMergeIterator {
-    fn schema(&self) -> SchemaRef {
-        self.output_schema.clone()
+    /// Drive this merge as a `Stream`, for a caller that wants to compose it.
+    ///
+    /// Chunk-at-a-time and demand-driven: nothing is merged until the consumer
+    /// asks, so the extra memory over the merge map itself is one chunk.
+    pub fn into_stream(self) -> BoxStream<'static, Result<RecordBatch>> {
+        futures::stream::unfold(self, |mut merge| async move {
+            merge.next_chunk().await.map(|item| (item, merge))
+        })
+        .boxed()
     }
-}
-
-fn core_to_arrow_err(e: CoreError) -> ArrowError {
-    ArrowError::ExternalError(Box::new(e))
 }
 
 #[cfg(test)]
@@ -722,10 +728,32 @@ mod tests {
         }
     }
 
-    /// A base source with no batches — a log-only file group. The iterator goes
+    /// A base source with no batches — a log-only file group. The merge goes
     /// straight to the log drain, which is where these mocks keep their records.
-    fn no_base(schema: &SchemaRef) -> Box<dyn RecordBatchReader + Send> {
-        Box::new(RecordBatchIterator::new(std::iter::empty(), schema.clone()))
+    fn no_base(_schema: &SchemaRef) -> BaseBatchStream {
+        futures::stream::empty().boxed()
+    }
+
+    /// A base source over fixed batches.
+    fn base_of(batches: Vec<Result<RecordBatch>>) -> BaseBatchStream {
+        futures::stream::iter(batches).boxed()
+    }
+
+    /// Drive a merge to exhaustion from a synchronous test. Nothing here does
+    /// I/O — the base sources are in-memory — so a local executor is enough.
+    fn drain(mut merge: FileGroupMergeStream) -> Vec<Result<RecordBatch>> {
+        futures::executor::block_on(async {
+            let mut out = Vec::new();
+            while let Some(chunk) = merge.next_chunk().await {
+                out.push(chunk);
+            }
+            out
+        })
+    }
+
+    /// As [`drain`], unwrapping each chunk.
+    fn drain_ok(merge: FileGroupMergeStream) -> Vec<RecordBatch> {
+        drain(merge).into_iter().map(|c| c.unwrap()).collect()
     }
 
     /// Drive a Buffered iterator to exhaustion, returning the per-chunk row
@@ -738,7 +766,7 @@ mod tests {
     ) -> (Vec<usize>, Vec<(String, i32)>, StreamStatsHandle) {
         let handle = new_stream_stats_handle();
         let _ = batch_size;
-        let it = FileGroupMergeIterator::new_buffered(
+        let it = FileGroupMergeStream::new_buffered(
             MockBuffer::boxed(records, stats),
             no_base(&schema),
             schema.clone(),
@@ -748,8 +776,7 @@ mod tests {
         );
         let mut chunk_rows = Vec::new();
         let mut all_rows = Vec::new();
-        for chunk in it {
-            let b = chunk.unwrap();
+        for b in drain_ok(it) {
             assert_eq!(b.schema(), schema, "every chunk reports the output schema");
             chunk_rows.push(b.num_rows());
             all_rows.extend(rows(&b));
@@ -802,14 +829,14 @@ mod tests {
         let schema = small_schema();
         let b1 = batch(schema.clone(), &["a", "b"], &[1, 2]);
         let b2 = batch(schema.clone(), &["c"], &[3]);
-        let it = FileGroupMergeIterator::new_eager_from_vec(
+        let it = FileGroupMergeStream::new_eager_from_vec(
             vec![b1, b2],
             schema.clone(),
             None,
             new_stream_stats_handle(),
         );
         assert_eq!(it.schema(), schema);
-        let out: Vec<RecordBatch> = it.map(|r| r.unwrap()).collect();
+        let out: Vec<RecordBatch> = drain_ok(it);
         assert_eq!(out.len(), 2);
         assert_eq!(rows(&out[0]), vec![("a".into(), 1), ("b".into(), 2)]);
         assert_eq!(rows(&out[1]), vec![("c".into(), 3)]);
@@ -821,13 +848,13 @@ mod tests {
         let schema = small_schema();
         let b1 = batch(schema.clone(), &["a", "b"], &[1, 2]);
         let b2 = batch(schema.clone(), &["c"], &[3]);
-        let it = FileGroupMergeIterator::new_eager_from_vec(
+        let it = FileGroupMergeStream::new_eager_from_vec(
             vec![b1, b2],
             schema,
             None,
             new_stream_stats_handle(),
         );
-        let result = it.collect_into_one_batch().unwrap();
+        let result = futures::executor::block_on(it.collect_into_one_batch()).unwrap();
         assert_eq!(
             rows(&result),
             vec![("a".into(), 1), ("b".into(), 2), ("c".into(), 3)]
@@ -838,13 +865,13 @@ mod tests {
     #[test]
     fn eager_empty_yields_zero_rows_via_collect() {
         let schema = small_schema();
-        let it = FileGroupMergeIterator::new_eager_from_vec(
+        let it = FileGroupMergeStream::new_eager_from_vec(
             vec![],
             schema.clone(),
             None,
             new_stream_stats_handle(),
         );
-        let result = it.collect_into_one_batch().unwrap();
+        let result = futures::executor::block_on(it.collect_into_one_batch()).unwrap();
         assert_eq!(result.num_rows(), 0);
         assert_eq!(result.schema(), schema);
     }
@@ -1027,24 +1054,20 @@ mod tests {
     #[test]
     fn buffered_merge_yielding_nothing_is_not_the_end_of_the_base() {
         let schema = small_schema();
-        let base = RecordBatchIterator::new(
-            vec![
-                Ok(batch(schema.clone(), &["a"], &[1])),
-                Ok(batch(schema.clone(), &["b"], &[2])),
-            ]
-            .into_iter(),
-            schema.clone(),
-        );
+        let base = base_of(vec![
+            Ok(batch(schema.clone(), &["a"], &[1])),
+            Ok(batch(schema.clone(), &["b"], &[2])),
+        ]);
         // The first base batch merges to nothing; the second must still be read.
-        let it = FileGroupMergeIterator::new_buffered(
+        let it = FileGroupMergeStream::new_buffered(
             MockBuffer::boxed_yielding_nothing_for(vec![], UpdateStats::default(), 1),
-            Box::new(base),
+            base,
             schema.clone(),
             schema,
             None,
             new_stream_stats_handle(),
         );
-        let out: Vec<(String, i32)> = it.flat_map(|c| rows(&c.unwrap())).collect();
+        let out: Vec<(String, i32)> = drain_ok(it).iter().flat_map(rows).collect();
         assert_eq!(
             out,
             vec![("b".to_string(), 2)],
@@ -1059,29 +1082,26 @@ mod tests {
     #[test]
     fn buffered_base_source_error_surfaces_rather_than_truncating() {
         let schema = small_schema();
-        let base = RecordBatchIterator::new(
-            vec![
-                Ok(batch(schema.clone(), &["a"], &[1])),
-                Err(ArrowError::ExternalError("base read blew up".into())),
-            ]
-            .into_iter(),
-            schema.clone(),
-        );
-        let mut it = FileGroupMergeIterator::new_buffered(
+        let base = base_of(vec![
+            Ok(batch(schema.clone(), &["a"], &[1])),
+            Err(CoreError::ReadFileSliceError("base read blew up".into())),
+        ]);
+        let it = FileGroupMergeStream::new_buffered(
             MockBuffer::boxed(vec![], UpdateStats::default()),
-            Box::new(base),
+            base,
             schema.clone(),
             schema,
             None,
             new_stream_stats_handle(),
         );
+        let chunks = drain(it);
         assert_eq!(
-            rows(&it.next().unwrap().unwrap()),
+            rows(&chunks[0].as_ref().unwrap().clone()),
             vec![("a".to_string(), 1)],
             "the batch read before the failure still comes through"
         );
-        match it.next() {
-            Some(Err(ArrowError::ExternalError(e))) => {
+        match chunks.get(1) {
+            Some(Err(e)) => {
                 let msg = e.to_string();
                 assert!(
                     msg.contains("base file source error"),
@@ -1090,7 +1110,7 @@ mod tests {
             }
             other => panic!("expected the base source error to surface, got {other:?}"),
         }
-        assert!(it.next().is_none(), "the iterator fuses after the error");
+        assert_eq!(chunks.len(), 2, "the merge stops after the error");
     }
 
     // ---- Error/termination spine ----
@@ -1190,32 +1210,28 @@ mod tests {
             empty_map: HashMap::default(),
         });
         // One base batch, so the buffer is actually asked to merge something:
-        // with an empty base the iterator would go straight to the drain and the
+        // with an empty base the merge would go straight to the drain and the
         // failure under test would never be reached.
-        let base = RecordBatchIterator::new(
-            vec![Ok(batch(schema.clone(), &["a"], &[1]))].into_iter(),
-            schema.clone(),
-        );
-        let mut it = FileGroupMergeIterator::new_buffered(
+        let base = base_of(vec![Ok(batch(schema.clone(), &["a"], &[1]))]);
+        let it = FileGroupMergeStream::new_buffered(
             buffer,
-            Box::new(base),
+            base,
             schema.clone(),
             schema,
             None,
             new_stream_stats_handle(),
         );
-        // The buffer's `ReadFileSliceError` surfaces once, preserved through the
-        // `ArrowError::ExternalError` wrapper (not swapped for another variant).
-        match it.next() {
-            Some(Err(ArrowError::ExternalError(e))) => match e.downcast_ref::<CoreError>() {
-                Some(CoreError::ReadFileSliceError(msg)) => assert_eq!(msg.as_str(), "boom"),
-                other => panic!("expected CoreError::ReadFileSliceError, got {other:?}"),
-            },
-            other => panic!("expected Some(Err(ArrowError::ExternalError)), got {other:?}"),
+        // The buffer's `ReadFileSliceError` surfaces once, as itself rather
+        // than swapped for another variant, and then the merge stops.
+        let chunks = drain(it);
+        match chunks.first() {
+            Some(Err(CoreError::ReadFileSliceError(msg))) => assert_eq!(msg.as_str(), "boom"),
+            other => panic!("expected CoreError::ReadFileSliceError, got {other:?}"),
         }
-        assert!(
-            it.next().is_none(),
-            "iterator fuses after an error (sticky done)"
+        assert_eq!(
+            chunks.len(),
+            1,
+            "the merge fuses after an error (sticky done)"
         );
     }
 
@@ -1236,7 +1252,7 @@ mod tests {
             &target_schema,
         );
         // 5 records with a converter installed, so per-chunk projection is exercised.
-        let it = FileGroupMergeIterator::new_buffered(
+        let it = FileGroupMergeStream::new_buffered(
             MockBuffer::boxed(batch_ref_seq(&merge_schema, 5), UpdateStats::default()),
             no_base(&merge_schema),
             merge_schema.clone(),
@@ -1251,7 +1267,7 @@ mod tests {
             "schema() reports the converter target before the first chunk"
         );
 
-        let chunks: Vec<RecordBatch> = it.map(|r| r.unwrap()).collect();
+        let chunks: Vec<RecordBatch> = drain_ok(it);
         // The MockBuffer drains its log-only inserts in one batch, so
         // the projection may land in a single chunk here; assert projection is
         // applied (schema + values below) rather than a specific chunk count.
@@ -1276,23 +1292,21 @@ mod tests {
     }
 
     /// The Eager (no-merge) source works with an arbitrary
-    /// `RecordBatchReader`, not just a Vec. Models the lazy base-file path
-    /// where the FG reader hands a `ParquetSyncReader` (or similar) to
-    /// `new_eager` directly, pulling one row-group per chunk.
+    /// base stream, not just a Vec. Models the real no-merge path, where the
+    /// reader hands `new_eager` the parquet stream directly and one row group
+    /// becomes one chunk.
     #[test]
-    fn eager_accepts_arbitrary_record_batch_reader() {
+    fn eager_accepts_an_arbitrary_base_stream() {
         let schema = small_schema();
         let b1 = batch(schema.clone(), &["a", "b"], &[1, 2]);
         let b2 = batch(schema.clone(), &["c"], &[3]);
-        let reader =
-            arrow_array::RecordBatchIterator::new(vec![Ok(b1), Ok(b2)].into_iter(), schema.clone());
-        let it = FileGroupMergeIterator::new_eager(
-            Box::new(reader),
+        let it = FileGroupMergeStream::new_eager(
+            base_of(vec![Ok(b1), Ok(b2)]),
             schema.clone(),
             None,
             new_stream_stats_handle(),
         );
-        let out: Vec<RecordBatch> = it.map(|r| r.unwrap()).collect();
+        let out: Vec<RecordBatch> = drain_ok(it);
         assert_eq!(out.len(), 2);
         assert_eq!(out[0].num_rows() + out[1].num_rows(), 3);
     }

--- a/crates/core/src/file_group/reader_v2/merge_iterator.rs
+++ b/crates/core/src/file_group/reader_v2/merge_iterator.rs
@@ -135,12 +135,15 @@ enum MergeSource {
     /// one emitted chunk per non-empty base source batch, plus a single
     /// final chunk for log-only inserts (keys never matched by any base row).
     ///
-    /// `batch_size` is retained but unused on the merge path — it is kept
-    /// in the public `new_buffered` signature for API compatibility with
-    /// callers that pass `DEFAULT_BATCH_SIZE`. Chunk size is
-    /// determined by the base source's own row-group cadence.
+    /// Chunk size is determined by the base source's own row-group cadence,
+    /// so there is no batch-size knob on this path.
     Buffered {
         buffer: Box<dyn HoodieFileGroupRecordBuffer>,
+        /// The base file, pulled one batch at a time. Owned here rather than by
+        /// the buffer: the buffer's job is to merge a batch, and only whoever
+        /// holds the source can say when the base is exhausted. `None` once it
+        /// is, or when the file group has no base file.
+        base_source: Option<Box<dyn RecordBatchReader + Send>>,
         /// Schema the merged chunks conform to (used as `target_schema`
         /// when reconciling base batches with nested-type child field
         /// name drift, and as the schema for `records_to_batch` when the
@@ -262,15 +265,16 @@ impl FileGroupMergeIterator {
     /// [`RecordBatchReader::schema`].
     pub fn new_buffered(
         buffer: Box<dyn HoodieFileGroupRecordBuffer>,
+        base_source: Box<dyn RecordBatchReader + Send>,
         merge_schema: SchemaRef,
         output_schema: SchemaRef,
         output_converter: Option<Box<dyn OutputConverter>>,
-        _batch_size: usize,
         stream_stats: StreamStatsHandle,
     ) -> Self {
         Self {
             source: MergeSource::Buffered {
                 buffer,
+                base_source: Some(base_source),
                 merge_schema,
                 state: BufferedState::BaseScanning,
             },
@@ -394,6 +398,7 @@ impl Iterator for FileGroupMergeIterator {
 
             MergeSource::Buffered {
                 buffer,
+                base_source,
                 merge_schema,
                 state,
             } => {
@@ -408,7 +413,46 @@ impl Iterator for FileGroupMergeIterator {
                 loop {
                     match state {
                         BufferedState::BaseScanning => {
-                            match buffer.next_merged_base_batch(merge_schema) {
+                            // Pull first, merge second. Only the source knows
+                            // when the base is exhausted, so that is the only
+                            // thing that moves the state machine on to the
+                            // drain — a merge that yields no rows just means
+                            // this batch contributed none, and must not be read
+                            // as the end of the base file.
+                            let pulled = match base_source.as_mut() {
+                                None => None,
+                                Some(source) => match source.next() {
+                                    None => {
+                                        *base_source = None;
+                                        None
+                                    }
+                                    Some(b) => Some(b),
+                                },
+                            };
+                            let base = match pulled {
+                                None => {
+                                    // Base exhausted — drain log-only inserts
+                                    // on the next loop turn.
+                                    *state = BufferedState::DrainingLogInserts;
+                                    continue;
+                                }
+                                Some(Ok(b)) => b,
+                                Some(Err(e)) => {
+                                    // Drop the source: a failed read must not be
+                                    // resumed as if it had merely ended, which
+                                    // would truncate the output silently.
+                                    *base_source = None;
+                                    log::error!("[FileGroupMergeIterator] base file source: {e}");
+                                    chunk_err = Some(CoreError::ReadFileSliceError(format!(
+                                        "base file source error: {e}"
+                                    )));
+                                    break;
+                                }
+                            };
+                            if base.num_rows() == 0 {
+                                continue; // skip empty source batches
+                            }
+                            match buffer.merge_base_batch(&base, merge_schema) {
                                 Ok(Some(b)) => {
                                     if b.num_rows() == 0 {
                                         // All base rows in this source batch lost
@@ -418,12 +462,7 @@ impl Iterator for FileGroupMergeIterator {
                                     out_batch = Some(b);
                                     break;
                                 }
-                                Ok(None) => {
-                                    // Base source exhausted — drain log-only
-                                    // inserts on the next loop turn.
-                                    *state = BufferedState::DrainingLogInserts;
-                                    continue;
-                                }
+                                Ok(None) => continue,
                                 Err(e) => {
                                     chunk_err = Some(e);
                                     break;
@@ -553,6 +592,9 @@ mod tests {
         queue: VecDeque<BufferedRecord>,
         stats: UpdateStats,
         empty_map: MergeMap,
+        /// How many base batches merge to nothing before one merges to rows.
+        /// Zero for every test that drives the drain with no base file.
+        merge_yields_nothing_for: usize,
     }
 
     impl MockBuffer {
@@ -560,10 +602,21 @@ mod tests {
             records: Vec<BufferedRecord>,
             stats: UpdateStats,
         ) -> Box<dyn HoodieFileGroupRecordBuffer> {
+            Self::boxed_yielding_nothing_for(records, stats, 0)
+        }
+
+        /// A buffer whose first `n` merges produce no batch at all, so the
+        /// iterator's reading of `Ok(None)` can be pinned.
+        fn boxed_yielding_nothing_for(
+            records: Vec<BufferedRecord>,
+            stats: UpdateStats,
+            n: usize,
+        ) -> Box<dyn HoodieFileGroupRecordBuffer> {
             Box::new(Self {
                 queue: records.into(),
                 stats,
                 empty_map: HashMap::default(),
+                merge_yields_nothing_for: n,
             })
         }
     }
@@ -632,6 +685,17 @@ mod tests {
             // surfaced via `drain_log_only_inserts` (log-only-insert path).
             Ok(None)
         }
+        fn merge_base_batch(
+            &mut self,
+            base: &RecordBatch,
+            _target_schema: &SchemaRef,
+        ) -> Result<Option<RecordBatch>> {
+            if self.merge_yields_nothing_for > 0 {
+                self.merge_yields_nothing_for -= 1;
+                return Ok(None);
+            }
+            Ok(Some(base.clone()))
+        }
         fn drain_log_only_inserts(
             &mut self,
             target_schema: &SchemaRef,
@@ -658,6 +722,12 @@ mod tests {
         }
     }
 
+    /// A base source with no batches — a log-only file group. The iterator goes
+    /// straight to the log drain, which is where these mocks keep their records.
+    fn no_base(schema: &SchemaRef) -> Box<dyn RecordBatchReader + Send> {
+        Box::new(RecordBatchIterator::new(std::iter::empty(), schema.clone()))
+    }
+
     /// Drive a Buffered iterator to exhaustion, returning the per-chunk row
     /// counts and the flattened `(key, v)` rows across all chunks (in order).
     fn drain_buffered(
@@ -667,12 +737,13 @@ mod tests {
         stats: UpdateStats,
     ) -> (Vec<usize>, Vec<(String, i32)>, StreamStatsHandle) {
         let handle = new_stream_stats_handle();
+        let _ = batch_size;
         let it = FileGroupMergeIterator::new_buffered(
             MockBuffer::boxed(records, stats),
+            no_base(&schema),
             schema.clone(),
             schema.clone(),
             None,
-            batch_size,
             handle.clone(),
         );
         let mut chunk_rows = Vec::new();
@@ -949,6 +1020,79 @@ mod tests {
         }
     }
 
+    /// A merge that yields no batch means *this* batch contributed no rows, not
+    /// that the base file has ended. Only the source says that. Reading the two
+    /// as the same thing would stop the scan at the first fully-deleted batch
+    /// and silently drop every base row after it.
+    #[test]
+    fn buffered_merge_yielding_nothing_is_not_the_end_of_the_base() {
+        let schema = small_schema();
+        let base = RecordBatchIterator::new(
+            vec![
+                Ok(batch(schema.clone(), &["a"], &[1])),
+                Ok(batch(schema.clone(), &["b"], &[2])),
+            ]
+            .into_iter(),
+            schema.clone(),
+        );
+        // The first base batch merges to nothing; the second must still be read.
+        let it = FileGroupMergeIterator::new_buffered(
+            MockBuffer::boxed_yielding_nothing_for(vec![], UpdateStats::default(), 1),
+            Box::new(base),
+            schema.clone(),
+            schema,
+            None,
+            new_stream_stats_handle(),
+        );
+        let out: Vec<(String, i32)> = it.flat_map(|c| rows(&c.unwrap())).collect();
+        assert_eq!(
+            out,
+            vec![("b".to_string(), 2)],
+            "the batch after one that merged to nothing must still reach the output"
+        );
+    }
+
+    /// A base source that fails mid-read surfaces the failure. The rows already
+    /// emitted make a truncated read look like a short but successful one, so
+    /// swallowing the error here would report partial data as complete - the
+    /// one failure this path must never produce.
+    #[test]
+    fn buffered_base_source_error_surfaces_rather_than_truncating() {
+        let schema = small_schema();
+        let base = RecordBatchIterator::new(
+            vec![
+                Ok(batch(schema.clone(), &["a"], &[1])),
+                Err(ArrowError::ExternalError("base read blew up".into())),
+            ]
+            .into_iter(),
+            schema.clone(),
+        );
+        let mut it = FileGroupMergeIterator::new_buffered(
+            MockBuffer::boxed(vec![], UpdateStats::default()),
+            Box::new(base),
+            schema.clone(),
+            schema,
+            None,
+            new_stream_stats_handle(),
+        );
+        assert_eq!(
+            rows(&it.next().unwrap().unwrap()),
+            vec![("a".to_string(), 1)],
+            "the batch read before the failure still comes through"
+        );
+        match it.next() {
+            Some(Err(ArrowError::ExternalError(e))) => {
+                let msg = e.to_string();
+                assert!(
+                    msg.contains("base file source error"),
+                    "the error must name the base source, got: {msg}"
+                );
+            }
+            other => panic!("expected the base source error to surface, got {other:?}"),
+        }
+        assert!(it.next().is_none(), "the iterator fuses after the error");
+    }
+
     // ---- Error/termination spine ----
 
     /// A buffer whose `has_next` always errors — pins the iterator's
@@ -1017,6 +1161,15 @@ mod tests {
             // surface-once-then-fuse contract.
             Err(crate::error::CoreError::ReadFileSliceError("boom".into()))
         }
+        fn merge_base_batch(
+            &mut self,
+            _base: &RecordBatch,
+            _target_schema: &SchemaRef,
+        ) -> Result<Option<RecordBatch>> {
+            // Same failure through the batch-at-a-time entry point, so the
+            // fuse contract is exercised whichever way the base is supplied.
+            Err(crate::error::CoreError::ReadFileSliceError("boom".into()))
+        }
         fn drain_log_only_inserts(
             &mut self,
             _target_schema: &SchemaRef,
@@ -1036,12 +1189,19 @@ mod tests {
         let buffer = Box::new(ErrOnHasNext {
             empty_map: HashMap::default(),
         });
+        // One base batch, so the buffer is actually asked to merge something:
+        // with an empty base the iterator would go straight to the drain and the
+        // failure under test would never be reached.
+        let base = RecordBatchIterator::new(
+            vec![Ok(batch(schema.clone(), &["a"], &[1]))].into_iter(),
+            schema.clone(),
+        );
         let mut it = FileGroupMergeIterator::new_buffered(
             buffer,
+            Box::new(base),
             schema.clone(),
             schema,
             None,
-            4,
             new_stream_stats_handle(),
         );
         // The buffer's `ReadFileSliceError` surfaces once, preserved through the
@@ -1078,10 +1238,10 @@ mod tests {
         // 5 records with a converter installed, so per-chunk projection is exercised.
         let it = FileGroupMergeIterator::new_buffered(
             MockBuffer::boxed(batch_ref_seq(&merge_schema, 5), UpdateStats::default()),
-            merge_schema,
+            no_base(&merge_schema),
+            merge_schema.clone(),
             target_schema.clone(),
             Some(Box::new(converter)),
-            2,
             new_stream_stats_handle(),
         );
         // schema() reports the post-projection target BEFORE iterating.

--- a/crates/core/src/file_group/reader_v2/merge_iterator.rs
+++ b/crates/core/src/file_group/reader_v2/merge_iterator.rs
@@ -66,13 +66,14 @@ pub type BaseBatchStream = BoxStream<'static, Result<RecordBatch>>;
 ///
 /// Matches Velox's typical operator batch size, and Spark Hudi's
 /// `hoodie.parquet.batchsize.default`. The merged base chunks are not sized by
-/// this: they follow the base file's own row-group cadence.
+/// this: the base read requests them at the reader's own batch size
+/// (`MERGE_CHUNK_ROWS` in the engine), and one source batch becomes one chunk.
 pub const DEFAULT_BATCH_SIZE: usize = 4096;
 
 /// Stage stats the streaming iterator accumulates as it emits chunks.
 ///
-/// The iterator owns the buffer once `open()` returns, so it accumulates these
-/// per chunk through a shared [`StreamStatsHandle`]. The
+/// The iterator owns the buffer once the stream is built, so it accumulates
+/// these per chunk through a shared [`StreamStatsHandle`]. The
 /// reader drains them into its [`HoodieReadStats`] once the stream is
 /// exhausted — see `HoodieFileGroupReader::drain_stream_stats`.
 ///
@@ -87,8 +88,9 @@ pub struct StreamReadStats {
     /// `records_to_batch` + the per-chunk `OutputConverter` projection.
     pub output_build_ms: u64,
     /// Peak number of entries the merge map held during the log scan. Recorded
-    /// off the buffer by `HoodieFileGroupReader::open` before iteration starts
-    /// (it is finalized at scan time, not during output streaming).
+    /// off the buffer by `HoodieFileGroupReader::init_record_iterators` before
+    /// the stream is returned (it is finalized at scan time, not during output
+    /// streaming).
     pub merge_map_peak_entries: u64,
     /// Insert / update / delete counts the update processor accumulated while
     /// the iterator drove the merge. Snapshotted off the buffer when the
@@ -120,12 +122,13 @@ enum MergeSource {
     Eager { source: BaseBatchStream },
 
     /// MOR merge path. Drives the buffer's vectorized
-    /// `next_merged_base_batch` + `drain_log_only_inserts` methods:
-    /// one emitted chunk per non-empty base source batch, plus a single
-    /// final chunk for log-only inserts (keys never matched by any base row).
+    /// `merge_base_batch` + `drain_log_only_inserts` methods:
+    /// one emitted chunk per non-empty base source batch, then the log-only
+    /// inserts (keys never matched by any base row) in
+    /// [`DEFAULT_BATCH_SIZE`]-row chunks until the drain reports exhaustion.
     ///
-    /// Chunk size is determined by the base source's own row-group cadence,
-    /// so there is no batch-size knob on this path.
+    /// Chunk size follows the base source's own batches, so there is no
+    /// batch-size knob on this path.
     Buffered {
         buffer: Box<dyn HoodieFileGroupRecordBuffer>,
         /// The base file, pulled one batch at a time. Owned here rather than by
@@ -138,7 +141,9 @@ enum MergeSource {
         /// name drift, and as the schema for `records_to_batch` when the
         /// final drain emits log-only inserts).
         merge_schema: SchemaRef,
-        /// Three-state machine: BaseScanning → DrainingLogInserts → Done.
+        /// Two-state machine: BaseScanning → DrainingLogInserts. The terminal
+        /// state is the stream's own sticky `done` flag, set on exhaustion or
+        /// error.
         state: BufferedState,
     },
 }
@@ -147,9 +152,11 @@ enum MergeSource {
 enum BufferedState {
     /// Pulling base batches from the source and merging against the log map.
     BaseScanning,
-    /// Base source exhausted; flush log-only inserts on the next call.
-    /// (Single transition state — one call produces the final batch, then
-    /// the iterator moves to `Done`.)
+    /// Base source exhausted; drain log-only inserts. Each call to the
+    /// buffer's `drain_log_only_inserts` yields one bounded chunk, and the
+    /// stream stays in this state until the drain returns `Ok(None)` —
+    /// collapsing it to a single call would silently drop every insert past
+    /// the first chunk.
     DrainingLogInserts,
 }
 

--- a/crates/core/src/file_group/reader_v2/merge_iterator.rs
+++ b/crates/core/src/file_group/reader_v2/merge_iterator.rs
@@ -1188,6 +1188,80 @@ mod tests {
         );
     }
 
+    /// A concurrent task makes progress *while* the merge runs, chunk by chunk.
+    ///
+    /// This is the non-blocking property, and it is separate from laziness: a
+    /// merge could pull one batch at a time and still hold its executor thread
+    /// for the whole read, which on a single-worker runtime starves everything
+    /// else on it. The base stream here awaits before yielding each batch, which
+    /// is what a ranged read looks like to the runtime; the assertion is that
+    /// the merge propagates that await rather than blocking through it.
+    ///
+    /// `current_thread` on purpose - one worker, so the ticker can only advance
+    /// if the merge actually gives the thread up. On a multi-threaded runtime
+    /// the ticker would run on another worker and prove nothing.
+    ///
+    /// The interleaving is checked per chunk rather than once at the end, and
+    /// that is what makes it discriminating: a merge that awaited the whole base
+    /// up front and then served chunks without awaiting again passes a single
+    /// end-of-read check and fails this one at chunk 2 (`4 -> 4`).
+    ///
+    /// The severe violation - blocking the thread *through* the base await -
+    /// shows up as a deadlock rather than a failed assertion, since on one
+    /// worker the pending read can never be rescheduled. Verified by mutation:
+    /// the test hangs instead of failing. Detected either way, but a hang is a
+    /// worse signal, so the per-chunk check above is what carries this test.
+    #[tokio::test]
+    async fn merge_stream_lets_other_tasks_run_between_chunks() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let schema = small_schema();
+        let ticks = Arc::new(AtomicUsize::new(0));
+        let t = ticks.clone();
+        let ticker = tokio::spawn(async move {
+            loop {
+                t.fetch_add(1, Ordering::SeqCst);
+                tokio::task::yield_now().await;
+            }
+        });
+
+        let batches: Vec<Result<RecordBatch>> = (0..4)
+            .map(|i| Ok(batch(schema.clone(), &["k"], &[i])))
+            .collect();
+        // Awaits before handing over each batch, standing in for the ranged read
+        // a real base source performs.
+        let base = futures::stream::iter(batches)
+            .then(|b| async move {
+                tokio::task::yield_now().await;
+                b
+            })
+            .boxed();
+
+        let mut merge = FileGroupMergeStream::new_buffered(
+            MockBuffer::boxed(vec![], UpdateStats::default()),
+            base,
+            schema.clone(),
+            schema,
+            None,
+            new_stream_stats_handle(),
+        );
+
+        let mut seen = 0usize;
+        let mut chunks = 0usize;
+        while merge.next_chunk().await.is_some() {
+            chunks += 1;
+            let now = ticks.load(Ordering::SeqCst);
+            assert!(
+                now > seen,
+                "the ticker did not advance while chunk {chunks} was produced ({seen} -> \
+                 {now}); the merge held the only worker thread instead of awaiting"
+            );
+            seen = now;
+        }
+        assert_eq!(chunks, 4, "one chunk per base batch");
+        ticker.abort();
+    }
+
     // ---- Error/termination spine ----
 
     /// A buffer whose `has_next` always errors — pins the iterator's

--- a/crates/core/src/file_group/reader_v2/merge_iterator.rs
+++ b/crates/core/src/file_group/reader_v2/merge_iterator.rs
@@ -353,10 +353,26 @@ impl FileGroupMergeStream {
 
     /// Produce the next merged chunk, or `None` once the merge is complete.
     ///
-    /// The only await is the base-file pull. Everything else — the merge
-    /// kernel, the drain, the output projection — is synchronous work on data
-    /// already in memory, so nothing here holds a lock or a borrow across the
-    /// await beyond the source itself.
+    /// The only await is the base-file pull. Everything else — the merge kernel,
+    /// the drain, the output projection — is synchronous work on data already in
+    /// memory, so nothing here holds a lock or a borrow across the await beyond
+    /// the source itself.
+    ///
+    /// That synchronous work is deliberately *not* moved to a blocking pool,
+    /// which is the question a reader of this arrives with. It was measured
+    /// rather than assumed: merging one chunk takes 0.4-1.1 ms, and 5.7-6.1 ms
+    /// once the merge map has spilled, so the spill is a ~6x amplifier on work
+    /// that is already synchronous and of the same kind. Handing each chunk to
+    /// `spawn_blocking` would reintroduce the sync/async crossing this type
+    /// exists to remove, and cost a task hop per chunk, to shave a
+    /// single-digit-millisecond poll — which is what a scan or join operator
+    /// costs anyway. What keeps that true is the chunk bound, not this comment:
+    /// see `MERGE_CHUNK_ROWS`, since the cost is linear in a chunk's rows.
+    ///
+    /// The one thing the measurement does not cover: it reads a spill file that
+    /// was just written, so the page cache is warm and the disk component is
+    /// understated. A cold spill file would be slower, though still bounded by
+    /// the same chunk size.
     ///
     /// Sticky: after an error, or after the merge completes, every later call
     /// returns `None`.

--- a/crates/core/src/file_group/reader_v2/merged_log_record_reader.rs
+++ b/crates/core/src/file_group/reader_v2/merged_log_record_reader.rs
@@ -422,6 +422,8 @@ impl Builder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::file_group::log_file::log_block::BlockType;
+    use crate::file_group::reader_v2::MAX_INSTANT_TIME;
     use crate::file_group::reader_v2::buffer::key_based::KeyBasedFileGroupRecordBuffer;
     use crate::storage::util::parse_uri;
 
@@ -458,6 +460,121 @@ mod tests {
             KeyBasedFileGroupRecordBuffer::new(ctx, "COMMIT_TIME_ORDERING".to_string(), false)
                 .unwrap(),
         )
+    }
+
+    /// Copy a log-file fixture into a temp dir, so a test can rewrite its bytes.
+    fn fixture_copy() -> (tempfile::TempDir, String) {
+        let file_name =
+            ".ff32ab89-5ad0-4968-83b4-89a34c95d32f-0_20250316025816068.log.1_0-54-122".to_string();
+        let src = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/data/log_files/valid_log_avro_data")
+            .join(&file_name);
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::copy(&src, dir.path().join(&file_name)).unwrap();
+        (dir, file_name)
+    }
+
+    fn storage_over(dir: &tempfile::TempDir) -> Arc<Storage> {
+        Storage::new_with_base_url(parse_uri(dir.path().to_str().unwrap()).unwrap()).unwrap()
+    }
+
+    /// Overwrite the payload of every data block, leaving the magic, lengths,
+    /// header and footer intact — well-formed on the outside, undecodable on the
+    /// inside, which is what a block from a rolled-back instant can look like.
+    /// Returns the instant time the blocks carry.
+    async fn make_payloads_undecodable(dir: &tempfile::TempDir, file_name: &str) -> String {
+        let configs = Arc::new(crate::config::HudiConfigs::new(
+            std::collections::HashMap::<String, String>::new(),
+        ));
+        let mut reader = crate::file_group::log_file::reader::LogFileReader::new_streaming(
+            configs,
+            storage_over(dir),
+            file_name,
+        )
+        .await
+        .unwrap();
+        let blocks = reader.read_all_blocks_metadata_only().unwrap();
+
+        let path = dir.path().join(file_name);
+        let mut bytes = std::fs::read(&path).unwrap();
+        let mut instant = String::new();
+        for block in &blocks {
+            if !matches!(
+                block.block_type,
+                BlockType::AvroData | BlockType::ParquetData
+            ) {
+                continue;
+            }
+            instant = block.instant_time().unwrap().to_string();
+            let location = &block.deferred_content.as_ref().unwrap().location;
+            // The content range opens with the 8-byte content-length field, which
+            // inflation reads back, so only the bytes after it are overwritten.
+            let payload_start = location.content_position
+                + if block.format_version.has_content_length() {
+                    8
+                } else {
+                    0
+                };
+            let end = (location.content_position + location.content_length) as usize;
+            bytes[payload_start as usize..end].fill(0xFF);
+        }
+        assert!(!instant.is_empty(), "fixture must carry a data block");
+        std::fs::write(&path, &bytes).unwrap();
+        instant
+    }
+
+    async fn scan_with(
+        dir: &tempfile::TempDir,
+        file_name: &str,
+        latest_instant_time: &str,
+    ) -> Result<HoodieMergedLogRecordReader> {
+        HoodieMergedLogRecordReader::new_builder()
+            .with_reader_context(make_test_reader_context())
+            .with_storage(storage_over(dir))
+            .with_log_files(vec![file_name.to_string()])
+            .with_latest_instant_time(latest_instant_time.to_string())
+            .with_record_buffer(make_test_buffer())
+            .with_force_full_scan(true)
+            .build()
+            .await
+    }
+
+    /// The undecodable payload is genuinely fatal when a gate admits its instant.
+    /// Pairs with the test below: without this one, that test could pass because
+    /// the bytes still decode rather than because the gate ran first.
+    #[tokio::test]
+    async fn test_undecodable_block_fails_the_read_when_admitted() {
+        let (dir, file_name) = fixture_copy();
+        scan_with(&dir, &file_name, MAX_INSTANT_TIME)
+            .await
+            .expect("the intact fixture reads");
+
+        make_payloads_undecodable(&dir, &file_name).await;
+        assert!(
+            scan_with(&dir, &file_name, MAX_INSTANT_TIME).await.is_err(),
+            "an admitted block with an undecodable payload must fail the read"
+        );
+    }
+
+    /// A block that cannot be decoded, inside an instant the gates discard, does
+    /// not fail the read: Pass 1 walks headers, so a block that is never admitted
+    /// is never fetched or decoded.
+    #[tokio::test]
+    async fn test_undecodable_block_in_a_discarded_instant_does_not_fail_the_read() {
+        let (dir, file_name) = fixture_copy();
+        let instant = make_payloads_undecodable(&dir, &file_name).await;
+
+        // Gate 2 discards any non-command block above `latest_instant_time`.
+        let below_every_instant = "0".repeat(instant.len());
+        let reader = scan_with(&dir, &file_name, &below_every_instant)
+            .await
+            .expect("a discarded block must not fail the read");
+        assert_eq!(reader.get_total_log_files(), 1);
+        assert_eq!(
+            reader.get_num_merged_records_in_log(),
+            0,
+            "the discarded block contributes no records"
+        );
     }
 
     /// Java: TestHoodieMergedLogRecordReader — builder validation

--- a/crates/core/src/file_group/reader_v2/merged_log_record_reader.rs
+++ b/crates/core/src/file_group/reader_v2/merged_log_record_reader.rs
@@ -493,7 +493,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let blocks = reader.read_all_blocks_metadata_only().unwrap();
+        let blocks = reader.read_all_blocks_metadata_only().await.unwrap();
 
         let path = dir.path().join(file_name);
         let mut bytes = std::fs::read(&path).unwrap();

--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -18,7 +18,6 @@
  */
 //! This module is responsible for interacting with the storage layer.
 
-use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -57,45 +56,6 @@ pub type RowFilterBuilder = Arc<
         + Send
         + Sync,
 >;
-
-#[allow(dead_code)]
-/// Runtime that owns every ranged object-store read issued from synchronous
-/// code.
-///
-/// A log file is read through `std::io::Read`, which is synchronous, while
-/// `object_store` is async. Bridging the two needs somewhere to drive the
-/// future, and the obvious choices do not work: the sync read can be reached
-/// from inside another runtime, where `block_on` panics with "Cannot start a
-/// runtime from within a runtime", and a runtime built per read would take
-/// hyper's connection dispatcher down with it when dropped, failing every
-/// subsequent request against the same cached store.
-///
-/// So reads are spawned here and the calling thread waits on a channel. The
-/// runtime outlives any individual caller, which is what keeps the dispatcher
-/// alive.
-pub static OBJECT_STORE_RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
-    tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(OBJECT_STORE_RUNTIME_WORKERS)
-        .enable_all()
-        .thread_name(OBJECT_STORE_RUNTIME_THREAD_NAME)
-        .build()
-        .expect("the object-store runtime must build")
-});
-
-/// Worker threads on [`OBJECT_STORE_RUNTIME`].
-///
-/// This runtime only drives object-store I/O, which is latency-bound rather
-/// than CPU-bound, so the count is a fixed small number rather than a function
-/// of the machine's cores: a host with 96 of them has no more requests in
-/// flight than one with 8, and sizing to cores would spend threads on nothing.
-pub(crate) const OBJECT_STORE_RUNTIME_WORKERS: usize = 8;
-
-/// Thread-name prefix for [`OBJECT_STORE_RUNTIME`]'s workers.
-///
-/// Load-bearing, not cosmetic: it is how a blocking bridge recognises that it is
-/// about to block one of its own workers — see
-/// [`in_object_store_runtime`](crate::storage::reader::in_object_store_runtime).
-pub(crate) const OBJECT_STORE_RUNTIME_THREAD_NAME: &str = "hudi-rs-objstore";
 
 #[derive(Clone, Debug)]
 pub struct Storage {

--- a/crates/core/src/storage/reader.rs
+++ b/crates/core/src/storage/reader.rs
@@ -17,11 +17,10 @@
  * under the License.
  */
 use crate::config::HudiConfigs;
-use crate::storage::{OBJECT_STORE_RUNTIME, OBJECT_STORE_RUNTIME_THREAD_NAME};
 use bytes::Bytes;
 use object_store::path::Path as ObjPath;
 use object_store::{ObjectMeta, ObjectStore};
-use std::io::{Error, ErrorKind, Read, Result, Seek, SeekFrom};
+use std::io::{Error, ErrorKind, Result};
 use std::sync::Arc;
 
 /// How much of a file a streaming reader keeps resident at once, when the table
@@ -73,67 +72,21 @@ pub fn stream_window_size(hudi_configs: &HudiConfigs) -> Result<u64> {
     }
 }
 
-/// Whether the calling thread is one of [`OBJECT_STORE_RUNTIME`]'s workers.
-///
-/// Recognised by thread name, which is the only handle available: a worker has no
-/// marker a caller can query, and `Handle::try_current()` cannot be compared to a
-/// `Runtime`'s own handle.
-pub(crate) fn in_object_store_runtime() -> bool {
-    std::thread::current()
-        .name()
-        .is_some_and(|name| name.starts_with(OBJECT_STORE_RUNTIME_THREAD_NAME))
-}
-
-/// Fetch a byte range synchronously, from any context.
-///
-/// See [`OBJECT_STORE_RUNTIME`] for why the work is spawned onto a shared
-/// runtime and waited on over a channel rather than driven with `block_on`.
-///
-/// # Where this may be called from
-///
-/// A blocking-pool thread (`spawn_blocking`) or an ordinary sync thread. Both are
-/// fine: the fetch runs on [`OBJECT_STORE_RUNTIME`], so the wait always ends.
-///
-/// **Not** from an async task on a worker thread — that blocks the worker for a
-/// whole round trip, starving every other task on that runtime, which is the
-/// "no blocking I/O in async" rule. Nothing here can detect that in general, so
-/// it remains the caller's obligation.
-///
-/// **Never** from an [`OBJECT_STORE_RUNTIME`] worker: the wait would depend on a
-/// task that can only be scheduled on the workers, and with enough concurrent
-/// callers every worker blocks and none of their tasks can ever run — a genuine
-/// deadlock rather than mere starvation. That case *is* detectable, and is
-/// refused below with a message rather than left to hang. It is unreachable
-/// today; the guard is here so wiring a new caller cannot make it reachable
-/// silently.
-fn get_range_blocking(
+/// Fetch `[offset, offset + length)` in one ranged request.
+async fn get_range(
     object_store: &Arc<dyn ObjectStore>,
     location: &ObjPath,
     offset: u64,
     length: u64,
 ) -> Result<Bytes> {
-    if in_object_store_runtime() {
-        return Err(Error::other(format!(
-            "a blocking ranged read was issued from an object-store runtime worker, which would \
-             deadlock: the wait can only be satisfied by a task on that same runtime. Drive this \
-             read from a blocking-pool thread instead (path '{location}')"
-        )));
-    }
     let end = offset.checked_add(length).ok_or_else(|| {
         Error::other(format!(
             "ranged read offset {offset} + length {length} overflows u64"
         ))
     })?;
-    let store = object_store.clone();
-    let location = location.clone();
-    let (tx, rx) = std::sync::mpsc::sync_channel(1);
-    OBJECT_STORE_RUNTIME.spawn(async move {
-        let res = store.get_range(&location, offset..end).await;
-        // The receiver is gone only if the caller panicked.
-        let _ = tx.send(res);
-    });
-    rx.recv()
-        .map_err(|_| Error::other("ranged object-store read task dropped"))?
+    object_store
+        .get_range(location, offset..end)
+        .await
         .map_err(|e| Error::other(format!("ranged object-store read failed: {e}")))
 }
 
@@ -158,8 +111,8 @@ impl LogBlockFetcher {
     }
 
     /// Read `[offset, offset + length)` in one ranged request.
-    pub fn read_content(&self, offset: u64, length: u64) -> Result<Bytes> {
-        get_range_blocking(&self.object_store, &self.location, offset, length)
+    pub async fn read_content(&self, offset: u64, length: u64) -> Result<Bytes> {
+        get_range(&self.object_store, &self.location, offset, length).await
     }
 
     /// The file these ranges are read from, so a caller batching across blocks
@@ -174,10 +127,6 @@ impl LogBlockFetcher {
     /// request, so a run of adjacent blocks costs one round trip rather than
     /// one each. Reading them one at a time is the same bytes and many more
     /// round trips, which is what dominates on object storage.
-    ///
-    /// Async, unlike [`Self::read_content`]: the caller is expected to have a
-    /// runtime, and going through the blocking bridge here would serialise the
-    /// very requests this exists to overlap.
     pub async fn read_contents(&self, ranges: &[std::ops::Range<u64>]) -> Result<Vec<Bytes>> {
         self.object_store
             .get_ranges(&self.location, ranges)
@@ -198,6 +147,11 @@ impl LogBlockFetcher {
 /// small file or a full read wants. [`StorageReader::new_streaming`] fetches
 /// bounded windows as the cursor moves, so walking a large file's structure
 /// never holds more than one window.
+///
+/// Reads are `async` inherent methods rather than `std::io::Read`: every byte
+/// comes from an object store, and a synchronous `Read` over an async store can
+/// only be had by blocking some thread on a runtime, which is a contract the
+/// compiler cannot check and every caller has to be told about.
 #[derive(Debug)]
 pub struct StorageReader {
     object_store: Arc<dyn ObjectStore>,
@@ -245,7 +199,7 @@ impl StorageReader {
     /// `window_size` is how much is fetched per refill and therefore the peak
     /// this reader buffers; see [`stream_window_size`] for where it comes from.
     ///
-    /// Nothing is read until the first [`Read::read`].
+    /// Nothing is read until the first read.
     pub fn new_streaming(
         object_store: Arc<dyn ObjectStore>,
         object_meta: ObjectMeta,
@@ -269,62 +223,113 @@ impl StorageReader {
         LogBlockFetcher::new(self.object_store.clone(), self.location.clone())
     }
 
-    /// Refill the window if the cursor has moved outside it. No-op past the end.
-    fn ensure_window(&mut self) -> Result<()> {
-        if self.pos >= self.file_len {
-            return Ok(());
-        }
-        let in_window = self.pos >= self.window_start
-            && self.pos < self.window_start + self.window.len() as u64;
-        if in_window {
-            return Ok(());
-        }
-        let start = self.pos;
-        let end = (start + self.window_size).min(self.file_len);
-        self.window = get_range_blocking(&self.object_store, &self.location, start, end - start)?;
-        self.window_start = start;
+    /// Length of the whole file, known without reading any of it.
+    pub fn file_len(&self) -> u64 {
+        self.file_len
+    }
+
+    /// Where the cursor sits.
+    pub fn position(&self) -> u64 {
+        self.pos
+    }
+
+    /// Move the cursor. No I/O, and a position past the end of the file is
+    /// allowed: it fails at the next read, which is what lets a caller skip past
+    /// a block's content without paying for it.
+    pub fn seek_to(&mut self, pos: u64) {
+        self.pos = pos;
+    }
+
+    /// Whether `[start, end)` lies inside the resident window.
+    fn window_covers(&self, start: u64, end: u64) -> bool {
+        start >= self.window_start && end <= self.window_start + self.window.len() as u64
+    }
+
+    /// Fetch a window starting at the cursor.
+    async fn fill_window(&mut self) -> Result<()> {
+        let end = self.pos.saturating_add(self.window_size).min(self.file_len);
+        self.window =
+            get_range(&self.object_store, &self.location, self.pos, end - self.pos).await?;
+        self.window_start = self.pos;
         Ok(())
     }
-}
 
-impl Read for StorageReader {
-    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-        if buf.is_empty() || self.pos >= self.file_len {
-            return Ok(0);
+    /// Read the next `len` bytes, advancing the cursor.
+    ///
+    /// A read that would run past the end of the file is
+    /// [`ErrorKind::UnexpectedEof`] and consumes nothing, which is how a caller
+    /// walking blocks recognises the end of the last one.
+    ///
+    /// Nothing is copied when the bytes are already resident: both the whole-file
+    /// buffer and the streaming window hand out `Bytes` slices of themselves.
+    pub async fn read_bytes(&mut self, len: u64) -> Result<Bytes> {
+        if len == 0 {
+            return Ok(Bytes::new());
         }
-        if let Some(ref whole) = self.whole {
-            let start = self.pos as usize;
-            let end = (start + buf.len()).min(whole.len());
-            let n = end - start;
-            buf[..n].copy_from_slice(&whole[start..end]);
-            self.pos += n as u64;
-            return Ok(n);
-        }
-        self.ensure_window()?;
-        let off = (self.pos - self.window_start) as usize;
-        let avail = self.window.len() - off;
-        let n = avail.min(buf.len());
-        buf[..n].copy_from_slice(&self.window[off..off + n]);
-        self.pos += n as u64;
-        Ok(n)
-    }
-}
-
-impl Seek for StorageReader {
-    fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
-        let new_pos = match pos {
-            SeekFrom::Start(p) => p as i128,
-            SeekFrom::End(p) => self.file_len as i128 + p as i128,
-            SeekFrom::Current(p) => self.pos as i128 + p as i128,
-        };
-        if new_pos < 0 {
+        let end = self.pos.checked_add(len).ok_or_else(|| {
+            Error::other(format!(
+                "read of {len} byte(s) at offset {} overflows u64",
+                self.pos
+            ))
+        })?;
+        if end > self.file_len {
             return Err(Error::new(
-                ErrorKind::InvalidInput,
-                "seek to a negative position",
+                ErrorKind::UnexpectedEof,
+                format!(
+                    "read of {len} byte(s) at offset {} runs past the end of '{}' ({} bytes)",
+                    self.pos, self.location, self.file_len
+                ),
             ));
         }
-        self.pos = new_pos as u64;
-        Ok(self.pos)
+
+        if let Some(whole) = self.whole.as_ref() {
+            let bytes = whole.slice(self.pos as usize..end as usize);
+            self.pos = end;
+            return Ok(bytes);
+        }
+
+        // Longer than a window: fetch exactly this range and leave the window
+        // alone, rather than growing what the reader keeps resident to fit one
+        // read. A log block's content can be larger than the window a caller
+        // tuned for sweeping headers, and it has to be contiguous to decode.
+        if len > self.window_size {
+            let bytes = get_range(&self.object_store, &self.location, self.pos, len).await?;
+            self.pos = end;
+            return Ok(bytes);
+        }
+
+        if !self.window_covers(self.pos, end) {
+            // A refilled window starts at the cursor and runs `window_size`
+            // bytes or to the end of the file, whichever comes first, so it
+            // covers `len` — the end-of-file case was refused above.
+            self.fill_window().await?;
+        }
+        let off = (self.pos - self.window_start) as usize;
+        let resident = self.window.len() - off;
+        if resident < len as usize {
+            return Err(Error::new(
+                ErrorKind::UnexpectedEof,
+                format!(
+                    "a window fetched at offset {} holds {resident} byte(s), short of the {len} \
+                     asked for: '{}' was truncated while it was being read",
+                    self.pos, self.location
+                ),
+            ));
+        }
+        let bytes = self.window.slice(off..off + len as usize);
+        self.pos = end;
+        Ok(bytes)
+    }
+
+    /// Fill `buf` from the cursor, advancing it. See [`Self::read_bytes`] for
+    /// what happens at the end of the file.
+    pub async fn read_exact(&mut self, buf: &mut [u8]) -> Result<()> {
+        if buf.is_empty() {
+            return Ok(());
+        }
+        let bytes = self.read_bytes(buf.len() as u64).await?;
+        buf.copy_from_slice(&bytes);
+        Ok(())
     }
 }
 
@@ -336,7 +341,9 @@ mod tests {
 
     /// A temp file of `len` bytes with a repeating pattern, plus the store and
     /// metadata needed to open it either way.
-    fn make_store(len: usize) -> (Arc<dyn ObjectStore>, ObjectMeta, Vec<u8>, tempfile::TempDir) {
+    async fn make_store(
+        len: usize,
+    ) -> (Arc<dyn ObjectStore>, ObjectMeta, Vec<u8>, tempfile::TempDir) {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("data.bin");
         let bytes: Vec<u8> = (0..len).map(|i| (i % 251) as u8).collect();
@@ -347,109 +354,72 @@ mod tests {
 
         let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new_with_prefix(&dir).unwrap());
         let location = ObjPath::from("data.bin");
-        let meta = OBJECT_STORE_RUNTIME
-            .block_on(async { store.head(&location).await })
-            .unwrap();
+        let meta = store.head(&location).await.unwrap();
         (store, meta, bytes, dir)
     }
 
-    fn read_all(reader: &mut StorageReader, chunk: usize) -> Vec<u8> {
+    /// Read the whole file in `chunk`-sized reads.
+    async fn read_all(reader: &mut StorageReader, chunk: u64) -> Vec<u8> {
         let mut out = Vec::new();
-        let mut buf = vec![0u8; chunk];
         loop {
-            let n = reader.read(&mut buf).unwrap();
-            if n == 0 {
-                break;
+            let want = chunk.min(reader.file_len() - reader.position());
+            if want == 0 {
+                return out;
             }
-            out.extend_from_slice(&buf[..n]);
+            out.extend_from_slice(&reader.read_bytes(want).await.unwrap());
         }
-        out
-    }
-
-    /// A blocking ranged read issued from an object-store runtime worker must be
-    /// refused, because it would deadlock rather than merely block: the wait can
-    /// only be satisfied by a task on the very runtime whose worker is waiting.
-    ///
-    /// Asserted from inside the runtime, since the guard keys off the calling
-    /// thread. The negative control matters as much as the positive: an ordinary
-    /// thread must still be allowed through, or the guard would break every real
-    /// caller.
-    #[test]
-    fn test_blocking_read_from_the_object_store_runtime_is_refused() {
-        let len = 4096;
-        let (store, meta, expected, _dir) = make_store(len);
-
-        // Positive: on a worker of that runtime, refused with a message naming
-        // the hazard.
-        let err = OBJECT_STORE_RUNTIME
-            .block_on(async {
-                let store = store.clone();
-                let location = meta.location.clone();
-                tokio::task::spawn(async move {
-                    assert!(
-                        in_object_store_runtime(),
-                        "a spawned task must run on an object-store worker"
-                    );
-                    get_range_blocking(&store, &location, 0, 16).err()
-                })
-                .await
-                .unwrap()
-            })
-            .expect("must be refused, not attempted");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("deadlock"),
-            "the error must say why it refused, got: {msg}"
-        );
-
-        // Negative control: an ordinary thread reads normally.
-        assert!(!in_object_store_runtime());
-        let bytes = get_range_blocking(&store, &meta.location, 0, 16).unwrap();
-        assert_eq!(bytes.as_ref(), &expected[..16]);
     }
 
     /// The two modes have to be indistinguishable to a caller. A streaming read
     /// serves out of a window and refills as the cursor advances, which is where
     /// an off-by-one would show up.
-    #[test]
-    fn test_streaming_read_matches_eager_across_window_refills() {
+    #[tokio::test]
+    async fn test_streaming_read_matches_eager_across_window_refills() {
         // Larger than one window, so the read spans several refills.
         let len = (DEFAULT_STREAM_WINDOW_SIZE as usize) * 2 + 4096;
-        let (store, meta, expected, _dir) = make_store(len);
+        let (store, meta, expected, _dir) = make_store(len).await;
 
-        let mut eager = OBJECT_STORE_RUNTIME
-            .block_on(StorageReader::new(store.clone(), meta.clone()))
+        let mut eager = StorageReader::new(store.clone(), meta.clone())
+            .await
             .unwrap();
-        assert_eq!(read_all(&mut eager, 64 * 1024), expected);
+        assert_eq!(read_all(&mut eager, 64 * 1024).await, expected);
 
         let mut streaming = StorageReader::new_streaming(store, meta, DEFAULT_STREAM_WINDOW_SIZE);
-        assert_eq!(read_all(&mut streaming, 64 * 1024), expected);
+        assert_eq!(read_all(&mut streaming, 64 * 1024).await, expected);
     }
 
-    /// Seeking backwards has to refill, and a seek past the end has to read
-    /// nothing rather than fetch. Both are what a block scan does when it walks
-    /// back to a header or jumps past a block it is skipping.
-    #[test]
-    fn test_streaming_seek_backwards_and_past_end() {
+    /// Seeking backwards has to refill, and a read that runs off the end has to
+    /// fail rather than come back short. Both are what a block scan does when it
+    /// walks back to a header or jumps past a block it is skipping.
+    #[tokio::test]
+    async fn test_streaming_seek_backwards_and_past_end() {
         let len = (DEFAULT_STREAM_WINDOW_SIZE as usize) + 1024;
-        let (store, meta, expected, _dir) = make_store(len);
+        let (store, meta, expected, _dir) = make_store(len).await;
         let mut reader = StorageReader::new_streaming(store, meta, DEFAULT_STREAM_WINDOW_SIZE);
 
         // Force a window near the end, then walk back to the start.
-        reader.seek(SeekFrom::Start(len as u64 - 512)).unwrap();
-        let mut tail = [0u8; 512];
-        reader.read_exact(&mut tail).unwrap();
+        reader.seek_to(len as u64 - 512);
+        let tail = reader.read_bytes(512).await.unwrap();
         assert_eq!(&tail[..], &expected[len - 512..]);
 
-        reader.seek(SeekFrom::Start(0)).unwrap();
-        let mut head = [0u8; 512];
-        reader.read_exact(&mut head).unwrap();
+        reader.seek_to(0);
+        let head = reader.read_bytes(512).await.unwrap();
         assert_eq!(&head[..], &expected[..512]);
 
-        reader.seek(SeekFrom::End(0)).unwrap();
-        assert_eq!(reader.read(&mut [0u8; 16]).unwrap(), 0);
-
-        assert!(reader.seek(SeekFrom::Current(-(len as i64) - 10)).is_err());
+        // At the end of the file, and past it, a read is refused rather than
+        // short — a caller walking blocks reads the refusal as the end.
+        reader.seek_to(len as u64);
+        assert_eq!(
+            reader.read_bytes(16).await.unwrap_err().kind(),
+            ErrorKind::UnexpectedEof
+        );
+        reader.seek_to(len as u64 * 2);
+        assert_eq!(
+            reader.read_bytes(1).await.unwrap_err().kind(),
+            ErrorKind::UnexpectedEof
+        );
+        // Nothing was consumed, so the cursor still says where the caller was.
+        assert_eq!(reader.position(), len as u64 * 2);
     }
 
     /// Absent config reads the same amount Hudi would: 16 MiB.
@@ -466,22 +436,48 @@ mod tests {
     /// The whole point of the knob: a caller tuning memory down must actually
     /// get less, not the default. Reading a file larger than the window they
     /// asked for proves the window, not just the field.
-    #[test]
-    fn test_configured_window_is_used_for_refills() {
+    #[tokio::test]
+    async fn test_configured_window_is_used_for_refills() {
         let window = 4096u64;
         let configs = HudiConfigs::new([(CONFIG_DFS_BUFFER_MAX_SIZE, window.to_string())]);
         assert_eq!(stream_window_size(&configs).unwrap(), window);
 
         let len = (window as usize) * 3 + 17;
-        let (store, meta, expected, _dir) = make_store(len);
+        let (store, meta, expected, _dir) = make_store(len).await;
         let mut reader = StorageReader::new_streaming(store, meta, window);
 
         // Same bytes as an eager read, across several refills of the smaller
         // window.
-        assert_eq!(read_all(&mut reader, 512), expected);
+        assert_eq!(read_all(&mut reader, 512).await, expected);
         assert!(
             reader.window.len() as u64 <= window,
             "a refill fetched {} bytes for a {window}-byte window",
+            reader.window.len()
+        );
+    }
+
+    /// A read longer than the window is served whole and without leaving that
+    /// much resident. This is the case a log block's content hits: it can be
+    /// larger than the window tuned for sweeping headers, and it has to be
+    /// contiguous to decode.
+    #[tokio::test]
+    async fn test_read_longer_than_the_window_does_not_grow_it() {
+        let window = 4096u64;
+        let len = (window as usize) * 4;
+        let (store, meta, expected, _dir) = make_store(len).await;
+        let mut reader = StorageReader::new_streaming(store, meta, window);
+
+        // Prime a window, so the oversized read below has one to leave alone.
+        reader.read_bytes(16).await.unwrap();
+        assert_eq!(reader.window.len() as u64, window);
+
+        reader.seek_to(1000);
+        let big = reader.read_bytes(window * 2).await.unwrap();
+        assert_eq!(&big[..], &expected[1000..1000 + (window * 2) as usize]);
+        assert_eq!(reader.position(), 1000 + window * 2);
+        assert!(
+            reader.window.len() as u64 <= window,
+            "an oversized read must not grow the resident window, now {} bytes",
             reader.window.len()
         );
     }
@@ -505,13 +501,17 @@ mod tests {
 
     /// A block fetcher reads only its own range, and does so without the file
     /// ever being resident.
-    #[test]
-    fn test_block_fetcher_reads_only_its_range() {
+    #[tokio::test]
+    async fn test_block_fetcher_reads_only_its_range() {
         let len = 8192;
-        let (store, meta, expected, _dir) = make_store(len);
+        let (store, meta, expected, _dir) = make_store(len).await;
         let reader = StorageReader::new_streaming(store, meta, DEFAULT_STREAM_WINDOW_SIZE);
 
-        let content = reader.block_fetcher().read_content(1000, 256).unwrap();
+        let content = reader
+            .block_fetcher()
+            .read_content(1000, 256)
+            .await
+            .unwrap();
         assert_eq!(&content[..], &expected[1000..1256]);
     }
 }

--- a/crates/core/src/storage/reader.rs
+++ b/crates/core/src/storage/reader.rs
@@ -161,6 +161,35 @@ impl LogBlockFetcher {
     pub fn read_content(&self, offset: u64, length: u64) -> Result<Bytes> {
         get_range_blocking(&self.object_store, &self.location, offset, length)
     }
+
+    /// The file these ranges are read from, so a caller batching across blocks
+    /// can group them by the file they belong to.
+    pub fn location(&self) -> &ObjPath {
+        &self.location
+    }
+
+    /// Read several ranges from this file in one call.
+    ///
+    /// `get_ranges` coalesces ranges that sit close together into a single
+    /// request, so a run of adjacent blocks costs one round trip rather than
+    /// one each. Reading them one at a time is the same bytes and many more
+    /// round trips, which is what dominates on object storage.
+    ///
+    /// Async, unlike [`Self::read_content`]: the caller is expected to have a
+    /// runtime, and going through the blocking bridge here would serialise the
+    /// very requests this exists to overlap.
+    pub async fn read_contents(&self, ranges: &[std::ops::Range<u64>]) -> Result<Vec<Bytes>> {
+        self.object_store
+            .get_ranges(&self.location, ranges)
+            .await
+            .map_err(|e| {
+                Error::other(format!(
+                    "batched ranged read of {} range(s) from '{}' failed: {e}",
+                    ranges.len(),
+                    self.location
+                ))
+            })
+    }
 }
 
 /// A seekable reader over a file in an object store.

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -2792,7 +2792,18 @@ mod tests {
             "both paths must return the same schema"
         );
 
-        // Same rows, not merely the same count.
+        // Same rows in the same ORDER, not merely the same multiset. Both entry
+        // points merge the base a row group at a time, so the sequence is a
+        // shared property and sorting here would stop guarding it.
+        //
+        // Honest limit: this fixture cannot yet detect a violation. The order
+        // only diverges when one base batch holds both surviving and replaced
+        // rows, and every MOR fixture in this repo updates every key, so
+        // collapsing the base on one path is invisible here — verified by
+        // mutation. `batch_boundaries_change_the_merged_row_order` in
+        // `buffer::key_based` is what discriminates; this pins the two entry
+        // points together and will discriminate given a fixture with surviving
+        // base rows across more than one batch.
         let key_of = |batches: &[RecordBatch]| {
             let mut keys: Vec<String> = Vec::new();
             for batch in batches {
@@ -2803,10 +2814,13 @@ mod tests {
                     .unwrap();
                 keys.extend((0..batch.num_rows()).map(|i| strings.value(i).to_string()));
             }
-            keys.sort();
             keys
         };
-        assert_eq!(key_of(&streamed), key_of(&eager));
+        assert_eq!(
+            key_of(&streamed),
+            key_of(&eager),
+            "the two entry points must return the same rows in the same order"
+        );
     }
 
     /// A read config that selects WHICH read to perform is dropped at table

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -2753,6 +2753,92 @@ mod tests {
     /// had a bounded row-group-at-a-time form with no caller. Asserting more than
     /// one batch is what keeps this honest: with the old fallback it was always
     /// exactly one.
+    /// A real merge-on-read read completes on a single-worker runtime without
+    /// starving a task sharing it, and returns the same rows as the eager read.
+    ///
+    /// `current_thread` is the point: one worker, so a read that monopolised it
+    /// outright - or that reached the deleted blocking bridge from inside the
+    /// runtime - would deadlock or starve the ticker completely, and this test
+    /// would hang or fail. It is a liveness check over the whole production path:
+    /// table open, log scan and gating, log-content fetch, base file, merge.
+    ///
+    /// **What it does NOT prove, established by mutation rather than assumed:**
+    /// it cannot detect blocking. Making `StorageReader::fill_window` sleep
+    /// 200 ms on the worker thread - twice, inside the log read - leaves this
+    /// test passing, because the assertions only require the ticker to advance
+    /// somewhere in each window and a real read has many other await points that
+    /// mask a blocked one. A pass here is not evidence that nothing blocks.
+    ///
+    /// What does pin non-blocking, and where:
+    ///   - the merge loop: `merge_stream_lets_other_tasks_run_between_chunks`,
+    ///     which owns every await in its base source and so cannot be masked;
+    ///   - the log read: no `block_on` remains in this crate outside test
+    ///     helpers - a structural property, asserted by no test.
+    #[tokio::test]
+    async fn test_a_merge_on_read_read_runs_on_a_single_worker_runtime() {
+        use crate::config::read::HudiReadConfig;
+        use futures::StreamExt;
+        use hudi_test::QuickstartTripsTable;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let ticks = Arc::new(AtomicUsize::new(0));
+        let counter = ticks.clone();
+        let ticker = tokio::spawn(async move {
+            loop {
+                counter.fetch_add(1, Ordering::SeqCst);
+                tokio::task::yield_now().await;
+            }
+        });
+
+        let table_path = QuickstartTripsTable::V8Trips8I3U1D.path_to_mor_avro();
+        let table = Table::new(&table_path).await.unwrap();
+        let options = ReadOptions::new()
+            .with_hudi_option(HudiReadConfig::FileGroupReaderVersion.as_ref(), "2");
+
+        let mut stream = table.read_stream(&options).await.unwrap();
+        let before_first = ticks.load(Ordering::SeqCst);
+
+        let first = stream
+            .next()
+            .await
+            .expect("the fixture yields at least one chunk")
+            .unwrap();
+        let after_first = ticks.load(Ordering::SeqCst);
+        assert!(
+            after_first > before_first,
+            "the ticker never ran while the log scan and base open happened \
+             ({before_first} -> {after_first}); that phase starved the only worker"
+        );
+
+        let mut rows = first.num_rows();
+        let mut chunks = 1usize;
+        while let Some(batch) = stream.next().await {
+            rows += batch.unwrap().num_rows();
+            chunks += 1;
+        }
+        let after_all = ticks.load(Ordering::SeqCst);
+        assert!(
+            after_all > after_first,
+            "the ticker did not advance across the remaining {} chunk(s) \
+             ({after_first} -> {after_all}); the merge held the only worker thread",
+            chunks - 1
+        );
+
+        // The read still has to be a read.
+        assert!(rows > 0, "the fixture must return rows");
+        let eager: usize = table
+            .read(&options)
+            .await
+            .unwrap()
+            .iter()
+            .map(|b| b.num_rows())
+            .sum();
+        assert_eq!(rows, eager, "the streamed read must return the same rows");
+
+        ticker.abort();
+    }
+
     #[tokio::test]
     async fn test_stream_merges_a_slice_incrementally_and_matches_the_eager_read() {
         use crate::config::read::HudiReadConfig;

--- a/crates/core/tests/table_read_tests.rs
+++ b/crates/core/tests/table_read_tests.rs
@@ -2215,11 +2215,11 @@ mod streaming_queries {
     /// incremental form, and yields the slice as a single batch.
     ///
     /// Deliberately does NOT assert a chunk count for version 2. Its cadence
-    /// follows the base file's row groups, not `batch_size` — which
-    /// `FileGroupMergeStream::new_buffered` accepts and discards (see its
-    /// `_batch_size` parameter). These fixtures are a single row group, so one
-    /// chunk is the correct answer for them, and asserting more would pin the
-    /// fixture's size rather than the reader's behavior.
+    /// follows the base read's own batch size, not `batch_size` —
+    /// `FileGroupMergeStream::new_buffered` no longer takes one. These fixtures
+    /// are a single row group smaller than that bound, so one chunk is the
+    /// correct answer for them, and asserting more would pin the fixture's
+    /// size rather than the reader's behavior.
     ///
     /// What is worth pinning here is that splitting the read into batches does
     /// not change what comes back: nothing else at table level compares the

--- a/crates/core/tests/table_read_tests.rs
+++ b/crates/core/tests/table_read_tests.rs
@@ -2216,7 +2216,7 @@ mod streaming_queries {
     ///
     /// Deliberately does NOT assert a chunk count for version 2. Its cadence
     /// follows the base file's row groups, not `batch_size` — which
-    /// `FileGroupMergeIterator::new_buffered` accepts and discards (see its
+    /// `FileGroupMergeStream::new_buffered` accepts and discards (see its
     /// `_batch_size` parameter). These fixtures are a single row group, so one
     /// chunk is the correct answer for them, and asserting more would pin the
     /// fixture's size rather than the reader's behavior.

--- a/docs/reader-spec.md
+++ b/docs/reader-spec.md
@@ -60,7 +60,9 @@ Per-slice reads — reading a single `FileSlice` the caller already selected (ty
 | `with_as_of_timestamp(ts)`   | `hoodie.read.as.of.timestamp`                | latest commit (Snapshot only)             |
 | `with_start_timestamp(ts)`   | `hoodie.read.start.timestamp`                | `19700101000000000` (Incremental only)    |
 | `with_end_timestamp(ts)`     | `hoodie.read.end.timestamp`                  | latest commit (Incremental only)          |
-| `with_batch_size(n)`         | `hoodie.read.stream.batch_size`              | `1024` (streaming only)                   |
+| `with_batch_size(n)`         | `hoodie.read.stream.batch_size`              | `1024` (streaming, base-file-only slices) |
+
+`with_batch_size` scope: it sizes the batches of a slice that has **no log files**, which is read straight from the base file. A slice **with** log files is merged, and the merge sizes its own chunks (`MERGE_CHUNK_ROWS`) so that one chunk of merging is a bounded amount of synchronous work; `hoodie.read.stream.batch_size` has no effect there. The two happen to agree at 1024 today.
 
 Timestamp resolution: all four public entry points — `read`, `read_stream`, `get_file_slices`, and `create_file_group_reader_with_options` — go through a single `prepare_reader_options` step that (1) strips timestamps irrelevant to the query type (snapshot discards `start/end_timestamp`; incremental discards `as_of_timestamp`) and (2) resolves the remaining timestamps into the `EndTimestamp` / `StartTimestamp` that `FileGroupReader` needs for log-scan bounds and commit-time filtering. Callers may set all three for convenience; only the applicable ones take effect.
 


### PR DESCRIPTION
> **Stacked on #688 → #687 → #686 → #682 → #678. Review those first.** This targets `main`, so it shows their commits alongside its own. The delta that belongs to this PR is the last commit: 3 files, +197/-4.

Third and last slice of #685, and it closes the one question the ticket left open. **The answer turned out to be "don't add `spawn_blocking`"** — so this PR is a measurement, a decision, and the bound that makes the decision hold.

## The question

#685 flagged it itself: a merge map that has spilled probes RocksDB synchronously, and once the merge is a `Stream` (#688) that probe runs on the task polling it rather than on a blocking thread. The ticket's own instruction was to measure before adding `spawn_blocking` for its own sake, "since that would reintroduce a crossing".

## The measurement

`spilled_merge_blocking_duration` (ignored; run with `--release --ignored --nocapture`) times one `merge_base_batch` against a 50 000-key log map, with and without the spill engaged:

| chunk rows | no-spill | spilled |
|---|---|---|
| 1024 | 0.4 – 1.1 ms | 5.7 – 6.1 ms |
| 8192 | 2.8 ms | 39 – 42 ms |

**The no-spill leg is the control, and it is what decides the question.** My first version of this benchmark did not have it, and without it the 40 ms figure looks like a spill problem. With it, the spill is a **~6× amplifier on work that is already synchronous and of the same kind**. Gating `spawn_blocking` on `merge_map_spilled()` (already available on the buffer trait) would treat the amplifier and leave a poll that is milliseconds long either way.

Per-chunk CPU work on the polling task is how a scan or join operator behaves. Handing each chunk to a blocking pool would reintroduce the sync/async crossing #686 and #688 removed, and cost a task hop plus a buffer move per chunk, to shave single-digit milliseconds.

## What the numbers do say

The cost is linear in a chunk's rows. That makes the chunk size the thing bounding how long one poll occupies its executor — and that bound was **inherited, not chosen**: the base read set no batch size, so it came from `parquet`'s own default of 1024 (`parquet-57.3.1`, `arrow_reader/mod.rs:171`, verified rather than assumed). That is a silent bound. A larger default upstream, or a caller passing a bigger batch size through here, multiplies every poll's cost with nothing failing.

`base_read_options` now asks for it explicitly as `MERGE_CHUNK_ROWS`.

**Behaviour change, small but real:** a parquet base file is unaffected — 1024 is what it was already getting. A **lance** base file defaulted to 8192, so its merge chunks become 1024: the same rows in more chunks, and the bound is now uniform across base-file formats instead of differing eightfold by backend. `read_data` concatenates its stream, so the single-batch path returns exactly what it did before.

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below

`test_a_merged_chunk_is_bounded_by_the_readers_own_batch_size` writes 5000 rows in **one** row group and asserts no chunk exceeds the bound — so a chunk that followed the file's layout fails it. It also asserts the option directly, and that combination is deliberate: the bound agrees with parquet's default today, so no output-level assertion can distinguish the pin from the default, while the realistic future break is a caller passing a larger size (for instance making `hoodie.read.stream.batch_size` effective on the merge path — the gap recorded in #687).

Mutation-checked, each reverted: dropping the pin, and raising it eightfold. Each fails that test.

Verified locally: format, clippy over all targets and without default features, the full `hudi-core` suite both ways (1324 lib tests, 1303 without defaults), the gold parity sweep green across all fixtures and both reader versions, and `cargo check` of `hudi-cpp` and `hudi-python`. Fork PR, so none of it ran in CI — the numbers are local.

## Limits of the measurement

Stated so nobody reads more into it than it supports:

- The spill file is freshly written, so the page cache is warm and **the disk component is understated**. A cold spill file would be slower — though still bounded by the same chunk size, which is the point of pinning it.
- One machine, single-threaded, release build. It is enough to separate "milliseconds" from "hundreds of milliseconds", which is the distinction the decision rests on, and not enough to quote as a throughput figure.

If the spilled path ever does need to come off the executor, the hook is unchanged and cheap: `merge_map_spilled()` on the buffer trait, checked once per merge rather than per chunk.

## A documented knob that does nothing on this path (found in self-review)

`docs/reader-spec.md` documents `with_batch_size(n)` -> `hoodie.read.stream.batch_size`, default 1024, and Python exposes it (`ReadOptions::with_batch_size`, `options.batch_size()`). It is honoured for a base-file-only slice and has **no effect** on a slice with log files, where the chunk follows `MERGE_CHUNK_ROWS`.

Measured, not argued: `--batch-size` 256 / 1024 / 8192 over a 1.43M-row table gives 1174 / 1164 / 1169 ms and identical rows. Flat.

This predates the stack - the value was already read and discarded - but removing the last reader of it and pinning the effective bound at a constant makes the divergence permanent, so it belongs on the record here.

**`docs/reader-spec.md` is corrected in this PR**: the row now reads `1024` (streaming, base-file-only slices), with a note that a merged slice sizes its own chunks and this knob has no effect there. The behaviour is left alone deliberately - making the knob effective on the merge path would scale how long one chunk of merging occupies its executor, linearly per the numbers above, so it is a decision of its own rather than a doc fix.

