### PR TITLE
feat(core): stream file slices by partition

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Create a Hudi table instance using its constructor or the `TableBuilder` API.
 
 All read APIs accept a `ReadOptions` (Rust) / `HudiReadOptions` (Python) value. It stores three fields — `filters`, `projection`, and `hudi_options` — and exposes chainable `with_*` builders for the rest. The available knobs:
 
-- `query_type` (`with_query_type`) — `Snapshot` (default) or `Incremental`. Drives dispatch in `read`, `read_stream`, and `get_file_slices`.
+- `query_type` (`with_query_type`) — `Snapshot` (default) or `Incremental`. Drives dispatch in `read`, `read_stream`, `get_file_slices`, and `get_file_slices_stream`.
 - `filters` — column filters as `(field, op, value)` tuples. The field can be any column (partition or data). Used for partition pruning, file-level stats pruning (snapshot only), and row-level filtering.
 - `projection` — columns to return. Streaming pushes the projection down to the parquet reader; eager reads project after merging.
 - `batch_size` (`with_batch_size`) — rows per batch (streaming only; eager reads return one batch per file slice).
@@ -336,6 +336,7 @@ All read APIs accept a `ReadOptions` (Rust) / `HudiReadOptions` (Python) value. 
 | Stage           | API                                                              | Description                                                                                              |
 |-----------------|------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
 | Query planning  | `get_file_slices(options)`                                       | Get the file slices the read targets, dispatched on `options.query_type`. To bucket for parallel reads, call `hudi::util::collection::split_into_chunks` on the result. |
+|                 | `get_file_slices_stream(options)` (Rust)                         | Stream targeted file slices as partition planning completes. Global order is unspecified. Storage-backed snapshots bound in-flight partition listings; metadata-table records and the incremental touched-file-group lookup remain eager. |
 |                 | `compute_table_stats(options)`                                   | Estimated `(num_rows, byte_size)` for scan planning. Snapshot (default) uses the metadata table; incremental aggregates from changed file slices. Returns `None` when stats cannot be computed. |
 | Query execution | `create_file_group_reader_with_options(read_options, extra_storage_overrides)` | Create a file group reader with the table's configs. Both args are optional. Timestamps are resolved automatically (e.g. `AsOfTimestamp` → `EndTimestamp`), so callers can pass the same options used for `get_file_slices`. |
 |                 | `read(options)` / `read_stream(options)`                         | Record-read APIs. Dispatch on `options.query_type`. `read_stream` errors on `Incremental` for now. Per-slice streaming lives on `FileGroupReader`. |

--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -25,6 +25,8 @@ use std::sync::Arc;
 
 use async_recursion::async_recursion;
 use bytes::Bytes;
+use futures::StreamExt;
+use futures::stream::BoxStream;
 use object_store::path::Path as ObjPath;
 use object_store::{ObjectStore, parse_url_opts};
 use url::Url;
@@ -257,6 +259,46 @@ impl Storage {
         }
         Ok(file_metadata)
     }
+
+    /// Recursively stream files below the table base path.
+    ///
+    /// Each item is a table-relative object path.
+    /// Unlike [`Self::list_files`], this uses the object store's paginated
+    /// `list` stream and does not wait for a complete directory result.
+    pub(crate) fn list_relative_paths_stream(&self) -> Result<BoxStream<'static, Result<String>>> {
+        let prefix_url = join_url_segments(&self.base_url, &[""])?;
+        let prefix_path = ObjPath::from_url_path(prefix_url.path())?;
+        let prefix = prefix_path.as_ref().trim_end_matches('/').to_string();
+
+        Ok(self
+            .object_store
+            .list(Some(&prefix_path))
+            .map(move |result| {
+                let object = result?;
+                let location = object.location.as_ref();
+                let suffix = location.strip_prefix(&prefix).ok_or_else(|| {
+                    InvalidPath(format!(
+                        "Object path '{location}' is not below table prefix '{prefix}'"
+                    ))
+                })?;
+                let relative_path = if prefix.is_empty() {
+                    suffix
+                } else {
+                    suffix.strip_prefix('/').ok_or_else(|| {
+                        InvalidPath(format!(
+                            "Object path '{location}' is not below table prefix '{prefix}'"
+                        ))
+                    })?
+                };
+                if relative_path.is_empty() {
+                    return Err(InvalidPath(format!(
+                        "Object path '{location}' has no path below table prefix '{prefix}'"
+                    )));
+                }
+                Ok(relative_path.to_string())
+            })
+            .boxed())
+    }
 }
 
 /// Get relative paths of leaf directories under a given directory.
