### PR TITLE
perf(core): copy an HFile record rather than its whole block per record

### DIFF
--- a/crates/core/src/hfile/key.rs
+++ b/crates/core/src/hfile/key.rs
@@ -37,9 +37,9 @@ pub const KEY_VALUE_HEADER_SIZE: usize = SIZEOF_INT32 * 2;
 /// For comparison and hashing, only the key content is used.
 #[derive(Debug, Clone)]
 pub struct Key {
-    /// Raw key bytes including the length prefix
+    /// This key's own bytes, including the length prefix
     bytes: Vec<u8>,
-    /// Offset to the start of the key within bytes
+    /// Offset to the start of the key within `bytes`; zero when parsed from a block
     offset: usize,
     /// Total length of the key part (including length prefix and other info)
     length: usize,
@@ -47,10 +47,18 @@ pub struct Key {
 
 impl Key {
     /// Create a new Key from bytes at the given offset with the specified length.
+    ///
+    /// Copies the key's own bytes, not the buffer it came from. `bytes` is a whole
+    /// data block, so copying it here cost the block once per key: parsing a block
+    /// of N keys copied it N times, which is quadratic in the block's record count.
     pub fn new(bytes: &[u8], offset: usize, length: usize) -> Self {
+        let end = offset.saturating_add(length).min(bytes.len());
+        let start = offset.min(end);
         Self {
-            bytes: bytes.to_vec(),
-            offset,
+            bytes: bytes[start..end].to_vec(),
+            // Zero because the bytes above start at the key, so every accessor's
+            // arithmetic stays as it was when this held the whole block.
+            offset: 0,
             length,
         }
     }
@@ -65,8 +73,12 @@ impl Key {
         }
     }
 
-    /// Returns the offset to the key content (after length prefix).
-    pub fn content_offset(&self) -> usize {
+    /// Returns the offset to the key content (after the length prefix).
+    ///
+    /// Private: this is an offset into *this key's* bytes, so it is only meaningful
+    /// with [`Self::bytes`]. It used to be an offset into the enclosing block, and a
+    /// caller pairing it with a block buffer would now index the wrong place.
+    fn content_offset(&self) -> usize {
         self.offset + SIZEOF_INT16
     }
 
@@ -80,6 +92,12 @@ impl Key {
     }
 
     /// Returns the key content as a byte slice.
+    ///
+    /// The bound below is against this key's own bytes. For a key parsed out of a
+    /// block that is `length` bytes, so a corrupt inner prefix claiming more content
+    /// than the key holds yields empty rather than reading on into the value that
+    /// follows it. A well-formed HFile cannot reach that: `key_length` is
+    /// `2 + row + 1 + family + qualifier + 9`, always at least `2 + content`.
     pub fn content(&self) -> &[u8] {
         let start = self.content_offset();
         let len = self.content_length();
@@ -99,7 +117,7 @@ impl Key {
         self.length
     }
 
-    /// Returns the raw bytes.
+    /// Returns this key's own bytes, prefix included.
     pub fn bytes(&self) -> &[u8] {
         &self.bytes
     }
@@ -206,9 +224,9 @@ impl std::fmt::Display for Utf8Key {
 /// - 1 byte: MVCC timestamp version (always 0 for Hudi)
 #[derive(Debug, Clone)]
 pub struct KeyValue {
-    /// The backing byte array containing the entire key-value record
+    /// This record's own bytes: header, key and value
     bytes: Vec<u8>,
-    /// Offset to the start of this record in bytes
+    /// Offset to the start of this record within `bytes`; zero when parsed
     offset: usize,
     /// The parsed key
     key: Key,
@@ -238,9 +256,21 @@ impl KeyValue {
         let key_offset = offset + KEY_VALUE_HEADER_SIZE;
         let key = Key::new(bytes, key_offset, key_length);
 
+        // This record's own bytes, not the block's. Copying the block here cost it
+        // once per record, so a block of N records copied itself N times on top of
+        // the N copies `Key::new` made.
+        let record_end = offset
+            .saturating_add(KEY_VALUE_HEADER_SIZE)
+            .saturating_add(key_length)
+            .saturating_add(value_length)
+            .min(bytes.len());
+        let record_start = offset.min(record_end);
+
         Self {
-            bytes: bytes.to_vec(),
-            offset,
+            bytes: bytes[record_start..record_end].to_vec(),
+            // Zero for the same reason as in `Key::new`: the bytes now start at the
+            // record, so `value()`'s arithmetic is unchanged.
+            offset: 0,
             key,
             key_length,
             value_length,
@@ -464,5 +494,74 @@ mod tests {
         assert_eq!(compare_keys(&key, &lookup1), Ordering::Equal);
         assert_eq!(compare_keys(&key, &lookup2), Ordering::Less);
         assert_eq!(compare_keys(&key, &lookup3), Ordering::Greater);
+    }
+
+    /// A record parsed at a nonzero offset reads its own key and value, and holds
+    /// only its own bytes.
+    ///
+    /// Every other test here parses at offset 0, where a record and the buffer it
+    /// came from are nearly the same thing, so none of them would notice a parse
+    /// that ignored the offset or sliced from the start. The narrowing is what this
+    /// pins: the second record's buffer must span that record, not the block, since
+    /// holding the block is what made parsing a block quadratic in its record count.
+    #[test]
+    fn a_record_at_a_nonzero_offset_reads_itself_and_holds_only_itself() {
+        // Two records in one buffer, laid out as an HFile data block does it:
+        // 4-byte key length, 4-byte value length, key, value, 1-byte MVCC.
+        fn record(key_content: &[u8], value: &[u8]) -> Vec<u8> {
+            let mut key = Vec::new();
+            key.extend_from_slice(&(key_content.len() as i16).to_be_bytes());
+            key.extend_from_slice(key_content);
+            let mut out = Vec::new();
+            out.extend_from_slice(&(key.len() as i32).to_be_bytes());
+            out.extend_from_slice(&(value.len() as i32).to_be_bytes());
+            out.extend_from_slice(&key);
+            out.extend_from_slice(value);
+            out.push(0); // MVCC timestamp version
+            out
+        }
+
+        let first = record(b"aaa", b"value-of-first");
+        let second = record(b"bbbb", b"second-value");
+        let mut block = first.clone();
+        block.extend_from_slice(&second);
+
+        let kv0 = KeyValue::parse(&block, 0);
+        assert_eq!(kv0.key().content(), b"aaa");
+        assert_eq!(kv0.value(), b"value-of-first");
+        assert_eq!(kv0.record_size(), first.len());
+
+        // The offset the block iterator would advance to.
+        let kv1 = KeyValue::parse(&block, kv0.record_size());
+        assert_eq!(
+            kv1.key().content(),
+            b"bbbb",
+            "the second record's key must be read from its own offset"
+        );
+        assert_eq!(
+            kv1.value(),
+            b"second-value",
+            "the second record's value must be read from its own offset"
+        );
+        assert_eq!(kv1.record_size(), second.len());
+
+        // Narrow, not the whole block: this is the property whose absence made a
+        // block of N records copy itself N times.
+        assert_eq!(
+            kv1.key().bytes().len(),
+            kv1.key_length(),
+            "a parsed key must hold exactly its own bytes, not the block's"
+        );
+        assert!(
+            kv1.bytes.len() < block.len(),
+            "a parsed record must hold less than the whole block, got {} of {}",
+            kv1.bytes.len(),
+            block.len()
+        );
+        assert_eq!(
+            kv1.bytes.len(),
+            KEY_VALUE_HEADER_SIZE + kv1.key_length() + kv1.value_length(),
+            "a parsed record must hold exactly its header, key and value"
+        );
     }
 }


### PR DESCRIPTION
## Description

Independent of the #691 to #696 stack: based on `main`, touching only `crates/core/src/hfile/key.rs`.

Parsing one HFile key-value copied the entire uncompressed data block twice, once into the `KeyValue` and once into the `Key` inside it. The buffer handed to both is the block, not the record, so parsing a block of N records copied it 2N times and iterating a block cost records times block size. Measured on generated blocks holding one data block each, per-record cost was 7.83us at 200 records, 16.06us at 1,000 and 66.15us at 5,000: growing with the block rather than staying flat.

Both structures index everything relative to their `offset`, so each can instead hold the bytes it actually spans with the offset at zero, leaving every accessor's arithmetic as it was. Per-record cost is then 0.16us, 0.16us and 0.12us at those three sizes, and iterating a block is 49 to 531 times faster across that range. The flatness matters more than the multiple: a fix aimed at the wrong cause would have moved the level without changing the shape.

Two behaviour notes, both stated because they are not visible from the diff.

`Key::content` now bounds its slice against the key's own bytes rather than against the rest of the block. On corrupt input where the inner length prefix claims more content than the key holds, it yields empty instead of reading on into the value that follows. A well-formed HFile cannot reach that, since a key length is `2 + row + 1 + family + qualifier + 9` and so always covers its content. Every other accessor is unchanged, checked by walking all 104,200 records of the nine fixtures and comparing against the previous implementation field by field.

`Key::content_offset` becomes private. It is an offset into the key's own bytes, so pairing it with a block buffer, which used to be correct, would now index the wrong place. Nothing outside the module used it. `Key::bytes` stays public but its meaning narrows from the enclosing block to the key itself; no caller in `crates/`, `python/` or `cpp/` reads it.

Lengths come straight out of the file and nothing upstream validates them, so the new slices clamp to the buffer. Corrupt lengths panic in the same places with the same messages as before rather than becoming silently wrong output.

While reviewing this, a pre-existing bug turned up in the same file and is filed separately rather than fixed here: `find_block_for_key` builds its search key with `Key::from_bytes` from a raw lookup string with no length prefix, so the block-index range query never resolves and every seek degrades to a linear block walk. Results stay correct, which is why nothing caught it. Both `Key` construction sites involved are byte-identical before and after this change.

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below

One test added, and it is the one the existing suite lacked. Every other test in `key.rs` parses at offset 0, where a record and the buffer it came from are nearly the same thing, so none of them would notice a parse that ignored the offset or sliced from the start of the buffer. The new test lays two records out as a data block does, parses the second at the offset the block iterator would advance to, and asserts it reads its own key and its own value. It then asserts the narrowing itself: the key holds exactly `key_length` bytes, the record holds exactly header plus key plus value, and less than the whole block.

That last group is what guards the regression, and it does so without timing anything, so it cannot be flaky. Reverting the change fails it with "a parsed key must hold exactly its own bytes, not the block's".

Equivalence was checked more broadly than the new test covers: a throwaway differential harness reimplemented the previous semantics side by side and compared `content`, `content_length`, `value`, `record_size`, `key_length` and `value_length` for every record of every data block of all nine fixtures, across GZ and NONE codecs, two and three level indexes, shortened first keys and non-unique keys. 104,200 records, no mismatches. Six corrupt inputs were run against both implementations and panic identically.

A timing benchmark was written for this and deliberately not included: it needs a directory of generated blocks too large to commit, so it could never fail in CI and carried no signal. The measurements above are reproducible from the generator described in the ticket.

Run locally: 1300 pass with default features, 1280 with `--no-default-features`, clippy clean on both feature sets with warnings denied, fmt clean, and `cargo check --workspace --all-targets --all-features` clean including the Python and C++ bindings. No CI run has happened: fork pull requests sit at `action_required` until a committer approves them.
