### PR TITLE
test(core): cover every metadata partition's log blocks through reader v2

### DIFF
--- a/crates/core/src/file_group/base_file/hfile.rs
+++ b/crates/core/src/file_group/base_file/hfile.rs
@@ -1584,4 +1584,230 @@ mod tests {
         );
         Ok(())
     }
+
+    /// One metadata-table file slice: the partition it lives in, its base file if
+    /// the slice has one, and the log files written after it.
+    struct MdtSlice {
+        label: &'static str,
+        partition: &'static str,
+        base_file: Option<&'static str>,
+        log_files: &'static [&'static str],
+        /// The base instant the slice is read as of.
+        instant: &'static str,
+    }
+
+    /// Every metadata partition in the fixture that has a merge-reachable slice.
+    ///
+    /// `column_stats`, `partition_stats` and `record_index` compact to a base file
+    /// written *after* all their log files, so their pre-compaction slice has log
+    /// files and no base file at all. That is the sharper case for this change: an
+    /// HFile log block that is skipped contributes nothing, so the read has no
+    /// records and no schema to build an output from, and fails outright.
+    const MDT_SLICES: &[MdtSlice] = &[
+        MdtSlice {
+            label: "files",
+            partition: "files",
+            base_file: Some("files-0000-0_0-955-2690_00000000000000000.hfile"),
+            log_files: &[
+                ".files-0000-0_20251220210108078.log.1_10-999-2838",
+                ".files-0000-0_20251220210123755.log.1_3-1032-2950",
+                ".files-0000-0_20251220210125441.log.1_5-1057-3024",
+                ".files-0000-0_20251220210127080.log.1_3-1082-3100",
+                ".files-0000-0_20251220210128625.log.1_5-1107-3174",
+                ".files-0000-0_20251220210129235.log.1_3-1118-3220",
+                ".files-0000-0_20251220210130911.log.1_3-1149-3338",
+            ],
+            instant: "00000000000000000",
+        },
+        MdtSlice {
+            label: "column_stats",
+            partition: "column_stats",
+            base_file: None,
+            log_files: &[
+                ".col-stats-0000-0_20251220210108078.log.1_7-999-2835",
+                ".col-stats-0000-0_20251220210123755.log.1_0-1032-2947",
+                ".col-stats-0000-0_20251220210125441.log.1_2-1057-3021",
+                ".col-stats-0000-0_20251220210127080.log.1_0-1082-3097",
+                ".col-stats-0000-0_20251220210128625.log.1_2-1107-3171",
+                ".col-stats-0000-0_20251220210129235.log.1_0-1118-3217",
+                ".col-stats-0000-0_20251220210130911.log.1_0-1149-3335",
+            ],
+            instant: "00000000000000001",
+        },
+        MdtSlice {
+            label: "partition_stats",
+            partition: "partition_stats",
+            base_file: None,
+            log_files: &[
+                ".partition-stats-0000-0_20251220210108078.log.1_9-999-2837",
+                ".partition-stats-0000-0_20251220210123755.log.1_2-1032-2949",
+                ".partition-stats-0000-0_20251220210125441.log.1_4-1057-3023",
+                ".partition-stats-0000-0_20251220210127080.log.1_2-1082-3099",
+                ".partition-stats-0000-0_20251220210128625.log.1_4-1107-3173",
+                ".partition-stats-0000-0_20251220210129235.log.1_2-1118-3219",
+                ".partition-stats-0000-0_20251220210130911.log.1_2-1149-3337",
+            ],
+            instant: "00000000000000003",
+        },
+        MdtSlice {
+            label: "record_index",
+            partition: "record_index",
+            base_file: None,
+            log_files: &[".record-index-0001-0_20251220210108078.log.1_0-999-2828"],
+            instant: "00000000000000002",
+        },
+        MdtSlice {
+            label: "secondary_index",
+            partition: "secondary_index_rider_idx",
+            base_file: Some("secondary-index-rider-idx-0002-0_2-1008-2876_00000000000000004.hfile"),
+            log_files: &[".secondary-index-rider-idx-0002-0_20251220210125441.log.1_0-1057-3019"],
+            instant: "00000000000000004",
+        },
+    ];
+
+    /// Read one slice through the v2 reader, optionally without its log files.
+    async fn read_mdt_slice(slice: &MdtSlice, with_logs: bool) -> crate::Result<RecordBatch> {
+        let configs = mdt_configs();
+        let storage = Storage::new(Arc::new(HashMap::new()), configs.clone())?;
+        let logs: Vec<String> = if with_logs {
+            slice
+                .log_files
+                .iter()
+                .map(|f| format!("{}/{f}", slice.partition))
+                .collect()
+        } else {
+            vec![]
+        };
+        // The base file's path is threaded in so the format resolves per path rather
+        // than from config alone; the metadata table's base files are HFile.
+        let base_file_path = slice.base_file.map(|b| format!("{}/{b}", slice.partition));
+        let mut context =
+            resolve_reader_context(&configs, !logs.is_empty(), base_file_path.as_deref())?;
+        context.rebuild_record_context(slice.partition.to_string());
+        let mut reader = HoodieFileGroupReader::new(
+            Arc::new(context),
+            storage,
+            InputSplit::new(
+                base_file_path.clone(),
+                Some(slice.instant.to_string()),
+                logs,
+                slice.partition.to_string(),
+            ),
+            ReaderParameters::default(),
+            None,
+            None,
+        )?;
+        reader.read().await
+    }
+
+    /// The record keys of a metadata read.
+    fn record_keys(batch: &RecordBatch) -> HashSet<String> {
+        batch
+            .column_by_name("key")
+            .expect("the metadata record key column, decoded from the HFile's values")
+            .as_string::<i32>()
+            .iter()
+            .flatten()
+            .map(str::to_string)
+            .collect()
+    }
+
+    /// Every metadata partition in the fixture reads through the v2 reader with its
+    /// HFile log blocks contributing.
+    ///
+    /// One case per partition rather than the `files` partition alone, because a
+    /// skipped log block is silent: the read succeeds and returns the base file's
+    /// rows, so a `files`-only test would pass on four of the five partitions
+    /// regardless.
+    ///
+    /// Two shapes of assertion, chosen by what the slice can prove:
+    ///
+    /// - **No base file** (`column_stats`, `partition_stats`, `record_index`). Every
+    ///   record comes from a log block, so a skipped block leaves the read with no
+    ///   records and no schema to build an output from, and it fails. Returning any
+    ///   row is the assertion.
+    /// - **Base file and log files** (`files`, `secondary_index`). A skipped block
+    ///   makes the merged read identical to a base-file-only read, so the two must
+    ///   differ.
+    ///
+    /// What this pins is that the blocks are **decoded and reach the merge**, not
+    /// what the merge then does with them. The rule the merge applies is the
+    /// metadata payload's own, asserted separately by
+    /// `v2_folds_a_metadata_files_slice_like_the_metadata_table_reader`, which
+    /// compares the folded values rather than the key set.
+    #[tokio::test]
+    async fn v2_reads_every_metadata_partition_with_its_log_blocks() -> crate::Result<()> {
+        for slice in MDT_SLICES {
+            let merged = read_mdt_slice(slice, true).await.map_err(|e| {
+                StorageError::Creation(format!(
+                    "{}: reading with log files failed: {e:?}",
+                    slice.label
+                ))
+            })?;
+            let merged_keys = record_keys(&merged);
+            assert!(
+                !merged_keys.is_empty(),
+                "{}: a read whose log blocks contribute must return records",
+                slice.label
+            );
+
+            match slice.base_file {
+                None => {
+                    // Nothing but log blocks, so the rows are proof on their own.
+                }
+                Some(_) => {
+                    let base_only = read_mdt_slice(slice, false).await?;
+                    assert_ne!(
+                        (record_keys(&base_only), base_only.num_rows()),
+                        (merged_keys.clone(), merged.num_rows()),
+                        "{}: adding log files changed nothing, so the blocks were skipped",
+                        slice.label
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// The `files` partition, checked against an oracle rather than against itself.
+    ///
+    /// `MetadataTableFileGroupReader` reads the same slice through a separate
+    /// implementation that decodes to Rust structs instead of Arrow, so agreeing
+    /// with it is evidence about the records rather than about this code path.
+    /// It is the only metadata partition that reader serves, which is why the
+    /// other four are covered by the weaker assertions above.
+    #[tokio::test]
+    async fn v2_reads_a_files_slice_matching_the_metadata_table_reader() -> crate::Result<()> {
+        let slice = &MDT_SLICES[0];
+        assert_eq!(slice.label, "files", "this case reads the files partition");
+
+        let configs = mdt_configs();
+        let storage = Storage::new(Arc::new(HashMap::new()), configs.clone())?;
+        let mut fg = FileGroup::new(
+            MDT_FILES_FILE_GROUP.to_string(),
+            MDT_FILES_PARTITION.to_string(),
+        );
+        fg.add_base_file_from_name(slice.base_file.expect("the files slice has a base file"))?;
+        fg.add_log_files_from_names(slice.log_files.iter().copied())?;
+        let expected: HashSet<String> = MetadataTableFileGroupReader::new(configs, storage)
+            .read_files_partition(
+                fg.get_file_slice_as_of(MAX_INSTANT_TIME)
+                    .expect("the file group has a slice"),
+                &[],
+            )
+            .await?
+            .into_keys()
+            .collect();
+        assert!(
+            !expected.is_empty(),
+            "the oracle must return keys, or the comparison is vacuous"
+        );
+
+        assert_eq!(
+            record_keys(&read_mdt_slice(slice, true).await?),
+            expected,
+            "the v2 read of a files slice must return the metadata-table reader's keys"
+        );
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Description

**Stacked on #691, which is stacked on #689. Review those first.** Until they merge the diff here shows their commits too; the delta is `50ae752..HEAD`, three files.

A file slice holding an HFile log block reads as though the slice had no log blocks: the read succeeds and returns the base file's rows. Nothing errors, and no counter records a skipped block, so the loss is silent. Version two is the default reader, and the version one fallback does not cover this because version two never reports an inability, it reports success.

The block type was skipped at five points: the prefetch window planner, pass one's classification into the per-instant map, pass three's decode dispatch, pass three's buffer dispatch, and the buffer itself, whose `if let LogBlockContent::Records(..)` has no else and discards anything other shape. Admitting the type at the first four alone would not have helped, because the buffer takes Arrow and nothing else.

An HFile block's records are Avro values stored under HFile keys, so they are decoded against the schema in the block header, which is the same resolution an Avro block already gets, and the buffer receives batches like every other data block type. That resolution now lives in one helper shared by both paths so they cannot drift on promotions. Whether an HFile block is decoded or handed back as key-value pairs is the caller's choice, because the metadata table reader wants the pairs.

A writer may leave the record's key field empty because the HFile entry key already holds it, so an empty field is filled from the entry key. This shares one implementation with the base file reader added in #691, including its guards: a populated value and a null value are both left alone.

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below

`harness_hfile_log_block_rejected` asserted `Invalid block type: 4`, which held upstream where HFile blocks were unrecognised, and was ignored with a note that the expectation needed re-deriving rather than inverting. It is re-derived and un-ignored as `harness_hfile_log_block_merges`.

Its expectation comes from the inputs, not from this reader: the base file was read with the parquet reader, and the block's two records were decoded with `apache_avro::from_avro_datum` against the schema in the block header. Both sides carry `ts = 100`, so event-time ordering ties and the case's commit-time ordering decides, which makes the log write win on two of the four keys. Without the fix the read returns the base file unchanged, so the case fails on the commit time of the first row.

The `key` column is asserted because it is where the entry key is filled. The base file holds it and the log writer left it empty, so without the fill two rows read as empty next to two holding their own keys.

This is **not** a Hudi parity oracle. The fixture has no gold data, because Spark cannot read it either, so nothing here checks hudi-rs against Hudi; it checks the merge against the decoded inputs.

The metadata table is the reason this change exists, so it is read directly rather than left to the next change in the stack, and every partition in the fixture is read rather than the `files` partition alone: a skipped block is silent, so a `files`-only test would pass on four of the five partitions regardless. `column_stats`, `partition_stats` and `record_index` compact to a base file written after all their log files, so their pre-compaction slice has log files and no base file at all, which makes them the sharper case: a skipped block leaves those reads with no records and no schema to build an output from, and they fail outright. `files` and `secondary_index` have both, so there the merged read is asserted to differ from a base-file-only read. The `files` slice additionally has a real oracle, `MetadataTableFileGroupReader`, which reads the same slice through a separate implementation on decoded structs rather than Arrow.

The merge mode used is commit-time ordering, which is not the metadata table's own mode. These cases pin that the blocks are decoded and reach the merge; whether the merge applies the metadata payload's rule is a separate change.

The test's metadata configs gained the table's own record key config. Without it the key resolves to `_hoodie_record_key`, which every metadata record leaves empty, so a merge collapses every key onto one entry. A base-file-only read never noticed, because with no log files there is no merge, which is why the gap survived until a test read log files.

Run locally: 1339 pass with default features, 1319 with `--no-default-features`, clippy clean on both feature sets with warnings denied, fmt clean, and the metadata table reader's own test still passes, which is what confirms that path still receives raw key-value pairs. Each of the four sites this change admits the block type at was reverted in turn, and the metadata cases fail on each. No CI run has happened: fork pull requests sit at `action_required` until a committer approves them, so all of the above is local only.