@@ -419,6 +461,53 @@ mod tests {
 
         assert!(!files.iter().any(|f| f.name.ends_with(".crc")));
         assert_eq!(files, vec![FileMetadata::new("a.parquet", 0)]);
+    }
+
+    #[tokio::test]
+    async fn storage_streams_table_relative_paths_recursively() {
+        use futures::TryStreamExt;
+
+        let base_url = Url::from_directory_path(
+            canonicalize(Path::new("tests/data/timeline/commits_stub")).unwrap(),
+        )
+        .unwrap();
+        let storage = Storage::new_with_base_url(base_url).unwrap();
+        let paths: HashSet<String> = storage
+            .list_relative_paths_stream()
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+
+        assert!(paths.contains("a.parquet"));
+        assert!(paths.contains("part1/b.parquet"));
+        assert!(paths.contains("part2/part22/c.parquet"));
+        assert!(paths.contains("part3/part32/part33/d.parquet"));
+        assert!(paths.iter().all(|path| !path.starts_with('/')));
+    }
+
+    #[tokio::test]
+    async fn storage_recursive_stream_respects_non_empty_prefix_boundary() {
+        use futures::TryStreamExt;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let table_dir = temp_dir.path().join("table");
+        let sibling_dir = temp_dir.path().join("table-sibling");
+        std::fs::create_dir_all(table_dir.join("partition")).unwrap();
+        std::fs::create_dir_all(&sibling_dir).unwrap();
+        std::fs::write(table_dir.join("partition/inside.parquet"), []).unwrap();
+        std::fs::write(sibling_dir.join("outside.parquet"), []).unwrap();
+
+        let base_url = Url::from_directory_path(&table_dir).unwrap();
+        let storage = Storage::new_with_base_url(base_url).unwrap();
+        let paths = storage
+            .list_relative_paths_stream()
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        assert_eq!(paths, vec!["partition/inside.parquet"]);
     }
 
     #[tokio::test]

--- a/crates/core/src/table/fs_view.rs
+++ b/crates/core/src/table/fs_view.rs
@@ -39,6 +39,8 @@ use crate::table::listing::FileLister;
 use crate::table::partition::PartitionPruner;
 use crate::timeline::view::TimelineView;
 use dashmap::DashMap;
+use futures::stream::{self, BoxStream};
+use futures::{StreamExt, TryStreamExt};
 
 /// A view of the Hudi table's data files (files stored outside the `.hoodie/` directory) in the file system. It provides APIs to load and
 /// access the file groups and file slices.
