### PR TITLE
feat: align DataFusion adapter with DataFusion 55

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,31 +38,31 @@ repository = "https://github.com/apache/hudi-rs"
 
 [workspace.dependencies]
 # arrow
-arrow = { version = "57" }
-arrow-arith = { version = "57" }
-arrow-array = { version = "57" }
-arrow-buffer = { version = "57" }
-arrow-cast = { version = "57" }
-arrow-ipc = { version = "57" }
-arrow-json = { version = "57" }
-arrow-ord = { version = "57" }
-arrow-row = { version = "57" }
-arrow-schema = { version = "57", features = ["serde"] }
-arrow-select = { version = "57" }
-object_store = { version = "0.12", features = ["aws", "azure", "gcp"] }
-parquet = { version = "57", features = ["async", "object_store"] }
+arrow = { version = "59.2.0" }
+arrow-arith = { version = "59.2.0" }
+arrow-array = { version = "59.2.0" }
+arrow-buffer = { version = "59.2.0" }
+arrow-cast = { version = "59.2.0" }
+arrow-ipc = { version = "59.2.0" }
+arrow-json = { version = "59.2.0" }
+arrow-ord = { version = "59.2.0" }
+arrow-row = { version = "59.2.0" }
+arrow-schema = { version = "59.2.0", features = ["serde"] }
+arrow-select = { version = "59.2.0" }
+object_store = { version = "0.13.2", features = ["aws", "azure", "gcp"] }
+parquet = { version = "59.2.0", features = ["async", "object_store"] }
 
 # avro
-arrow-avro = { version = "57" }
+arrow-avro = { version = "59.2.0" }
 apache-avro = { version = "0.21", features = ["derive"] }
 apache-avro-derive = { version = "0.21" }
 
 # datafusion
-datafusion = { version = "52" }
-datafusion-expr = { version = "52" }
-datafusion-common = { version = "52" }
-datafusion-physical-expr = { version = "52" }
-datafusion-ffi = { version = "52" }
+datafusion = { version = "55" }
+datafusion-expr = { version = "55" }
+datafusion-common = { version = "55" }
+datafusion-physical-expr = { version = "55" }
+datafusion-ffi = { version = "55" }
 
 # serde
 percent-encoding = { version = "2" }

