### PR TITLE
fix(python): compile the datafusion feature into every python build

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -58,6 +58,10 @@ datafusion = [
 
 [tool.maturin]
 module-name = "hudi._internal"
+# hudi/__init__.py exports HudiDataFusionDataSource unconditionally, so every
+# build (wheel or from-sdist) must compile the datafusion feature or the
+# resulting package fails on `import hudi`.
+features = ["datafusion"]
 
 [tool.ruff]
 target-version = 'py310'


### PR DESCRIPTION
## Description

`python/hudi/__init__.py` imports `HudiDataFusionDataSource` unconditionally, but the class is compiled only under the `datafusion` cargo feature and `python/Cargo.toml` defaults to no features. The release workflow passes no feature flags to maturin, so a 0.5.0 wheel or sdist built by it fails on `import hudi` with an ImportError. This was introduced after 0.4.0 (#412), so no published artifact is affected yet; this prevents the first broken release.

Declaring `features = ["datafusion"]` in `[tool.maturin]` fixes both artifact kinds with one setting: maturin reads it for CLI builds (the release wheel jobs) and for PEP 517 builds (a user installing the sdist), where a workflow-level `--features` flag would not reach. Importing without the `datafusion` Python package still works; that package is only needed when handing the table to a DataFusion `SessionContext`, which is what the `hudi[datafusion]` extra installs.

Note for the release: the wheels will now compile DataFusion on targets the CI test matrix does not cover (Windows, cross x86_64 macOS), and they will be noticeably larger than 0.4.0's. A dry-run build of those two targets before tagging would be prudent.

## How are the changes test-covered

- [ ] N/A
- [ ] Automated tests (unit and/or integration tests)
- [x] Manual tests
  - [x] Details are described below

Built three wheels locally and installed each into a clean venv: one the way the release workflow currently builds (reproduces the ImportError), one with `--features datafusion` on the CLI, and one with no CLI flags relying on this `[tool.maturin]` setting. The latter two import cleanly and expose `HudiDataFusionDataSource`.