@@ -305,6 +307,99 @@ impl FileSystemView {
 
         self.collect_file_slices(partition_pruner, timeline_view)
             .await
+    }
+
+    /// Stream file slices as each partition's file groups become available.
+    ///
+    /// Storage-backed listing retains only the bounded set of partition
+    /// listings in flight plus the current partition's file groups. Metadata
+    /// table records are still fetched eagerly because that reader does not yet
+    /// expose a row stream.
+    pub(crate) async fn get_file_slices_stream(
+        &self,
+        partition_pruner: &PartitionPruner,
+        file_pruner: &FilePruner,
+        table_schema: &Schema,
+        timeline_view: Arc<TimelineView>,
+        metadata_table: Option<&Table>,
+        estimator: Option<FileStatsEstimator>,
+    ) -> Result<BoxStream<'static, Result<FileSlice>>> {
+        let configured_base_file_format = self.configured_base_file_format()?;
+        let metadata_backed = metadata_table.is_some();
+
+        let file_groups_stream: BoxStream<'static, Result<(String, Vec<FileGroup>)>> =
+            if let Some(mdt) = metadata_table {
+                let records = mdt.fetch_files_partition_records(partition_pruner).await?;
+                let file_groups = file_groups_from_files_partition_records(
+                    &records,
+                    configured_base_file_format.as_ref(),
+                    timeline_view.as_ref(),
+                    estimator.as_ref(),
+                )?;
+                stream::iter(file_groups.into_iter().map(Ok)).boxed()
+            } else {
+                let lister = FileLister::new(
+                    self.hudi_configs.clone(),
+                    self.storage.clone(),
+                    partition_pruner.clone(),
+                );
+                lister
+                    .list_file_groups_for_relevant_partitions_stream(
+                        timeline_view.clone(),
+                        estimator,
+                    )
+                    .await?
+            };
+
+        let view = self.clone();
+        let partition_pruner = partition_pruner.clone();
+        let file_pruner = file_pruner.clone();
+        let table_schema = table_schema.clone();
+
+        Ok(file_groups_stream
+            .then(move |result| {
+                let view = view.clone();
+                let partition_pruner = partition_pruner.clone();
+                let file_pruner = file_pruner.clone();
+                let table_schema = table_schema.clone();
+                let timeline_view = timeline_view.clone();
+                let configured_base_file_format = configured_base_file_format.clone();
+                async move {
+                    let (partition_path, file_groups) = result?;
+                    if metadata_backed
+                        && !partition_pruner.is_empty()
+                        && !partition_pruner.should_include(&partition_path)
+                    {
+                        return Ok::<Vec<FileSlice>, crate::error::CoreError>(Vec::new());
+                    }
+
+                    let retained = view
+                        .apply_stats_pruning_from_footers(
+                            file_groups,
+                            &file_pruner,
+                            &table_schema,
+                            timeline_view.as_of_timestamp(),
+                            configured_base_file_format.as_ref(),
+                        )
+                        .await;
+
+                    let timestamp = timeline_view.as_of_timestamp();
+                    let excluding_file_groups = timeline_view.excluding_file_groups();
+                    let mut slices = Vec::new();
+                    for file_group in retained {
+                        if excluding_file_groups.contains(&file_group) {
+                            continue;
+                        }
+                        if let Some(file_slice) = file_group.get_file_slice_as_of(timestamp) {
+                            slices.push(file_slice.clone());
+                        }
+                    }
+                    Ok::<Vec<FileSlice>, crate::error::CoreError>(slices)
+                }
+            })
+            .map_ok(|slices| stream::iter(slices.into_iter().map(Ok)))
+            .try_flatten()
+            .boxed())
     }
 
     /// Get file slices using storage listing only.

--- a/crates/core/src/table/listing.rs
+++ b/crates/core/src/table/listing.rs
@@ -32,8 +32,9 @@ use crate::table::partition::{
 };
 use crate::timeline::completion_time::CompletionTimeView;
 use dashmap::DashMap;
+use futures::stream::BoxStream;
 use futures::{StreamExt, TryStreamExt, stream};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 #[derive(Clone, Debug)]
@@ -200,6 +201,47 @@ impl FileLister {
             .collect())
     }
 
+    /// Discover relevant partitions from the object store's recursive listing
+    /// without waiting to materialize the table-wide partition path vector.
+    ///
+    /// A set of emitted partition paths is retained because object stores do
+    /// not guarantee that objects from the same partition are contiguous. The
+    /// set holds one path string per partition; file metadata, file groups, and
+    /// slices remain bounded by downstream concurrency.
+    fn list_relevant_partition_paths_stream(&self) -> Result<BoxStream<'static, Result<String>>> {
+        if !is_table_partitioned(&self.hudi_configs)? {
+            return Ok(stream::once(async { Ok(EMPTY_PARTITION_PATH.to_string()) }).boxed());
+        }
+
+        let paths = self.storage.list_relative_paths_stream()?;
+        let partition_pruner = self.partition_pruner.clone();
+        Ok(
+            stream::try_unfold((paths, HashSet::new()), move |(mut paths, mut seen)| {
+                let partition_pruner = partition_pruner.clone();
+                async move {
+                    while let Some(relative_path) = paths.try_next().await? {
+                        let first_segment = relative_path.split('/').next().unwrap_or_default();
+                        if LAKE_FORMAT_METADATA_DIRS.contains(&first_segment) {
+                            continue;
+                        }
+
+                        let Some((partition_path, _)) = relative_path.rsplit_once('/') else {
+                            continue;
+                        };
+                        if (partition_pruner.is_empty()
+                            || partition_pruner.should_include(partition_path))
+                            && seen.insert(partition_path.to_string())
+                        {
+                            return Ok(Some((partition_path.to_string(), (paths, seen))));
+                        }
+                    }
+                    Ok(None)
+                }
+            })
+            .boxed(),
+        )
+    }
+
     /// List file groups for all relevant partitions.
     ///
     /// # Arguments