--- a/benchmark/filegroup/src/gen.rs
+++ b/benchmark/filegroup/src/gen.rs
@@ -252,7 +252,7 @@ fn batch(from: u64, rows: usize) -> RecordBatch {
 fn write_one(path: &Path, target_bytes: u64, row_group_rows: usize, start_key: u64) -> u64 {
     let props = WriterProperties::builder()
         .set_compression(Compression::UNCOMPRESSED)
-        .set_max_row_group_size(row_group_rows)
+        .set_max_row_group_row_count(Some(row_group_rows))
         .build();
     let file = fs::File::create(path).expect("create parquet");
     let mut writer = ArrowWriter::try_new(file, schema(), Some(props)).expect("writer");

--- a/benchmark/tpch/Cargo.toml
+++ b/benchmark/tpch/Cargo.toml
@@ -38,7 +38,7 @@ parquet = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
-tpchgen = "2"
-tpchgen-arrow = "2"
+tpchgen = "3"
+tpchgen-arrow = "3"
 serde_yaml = "0.9"
 url = { workspace = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -92,10 +92,10 @@ flate2 = { workspace = true }
 # prost-build at compile time, which shells out to `protoc`. Any build of
 # hudi-core (CI, Docker, local dev, downstream consumers) must therefore
 # have `protoc` available on PATH — there is no opt-out.
-lance-core = { version = "4.0.1" }
-lance-encoding = { version = "4.0.1" }
-lance-file = { version = "4.0.1" }
-lance-io = { version = "4.0.1" }
+lance-core = { version = "4.0.1", optional = true }
+lance-encoding = { version = "4.0.1", optional = true }
+lance-file = { version = "4.0.1", optional = true }
+lance-io = { version = "4.0.1", optional = true }
 
 # datafusion
 datafusion = { workspace = true, optional = true }
@@ -120,6 +120,13 @@ result_large_err = "allow"
 
 [features]
 default = ["spill-rocksdb"]
+
+lance = [
+    "dep:lance-core",
+    "dep:lance-encoding",
+    "dep:lance-file",
+    "dep:lance-io",
+]
 
 # The merge-on-read merge map's on-disk tier, which it spills to when a file
 # group's log records exceed `hoodie.memory.merge.max.size`.

--- a/crates/core/src/avro_to_arrow/schema.rs
+++ b/crates/core/src/avro_to_arrow/schema.rs
@@ -126,7 +126,7 @@ fn schema_to_field_with_props(
                     .map(|s| schema_to_field_with_props(s, None, has_nullable, None))
                     .collect::<Result<Vec<Field>>>()?;
                 let type_ids = 0_i8..fields.len() as i8;
-                DataType::Union(UnionFields::new(type_ids, fields), UnionMode::Dense)
+                DataType::Union(UnionFields::try_new(type_ids, fields)?, UnionMode::Dense)
             }
         }
         AvroSchema::Record(RecordSchema { fields, .. }) => {

--- a/crates/core/src/file_group/base_file/mod.rs
+++ b/crates/core/src/file_group/base_file/mod.rs
@@ -17,6 +17,7 @@
  * under the License.
  */
 pub mod hfile;
+#[cfg(feature = "lance")]
 pub mod lance;
 pub mod parquet;
 pub mod reader;

--- a/crates/core/src/file_group/base_file/parquet.rs
+++ b/crates/core/src/file_group/base_file/parquet.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 
 use futures::StreamExt;
 use futures::future::BoxFuture;
+use object_store::ObjectStoreExt;
 use object_store::path::Path as ObjPath;
 use parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
 use parquet::arrow::async_reader::{AsyncFileReader, ParquetObjectReader};

--- a/crates/core/src/file_group/base_file/parquet.rs
+++ b/crates/core/src/file_group/base_file/parquet.rs
@@ -25,6 +25,12 @@ use futures::future::BoxFuture;
 use object_store::ObjectStoreExt;
 use object_store::path::Path as ObjPath;
 use parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
+// `ParquetObjectReader` is deprecated as of parquet 59 in favour of hand-rolling
+// an `AsyncFileReader` over `object_store`. Replacing it is its own change — it
+// has to carry the counting wrapper and the metadata normalization below — so
+// the deprecated reader is kept, allowed at each use site rather than for the
+// whole file.
+#[allow(deprecated)]
 use parquet::arrow::async_reader::{AsyncFileReader, ParquetObjectReader};
 use parquet::arrow::{ParquetRecordBatchStreamBuilder, RowNumber, parquet_to_arrow_schema};
 use parquet::file::metadata::ParquetMetaData;
@@ -89,6 +95,7 @@ impl<R: AsyncFileReader> AsyncFileReader for CountingReader<R> {
 
 /// The builder every read here is driven from: a parquet object reader with the
 /// read-volume counters wrapped around it.
+#[allow(deprecated)]
 type CountedBuilder = ParquetRecordBatchStreamBuilder<CountingReader<ParquetObjectReader>>;
 
 /// Parquet implementation of [`BaseFileReader`].
@@ -134,6 +141,7 @@ impl ParquetBaseFileReader {
         file_size: u64,
         row_index_column: Option<&str>,
     ) -> Result<CountedBuilder> {
+        #[allow(deprecated)]
         let mut reader = ParquetObjectReader::new(self.storage.object_store.clone(), obj_path)
             .with_file_size(file_size);
 

--- a/crates/core/src/file_group/base_file/reader.rs
+++ b/crates/core/src/file_group/base_file/reader.rs
@@ -30,6 +30,8 @@ use futures::stream::BoxStream;
 use crate::config::table::BaseFileFormatValue;
 use crate::statistics::StatisticsContainer;
 use crate::storage::error::Result;
+#[cfg(not(feature = "lance"))]
+use crate::storage::error::StorageError;
 use crate::storage::file_metadata::FileMetadata;
 use crate::storage::{RowFilterBuilder, RowGroupSelector, Storage};
 

--- a/crates/core/src/file_group/base_file/reader.rs
+++ b/crates/core/src/file_group/base_file/reader.rs
@@ -322,9 +322,14 @@ pub fn create_base_file_reader(
         BaseFileFormatValue::HFile => Ok(Arc::new(super::hfile::HFileBaseFileReader::new(
             storage.clone(),
         ))),
+        #[cfg(feature = "lance")]
         BaseFileFormatValue::Lance => Ok(Arc::new(super::lance::LanceBaseFileReader::new(
             storage.clone(),
         ))),
+        #[cfg(not(feature = "lance"))]
+        BaseFileFormatValue::Lance => Err(StorageError::UnsupportedBaseFileFormat(
+            "lance support is not enabled".to_string(),
+        )),
     }
 }
 

--- a/crates/core/src/file_group/reader_v2/engine.rs
+++ b/crates/core/src/file_group/reader_v2/engine.rs
@@ -1428,7 +1428,7 @@ mod tests {
         use parquet::arrow::ArrowWriter;
         use parquet::file::properties::WriterProperties;
         let props = WriterProperties::builder()
-            .set_max_row_group_size(rows_per_group)
+            .set_max_row_group_row_count(Some(rows_per_group))
             .build();
         let file = std::fs::File::create(dir.join(name)).unwrap();
         let mut writer = ArrowWriter::try_new(file, batch.schema(), Some(props)).unwrap();

--- a/crates/core/src/file_group/reader_v2/row_serde.rs
+++ b/crates/core/src/file_group/reader_v2/row_serde.rs
@@ -80,7 +80,7 @@ pub fn to_binary_row_body(record: &RecordBatch) -> Option<Vec<u8>> {
     let generator = arrow_ipc::writer::IpcDataGenerator {};
     let mut dict_tracker = arrow_ipc::writer::DictionaryTracker::new(false);
     let opts = arrow_ipc::writer::IpcWriteOptions::default();
-    let mut compression_context = arrow_ipc::writer::CompressionContext::default();
+    let mut compression_context = arrow_ipc::writer::IpcWriteContext::default();
     let (dictionaries, encoded) = generator
         .encode(record, &mut dict_tracker, &opts, &mut compression_context)
         .ok()?;

--- a/crates/core/src/schema/resolver.rs
+++ b/crates/core/src/schema/resolver.rs
@@ -20,6 +20,7 @@ use crate::avro_to_arrow::to_arrow_schema;
 use crate::config::table::BaseFileFormatValue;
 use crate::config::table::HudiTableConfig;
 use crate::error::{CoreError, Result};
+#[cfg(feature = "lance")]
 use crate::file_group::base_file::lance::LanceBaseFileReader;
 use crate::file_group::base_file::parquet::ParquetBaseFileReader;
 use crate::metadata::commit::HoodieCommitMetadata;
@@ -182,11 +183,14 @@ async fn read_schema_by_extension(path: &str, storage: &Arc<Storage>) -> Result<
                 .get_schema(path)
                 .await?,
         )),
+        #[cfg(feature = "lance")]
         Some(BaseFileFormatValue::Lance) => Ok(Some(
             LanceBaseFileReader::new(storage.clone())
                 .get_schema(path)
                 .await?,
         )),
+        #[cfg(not(feature = "lance"))]
+        Some(BaseFileFormatValue::Lance) => Ok(None),
         _ => Ok(None),
     }
 }

--- a/crates/core/src/storage/counting.rs
+++ b/crates/core/src/storage/counting.rs
@@ -32,7 +32,7 @@ use async_trait::async_trait;
 use futures::stream::BoxStream;
 use object_store::path::Path;
 use object_store::{
-    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
     PutMultipartOptions, PutOptions, PutPayload, PutResult, Result,
 };
 
@@ -101,17 +101,22 @@ impl ObjectStore for CountingObjectStore {
     }
 
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
-        self.counts.gets.fetch_add(1, Ordering::Relaxed);
+        // A metadata-only lookup reaches the store as a `get_opts` carrying
+        // `head`, not as its own trait method, so the two request kinds are
+        // told apart here.
+        if options.head {
+            self.counts.heads.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.counts.gets.fetch_add(1, Ordering::Relaxed);
+        }
         self.inner.get_opts(location, options).await
     }
 
-    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
-        self.counts.heads.fetch_add(1, Ordering::Relaxed);
-        self.inner.head(location).await
-    }
-
-    async fn delete(&self, location: &Path) -> Result<()> {
-        self.inner.delete(location).await
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, Result<Path>>,
+    ) -> BoxStream<'static, Result<Path>> {
+        self.inner.delete_stream(locations)
     }
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, Result<ObjectMeta>> {
@@ -122,11 +127,7 @@ impl ObjectStore for CountingObjectStore {
         self.inner.list_with_delimiter(prefix).await
     }
 
-    async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
-        self.inner.copy(from, to).await
-    }
-
-    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
-        self.inner.copy_if_not_exists(from, to).await
+    async fn copy_opts(&self, from: &Path, to: &Path, options: CopyOptions) -> Result<()> {
+        self.inner.copy_opts(from, to, options).await
     }
 }