@@ -243,6 +285,49 @@ impl FileLister {
             .await?;
 
         Ok(file_groups_map.as_ref().to_owned())
+    }
+
+    /// Stream file groups one partition at a time.
+    ///
+    /// Partition discovery and per-partition file listing are both deferred
+    /// until the returned stream is polled. The recursive discovery listing
+    /// intentionally does not reuse its individual file entries: object stores
+    /// do not guarantee per-partition contiguity, so doing so correctly would
+    /// retain incomplete file groups for the whole table. Each newly discovered
+    /// partition therefore gets one delimiter listing to obtain its complete
+    /// file set. At most
+    /// `hoodie.plan.listing.parallelism` partition listings are in flight, so
+    /// callers can consume completed partitions without retaining every table
+    /// file group or slice in memory.
+    pub async fn list_file_groups_for_relevant_partitions_stream<
+        V: CompletionTimeView + Send + Sync + 'static,
+    >(
+        &self,
+        completion_time_view: Arc<V>,
+        estimator: Option<FileStatsEstimator>,
+    ) -> Result<BoxStream<'static, Result<(String, Vec<FileGroup>)>>> {
+        let partition_paths = self.list_relevant_partition_paths_stream()?;
+        let parallelism = self.hudi_configs.get_or_default(ListingParallelism).into();
+        let lister = self.clone();
+
+        Ok(partition_paths
+            .map_ok(move |partition_path| {
+                let lister = lister.clone();
+                let completion_time_view = completion_time_view.clone();
+                let estimator = estimator.clone();
+                async move {
+                    let file_groups = lister
+                        .list_file_groups_for_partition(
+                            &partition_path,
+                            completion_time_view.as_ref(),
+                            estimator.as_ref(),
+                        )
+                        .await?;
+                    Ok::<_, CoreError>((partition_path, file_groups))
+                }
+            })
+            .try_buffer_unordered(parallelism)
+            .boxed())
     }
 }
 

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -518,6 +518,158 @@ impl Table {
         }
     }
 