--- a/crates/core/src/storage/error.rs
+++ b/crates/core/src/storage/error.rs
@@ -49,6 +49,7 @@ pub enum StorageError {
     #[error(transparent)]
     ParquetError(#[from] parquet::errors::ParquetError),
 
+    #[cfg(feature = "lance")]
     #[error(transparent)]
     LanceError(#[from] lance_core::Error),
 

--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -81,6 +81,9 @@ pub type RowGroupSelector =
 pub struct Storage {
     pub(crate) base_url: Arc<Url>,
     pub(crate) object_store: Arc<dyn ObjectStore>,
+    /// Read only by the Lance base-file reader, which hands them to Lance's own
+    /// object-store resolver, so nothing reads them without that feature.
+    #[cfg_attr(not(feature = "lance"), allow(dead_code))]
     pub(crate) options: Arc<HashMap<String, String>>,
     pub(crate) hudi_configs: Arc<HudiConfigs>,
     /// Read-volume counters for the base-file reads made through this

--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -26,7 +26,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use async_recursion::async_recursion;
 use bytes::Bytes;
 use object_store::path::Path as ObjPath;
-use object_store::{ObjectStore, parse_url_opts};
+use object_store::{ObjectStore, ObjectStoreExt, parse_url_opts};
 use url::Url;
 
 use crate::config::HudiConfigs;

--- a/crates/core/src/storage/reader.rs
+++ b/crates/core/src/storage/reader.rs
@@ -19,7 +19,7 @@
 use crate::config::HudiConfigs;
 use bytes::Bytes;
 use object_store::path::Path as ObjPath;
-use object_store::{ObjectMeta, ObjectStore};
+use object_store::{ObjectMeta, ObjectStore, ObjectStoreExt};
 use std::io::{Error, ErrorKind, Result};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/crates/core/tests/statistics_tests.rs
+++ b/crates/core/tests/statistics_tests.rs
@@ -69,7 +69,7 @@ fn write_parquet_file_multiple_row_groups(batches: &[RecordBatch], path: &std::p
     let props = WriterProperties::builder()
         .set_compression(Compression::SNAPPY)
         .set_statistics_enabled(parquet::file::properties::EnabledStatistics::Page)
-        .set_max_row_group_size(3) // Force smaller row groups
+        .set_max_row_group_row_count(Some(3)) // Force smaller row groups
         .build();
     let mut writer = ArrowWriter::try_new(file, batches[0].schema(), Some(props)).unwrap();
     for batch in batches {

--- a/crates/datafusion/Cargo.toml
+++ b/crates/datafusion/Cargo.toml
@@ -34,6 +34,9 @@ default = ["spill-rocksdb"]
 # re-enable that tier through feature unification whatever the umbrella crate
 # asked for.
 spill-rocksdb = ["hudi-core/spill-rocksdb"]
+# Forwarded the same way, for the Lance base-file reader that hudi-core keeps
+# behind its own `lance` feature.
+lance = ["hudi-core/lance"]
 
 [dependencies]
 hudi-core = { version = "0.5.0-dev", path = "../core", default-features = false, features = [

--- a/crates/datafusion/src/hudi_exec.rs
+++ b/crates/datafusion/src/hudi_exec.rs
@@ -19,7 +19,6 @@
 //! Custom DataFusion execution plan for reading Hudi tables through
 //! [`FileGroupReader`], supporting all base file formats and MOR log merging.
 
-use std::any::Any;
 use std::fmt;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -37,7 +36,9 @@ use datafusion::physical_plan::{
 };
 use datafusion_common::DataFusionError::Execution;
 use datafusion_common::stats::Precision;
+use datafusion_common::tree_node::TreeNodeRecursion;
 use datafusion_common::{ColumnStatistics, DataFusionError, Result, Statistics};
+use datafusion_physical_expr::PhysicalExpr;
 use futures::stream::{self, BoxStream, TryStreamExt};
 use futures::{Stream, StreamExt};
 
@@ -63,7 +64,7 @@ pub struct HudiScanExec {
     projected_schema: SchemaRef,
     projection: Option<Vec<usize>>,
     limit: Option<usize>,
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
 }
 
@@ -152,7 +153,7 @@ impl HudiScanExec {
             projected_schema,
             projection,
             limit,
-            properties,
+            properties: Arc::new(properties),
             metrics: ExecutionPlanMetricsSet::new(),
         }
     }
@@ -262,16 +263,19 @@ impl ExecutionPlan for HudiScanExec {
         "HudiScanExec"
     }
 
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
         vec![]
+    }
+
+    fn apply_expressions(
+        &self,
+        _f: &mut dyn FnMut(&Arc<dyn PhysicalExpr>) -> Result<TreeNodeRecursion>,
+    ) -> Result<TreeNodeRecursion> {
+        Ok(TreeNodeRecursion::Continue)
     }
 
     fn with_new_children(
@@ -394,11 +398,7 @@ impl ExecutionPlan for HudiScanExec {
         )))
     }
 
-    fn statistics(&self) -> Result<Statistics> {
-        Ok(self.aggregate_file_slice_statistics())
-    }
-
-    fn partition_statistics(&self, partition: Option<usize>) -> Result<Statistics> {
+    fn partition_statistics(&self, partition: Option<usize>) -> Result<Arc<Statistics>> {
         let column_statistics =
             vec![ColumnStatistics::new_unknown(); self.projected_schema.fields().len()];
 
@@ -410,11 +410,14 @@ impl ExecutionPlan for HudiScanExec {
             ),
             Some(idx) => match self.file_slice_partitions.get(idx) {
                 Some(slices) => Box::new(std::iter::once(slices.as_slice())),
-                None => return Ok(Statistics::new_unknown(&self.projected_schema)),
+                None => return Ok(Arc::new(Statistics::new_unknown(&self.projected_schema))),
             },
         };
 
-        Ok(Self::aggregate_partitions(partitions, column_statistics))
+        Ok(Arc::new(Self::aggregate_partitions(
+            partitions,
+            column_statistics,
+        )))
     }
 
     fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
@@ -440,17 +443,6 @@ impl ExecutionPlan for HudiScanExec {
 }
 
 impl HudiScanExec {
-    fn aggregate_file_slice_statistics(&self) -> Statistics {
-        let column_statistics =
-            vec![ColumnStatistics::new_unknown(); self.projected_schema.fields().len()];
-        Self::aggregate_partitions(
-            self.file_slice_partitions
-                .iter()
-                .map(|slices| slices.as_slice()),
-            column_statistics,
-        )
-    }
-
     fn aggregate_partitions<'a, I>(
         partitions: I,
         column_statistics: Vec<ColumnStatistics>,

--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -20,7 +20,6 @@
 pub(crate) mod hudi_exec;
 pub(crate) mod util;
 
-use std::any::Any;
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt::Debug;
@@ -46,7 +45,6 @@ use datafusion_common::stats::Precision;
 use datafusion_common::{DataFusionError, Statistics};
 use datafusion_expr::utils::split_conjunction;
 use datafusion_expr::{CreateExternalTable, Expr, TableProviderFilterPushDown, TableType};
-use datafusion_physical_expr::create_physical_expr;
 use log::warn;
 
 use crate::hudi_exec::HudiScanExec;
@@ -122,6 +120,7 @@ fn filter_field_matches_partition_column(filter_field: &str, partition_column: &
 #[derive(Clone)]
 pub struct HudiDataSource {
     table: Arc<HudiTable>,
+    options: HashMap<String, String>,
     /// Cached table schema (with meta fields) for synchronous access in `TableProvider::schema()`.
     /// This provider is a construction-time metadata snapshot; create a new
     /// provider to observe schema/stat changes from later commits.
@@ -232,6 +231,7 @@ impl HudiDataSource {
             }
             None => default_file_slice_read_concurrency(),
         };
+        let options = all_options.iter().cloned().collect();
         let table = HudiTable::new_with_options(base_uri, all_options)
             .await
             .map_err(|e| external_error("Failed to create Hudi table", e))?;
@@ -293,6 +293,7 @@ impl HudiDataSource {
 
         Ok(Self {
             table: Arc::new(table),
+            options,
             schema,
             partition_schema,
             cached_stats,
@@ -301,6 +302,16 @@ impl HudiDataSource {
             file_slice_read_concurrency,
             base_file_format,
         })
+    }
+
+    /// Returns the table location needed to reconstruct this provider.
+    pub fn base_uri(&self) -> String {
+        self.table.base_url().to_string()
+    }
+
+    /// Returns the caller-supplied options needed to reconstruct this provider.
+    pub fn options(&self) -> &HashMap<String, String> {
+        &self.options
     }
 
     fn get_input_partitions(&self) -> usize {
@@ -683,7 +694,7 @@ impl HudiDataSource {
         let filter = filters.iter().cloned().reduce(|acc, new| acc.and(new));
         if let Some(expr) = filter {
             let df_schema = DFSchema::try_from(table_schema.clone())?;
-            let predicate = create_physical_expr(&expr, &df_schema, state.execution_props())?;
+            let predicate = state.create_physical_expr(expr, &df_schema)?;
             parquet_source = parquet_source.with_predicate(predicate)
         }
 
@@ -787,10 +798,6 @@ impl HudiDataSource {
 
 #[async_trait]
 impl TableProvider for HudiDataSource {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
@@ -1015,7 +1022,7 @@ impl TableProviderFactory for HudiTableFactory {
         cmd: &CreateExternalTable,
     ) -> Result<Arc<dyn TableProvider>> {
         let options = HudiTableFactory::resolve_options(state, cmd)?;
-        let base_uri = cmd.location.as_str();
+        let base_uri = cmd.locations[0].as_str();
         let table_provider = HudiDataSource::new_with_options(base_uri, options).await?;
         Ok(Arc::new(table_provider))
     }

--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -1165,7 +1165,6 @@ mod tests {
         let state = ctx.state();
         let plan = hudi.scan(&state, None, filters, None).await.unwrap();
         let exec = plan
-            .as_any()
             .downcast_ref::<HudiScanExec>()
             .expect("scan should route to HudiScanExec");
 
@@ -1438,7 +1437,6 @@ mod tests {
             .await
             .unwrap();
         let exec = plan
-            .as_any()
             .downcast_ref::<HudiScanExec>()
             .expect("MOR snapshot scan should use HudiScanExec");
 

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -40,7 +40,7 @@ parquet = { workspace = true }
 
 # datafusion (optional, for verification helpers)
 datafusion = { workspace = true, optional = true }
-hudi-datafusion = { path = "../datafusion", optional = true }
+hudi-datafusion = { path = "../datafusion", optional = true, default-features = false }
 
 # serde (reading the gold_options manifests shipped inside fixtures)
 serde = { workspace = true }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -50,7 +50,7 @@ futures = { workspace = true }
 tokio = { workspace = true }
 
 [dependencies.pyo3]
-version = "0.26"
+version = "0.29"
 features = ["extension-module", "abi3", "abi3-py310"]
 
 [features]


### PR DESCRIPTION
## What changes are included?

Aligns the Hudi DataFusion adapter with DataFusion 55, Arrow/Parquet 59.2, and `object_store` 0.13.2 so it can be consumed by current Ballista.

- adapts `TableProvider` and `ExecutionPlan` implementations to the DataFusion 55 APIs
- keeps Lance behind an explicit feature because released Lance crates still use older Arrow/object-store types
- updates object-store calls for the 0.13 extension trait
- exposes the Hudi provider's base URI and caller-supplied options as the minimal remote reconstruction recipe
- updates the Python binding's pyo3 version required by Arrow 59

This draft intentionally focuses on the Parquet COW path needed by the Ballista integration. Lance feature alignment is separate work.

## Tests

- `cargo check -p hudi-datafusion`
- `cargo check -p hudi-datafusion --no-default-features`
- `cargo test -p hudi-datafusion --no-default-features --test query_tests test_v9_txns_cow_tables`

The Ballista follow-up also executes a projected and filtered COW read through a two-worker standalone cluster.