+    /// Stream the [`FileSlice`]s targeted by a read.
+    ///
+    /// Snapshot queries list files with bounded partition concurrency and emit
+    /// slices as each partition completes instead of retaining the table-wide
+    /// file-group and slice collections. Metadata-table-backed snapshots still
+    /// fetch the metadata records eagerly because that reader does not yet
+    /// expose a row stream. Incremental planning retains its existing eager
+    /// touched-file-group lookup, then exposes the resulting slices as a stream.
+    ///
+    /// The stream has no stable global ordering; consumers that require one
+    /// should sort by partition path and file ID after collection. Listing work
+    /// is driven by polling the stream; dropping it cancels the in-flight
+    /// partition futures without spawning detached tasks.
+    ///
+    /// # Example
+    /// ```ignore
+    /// use futures::TryStreamExt;
+    /// use hudi::table::ReadOptions;
+    ///
+    /// let mut slices = table.get_file_slices_stream(&ReadOptions::new()).await?;
+    /// while let Some(slice) = slices.try_next().await? {
+    ///     schedule(slice);
+    /// }
+    /// ```
+    pub async fn get_file_slices_stream(
+        &self,
+        options: &ReadOptions,
+    ) -> Result<futures::stream::BoxStream<'static, Result<FileSlice>>> {
+        use futures::StreamExt;
+        use futures::stream;
+
+        let prepared = self.prepare_reader_options(options)?;
+        let base_file_only = self.is_base_file_only(&prepared)?;
+        match prepared.query_type()? {
+            QueryType::Snapshot => {
+                let Some(timestamp) = prepared.end_timestamp() else {
+                    return Ok(stream::empty().boxed());
+                };
+                self.get_file_slices_stream_inner(timestamp, &prepared.filters, base_file_only)
+                    .await
+            }
+            QueryType::Incremental => {
+                let (Some(start), Some(end)) =
+                    (prepared.start_timestamp(), prepared.end_timestamp())
+                else {
+                    return Ok(stream::empty().boxed());
+                };
+                self.get_file_slices_between_stream_inner(
+                    start,
+                    end,
+                    &prepared.filters,
+                    base_file_only,
+                )
+                .await
+            }
+        }
+    }
+
+    async fn get_file_slices_between_stream_inner(
+        &self,
+        start_timestamp: &str,
+        end_timestamp: &str,
+        filters: &[Filter],
+        base_file_only: bool,
+    ) -> Result<futures::stream::BoxStream<'static, Result<FileSlice>>> {
+        use futures::future;
+        use futures::{StreamExt, TryStreamExt};
+
+        let estimator = self.get_or_init_estimator(end_timestamp).await;
+        let file_groups = self
+            .timeline
+            .get_file_groups_between(Some(start_timestamp), Some(end_timestamp), estimator)
+            .await?;
+        let mut touched: HashMap<String, HashSet<String>> = HashMap::new();
+        for file_group in file_groups {
+            touched
+                .entry(file_group.partition_path)
+                .or_default()
+                .insert(file_group.file_id);
+        }
+
+        let stream = self
+            .get_file_slices_stream_inner(end_timestamp, filters, base_file_only)
+            .await?;
+        Ok(stream
+            .try_filter(move |slice| {
+                future::ready(
+                    touched
+                        .get(&slice.partition_path)
+                        .is_some_and(|file_ids| file_ids.contains(slice.file_id())),
+                )
+            })
+            .boxed())
+    }
+
+    async fn get_file_slices_stream_inner(
+        &self,
+        timestamp: &str,
+        filters: &[Filter],
+        base_file_only: bool,
+    ) -> Result<futures::stream::BoxStream<'static, Result<FileSlice>>> {
+        use futures::{StreamExt, TryStreamExt};
+
+        let timeline_view = Arc::new(self.timeline.create_view_as_of(timestamp).await?);
+        let partition_schema = self.get_partition_schema().await?;
+        let table_schema = self.get_schema_with_meta_fields().await?;
+        validate_fields_against_schemas(filters, [&table_schema, &partition_schema])?;
+
+        let partition_pruner =
+            PartitionPruner::new(filters, &partition_schema, self.hudi_configs.as_ref())?;
+        let file_pruner = if base_file_only {
+            FilePruner::new(filters, &table_schema, &partition_schema)?
+        } else {
+            FilePruner::empty()
+        };
+
+        let metadata_table = if self.is_metadata_table_enabled() {
+            match self.get_or_init_metadata_table().await {
+                Ok(mdt) => Some(mdt),
+                Err(e) => {
+                    log::warn!(
+                        "Failed to create metadata table, falling back to storage listing: {e}"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        let estimator = self.get_or_init_estimator(timestamp).await.cloned();
+        let stream = self
+            .file_system_view
+            .get_file_slices_stream(
+                &partition_pruner,
+                &file_pruner,
+                &table_schema,
+                timeline_view,
+                metadata_table,
+                estimator,
+            )
+            .await?;
+
+        Ok(stream
+            .map_ok(move |mut slice| {
+                if base_file_only {
+                    slice.log_files.clear();
+                }
+                slice
+            })
+            .boxed())
+    }
+
     async fn get_file_slices_inner(
         &self,
         timestamp: &str,
@@ -1761,7 +1913,7 @@ mod tests {
 
     #[tokio::test]
     async fn empty_hudi_table_read_apis_return_empty() {
-        use futures::StreamExt;
+        use futures::{StreamExt, TryStreamExt};
 
         let base_url = SampleTable::V6Empty.url_to_cow();
         let hudi_table = Table::new(base_url.path()).await.unwrap();
@@ -1781,6 +1933,15 @@ mod tests {
 
         let mut snapshot_stream = hudi_table.read_stream(&ReadOptions::new()).await.unwrap();
         assert!(snapshot_stream.next().await.is_none());
+
+        let file_slices = hudi_table
+            .get_file_slices_stream(&ReadOptions::new())
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert!(file_slices.is_empty());
     }
 
     #[tokio::test]
@@ -1893,6 +2054,130 @@ mod tests {
             .unwrap();
         assert!(!snapshot_slices.is_empty());
         assert!(!incremental_slices.is_empty());
+    }
+
+    #[tokio::test]
+    async fn hudi_table_get_file_slices_stream_matches_eager_snapshot() -> Result<()> {
+        use futures::TryStreamExt;
+
+        let base_url = SampleTable::V6SimplekeygenNonhivestyle.url_to_cow();
+        let hudi_table = Table::new(base_url.path()).await?;
+        let options = ReadOptions::new().with_filters([("byteField", ">=", "20")])?;
+
+        let mut eager = hudi_table.get_file_slices(&options).await?;
+        let mut streamed = hudi_table
+            .get_file_slices_stream(&options)
+            .await?
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        let compare = |left: &FileSlice, right: &FileSlice| {
+            left.partition_path
+                .cmp(&right.partition_path)
+                .then_with(|| left.file_id().cmp(right.file_id()))
+                .then_with(|| {
+                    left.creation_instant_time()
+                        .cmp(right.creation_instant_time())
+                })
+        };
+        eager.sort_by(compare);
+        streamed.sort_by(compare);
+        assert_eq!(streamed, eager);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn hudi_table_get_file_slices_stream_matches_eager_metadata_snapshot() -> Result<()> {
+        use futures::TryStreamExt;
+
+        let base_url = SampleTable::V9TxnsSimpleMeta.url_to_cow();
+        let hudi_table = Table::new(base_url.path()).await?;
+        assert!(hudi_table.is_metadata_table_enabled());
+
+        let mut eager = hudi_table.get_file_slices(&ReadOptions::new()).await?;
+        let mut streamed = hudi_table
+            .get_file_slices_stream(&ReadOptions::new())
+            .await?
+            .try_collect::<Vec<_>>()
+            .await?;
+        eager.sort_by(|left, right| {
+            left.partition_path
+                .cmp(&right.partition_path)
+                .then_with(|| left.file_id().cmp(right.file_id()))
+        });
+        streamed.sort_by(|left, right| {
+            left.partition_path
+                .cmp(&right.partition_path)
+                .then_with(|| left.file_id().cmp(right.file_id()))
+        });
+        assert_eq!(streamed, eager);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn hudi_table_get_file_slices_stream_matches_eager_incremental() -> Result<()> {
+        use futures::TryStreamExt;
+
+        let base_url = SampleTable::V6Nonpartitioned.url_to_cow();
+        let hudi_table = Table::new(base_url.path()).await?;
+        let options = ReadOptions::new()
+            .with_query_type(QueryType::Incremental)
+            .with_start_timestamp(EARLIEST_START_TIMESTAMP);
+
+        let eager = hudi_table.get_file_slices(&options).await?;
+        let streamed = hudi_table
+            .get_file_slices_stream(&options)
+            .await?
+            .try_collect::<Vec<_>>()
+            .await?;
+        assert_eq!(streamed, eager);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn hudi_table_get_file_slices_stream_emits_before_later_partition_error() -> Result<()> {
+        use crate::config::plan::HudiPlanConfig;
+        use futures::TryStreamExt;
+        use std::path::Path;
+
+        let table_path = SampleTable::V6SimplekeygenNonhivestyle.path_to_cow_fresh();
+        let bad_partition = Path::new(&table_path).join("z-bad");
+        std::fs::create_dir_all(&bad_partition).unwrap();
+        std::fs::write(bad_partition.join("not-a-hudi-name.parquet"), []).unwrap();
+
+        let hudi_table = Table::new_with_options(
+            &table_path,
+            // With one in-flight partition, `try_buffer_unordered` cannot pull
+            // z-bad from the discovery stream until the first partition's
+            // future has yielded. The first assertion therefore distinguishes
+            // streaming discovery from a path that discovers every partition
+            // before it emits anything.
+            [(HudiPlanConfig::ListingParallelism, "1")],
+        )
+        .await?;
+        assert!(
+            hudi_table
+                .get_file_slices(&ReadOptions::new())
+                .await
+                .is_err(),
+            "the eager API cannot return any slice when a later partition fails"
+        );
+
+        let mut stream = hudi_table
+            .get_file_slices_stream(&ReadOptions::new())
+            .await?;
+        let first = stream
+            .try_next()
+            .await?
+            .expect("a valid partition must be emitted before z-bad is listed");
+        assert_ne!(first.partition_path, "z-bad");
+
+        let error = stream
+            .try_collect::<Vec<_>>()
+            .await
+            .expect_err("the malformed later partition must still propagate its error");
+        assert!(error.to_string().contains("not-a-hudi-name.parquet"));
+        Ok(())
     }
 
     #[tokio::test]

--- a/docs/reader-spec.md
+++ b/docs/reader-spec.md
@@ -62,14 +62,14 @@ Per-slice reads — reading a single `FileSlice` the caller already selected (ty
 | `with_end_timestamp(ts)`     | `hoodie.read.end.timestamp`                  | latest commit (Incremental only)          |
 | `with_batch_size(n)`         | `hoodie.read.stream.batch_size`              | `1024` (streaming only)                   |
 
-Timestamp resolution: all four public entry points — `read`, `read_stream`, `get_file_slices`, and `create_file_group_reader_with_options` — go through a single `prepare_reader_options` step that (1) strips timestamps irrelevant to the query type (snapshot discards `start/end_timestamp`; incremental discards `as_of_timestamp`) and (2) resolves the remaining timestamps into the `EndTimestamp` / `StartTimestamp` that `FileGroupReader` needs for log-scan bounds and commit-time filtering. Callers may set all three for convenience; only the applicable ones take effect.
+Timestamp resolution: all five public entry points — `read`, `read_stream`, `get_file_slices`, `get_file_slices_stream`, and `create_file_group_reader_with_options` — go through a single `prepare_reader_options` step that (1) strips timestamps irrelevant to the query type (snapshot discards `start/end_timestamp`; incremental discards `as_of_timestamp`) and (2) resolves the remaining timestamps into the `EndTimestamp` / `StartTimestamp` that `FileGroupReader` needs for log-scan bounds and commit-time filtering. Callers may set all three for convenience; only the applicable ones take effect.
 
 Which knobs each API consumes:
 
 | API                                                              | query type | as-of | start/end | filters | projection | batch size | hudi_options pass-through |
 |------------------------------------------------------------------|:----------:|:-----:|:---------:|:-------:|:----------:|:----------:|:-------------------------:|
 | `read` / `read_stream`                                           | yes        | when Snapshot | when Incremental | yes | yes | streaming | yes |
-| `get_file_slices`                                                | yes        | when Snapshot | when Incremental | yes | — | — | — |
+| `get_file_slices` / `get_file_slices_stream`                     | yes        | when Snapshot | when Incremental | yes | — | — | — |
 | `create_file_group_reader_with_options`                          | yes        | when Snapshot | when Incremental | — | — | — | yes |
 | `FileGroupReader::read_file_slice` / `_from_paths`               | —          | — | — | yes | yes | — | — |
 | `FileGroupReader::read_file_slice_stream` / `_from_paths_stream` | —          | — | — | yes | yes | yes | — |
@@ -79,7 +79,7 @@ Notes:
 - `read_stream` errors with `Unsupported` for `query_type = Incremental` — incremental streaming is not yet implemented.
 - The `hudi_options` bag is a per-read override layer — set arbitrary `hoodie.read.*` configs (e.g. `hoodie.read.use.read_optimized.mode = true`) for this single read. Read configs (`hoodie.read.*`) are not stored in the `Table` instance; they flow exclusively through `ReadOptions`.
 - Per-slice reads are exposed only by `FileGroupReader`. The `Table` type owns logical reads (snapshot, incremental); per-slice reads are physical and belong at the file-group layer. To read one slice with table-level configs, build a `FileGroupReader` via `Table::create_file_group_reader_with_options` and call its per-slice methods. The method resolves timestamps automatically (e.g. `AsOfTimestamp` → `EndTimestamp`), so callers can pass the same `ReadOptions` used for `get_file_slices`.
-- For parallel reads, call `get_file_slices(...)` and bucket the result with `hudi::util::collection::split_into_chunks` or your engine's preferred partitioning policy.
+- For parallel reads, call `get_file_slices(...)` and bucket the result with `hudi::util::collection::split_into_chunks`, or consume `get_file_slices_stream(...)` directly as unordered partition plans become available. Storage-backed snapshots bound in-flight partition listings. Metadata-table records and the incremental touched-file-group lookup are still materialized eagerly.
 
 Timestamp formats are documented in [§6](#timestamps).
 
@@ -123,6 +123,7 @@ All public symbols are re-exported from the `hudi` crate.
 | `get_partition_schema()`                                                   | `Result<Schema>`                                     |
 | `get_timeline()`                                                           | `&Timeline`                                          |
 | `get_file_slices(&ReadOptions)`                                            | `Result<Vec<FileSlice>>` (dispatches on `query_type`) |
+| `get_file_slices_stream(&ReadOptions)`                                     | `Result<BoxStream<'static, Result<FileSlice>>>` (unordered; dispatches on `query_type`) |
 | `create_file_group_reader_with_options(read_options, extra_storage_overrides)` | `Result<FileGroupReader>`                            |
 | `read(&ReadOptions)`                                                       | `Result<Vec<RecordBatch>>` (dispatches on `query_type`) |
 | `read_stream(&ReadOptions)`                                                | `Result<BoxStream<'static, Result<RecordBatch>>>` (errors on `Incremental`) |
@@ -320,7 +321,7 @@ A timezone offset (`Z` or `±HH:MM`) is required for RFC 3339 inputs — naive `
 
 ### Empty results
 
-A table with no completed commits yields empty `Vec` / `List` for eager reads and `get_file_slices`, and an empty stream for `read_stream`.
+A table with no completed commits yields empty `Vec` / `List` for eager reads and `get_file_slices`, and an empty stream for `read_stream` and `get_file_slices_stream`.
 
 ### Errors
 


### PR DESCRIPTION
## Description

Add `Table::get_file_slices_stream` so engines can begin scheduling reads before every partition and file slice has been planned.

For storage-backed tables, the new path:

- discovers partition paths from the object store's recursive stream;
- deduplicates and prunes partitions as paths arrive;
- bounds per-partition listings with `hoodie.plan.listing.parallelism`;
- applies footer pruning and timeline exclusion per partition;
- emits slices without a table-wide file-group or file-slice collection.

Snapshot and incremental query semantics match `get_file_slices`. Incremental planning still materializes the touched file-group set. Metadata-table-backed planning still materializes files-partition records because the metadata reader does not expose a row stream. Both paths use the new public stream API without changing the eager API.

The recursive discovery pass intentionally performs one delimiter listing for each emitted partition. Object stores do not guarantee partition-contiguous object order; reusing discovery entries would require retaining incomplete file groups table-wide. The stream instead retains one deduplication entry per emitted partition and bounds file groups and slices by listing concurrency. Global stream order is intentionally unspecified.

On a synthetic local table with 2,003 slices, the eager API returned only after all 2,003 slices were materialized. Post-change runs yielded the first slice in 244–262 ms and drained all 2,003 slices in 2.1–4.2 s under concurrent system load. These measurements demonstrate time-to-first-slice behavior, not a stable total-throughput improvement.

Closes #590.

Related: #597 optimizes the existing eager recursive listing path. This change adds a separate object-store-backed stream and does not modify `get_leaf_dirs`.

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [x] Manual tests
  - [x] Details are described below

Automated coverage verifies snapshot, incremental, metadata-table, and empty-table parity; first-slice-before-complete-discovery behavior; deferred listing-error propagation; recursive relative paths; and non-empty table-prefix boundaries.

Manual verification used the synthetic 2,003-slice table described above and confirmed that the eager and streamed APIs both returned all 2,003 slices.

Commands run:

- `cargo fmt --all -- --check`
- `cargo clippy -p hudi-core --all-targets --no-default-features -- -D warnings`
- `cargo clippy -p hudi-core --all-targets --all-features -- -D warnings`
- `cargo test -p hudi-core --no-default-features`
- `cargo test -p hudi-core --lib`
- `cargo check -p hudi -p hudi-cpp -p hudi-python --no-default-features`
- `cargo doc -p hudi-core --no-default-features --no-deps`