### PR TITLE
fix(release): align the release guide and scripts with their actual behavior

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -93,8 +93,11 @@ Create and merge a PR to bump the major or minor version on the `main` branch, u
 `./release/bump_version_in_main.sh`. For example, if the current version is `0.5.0-dev`, bump it to
 `0.6.0-dev` (minor) or `1.0.0-dev` (major); `main` always carries the `-dev` suffix.
 
-On the release branch, bump the version to indicate pre-release by pushing a commit. Pre-releases
-use `rc.1`, `rc.2`, etc; the release scripts accept only `X.Y.Z` and `X.Y.Z-rc.W` versions.
+On the release branch, bump the version to indicate pre-release by pushing a commit.
+
+- If it is meant for internal testing, go with `alpha.1`, `alpha.2`, etc
+- If it is meant for public testing, go with `beta.1`, `beta.2`, etc
+- If it is ready for voting, go with `rc.1`, `rc.2`, etc
 
 ```shell
 RELEASE_VER=x.y.z-rc.1
@@ -115,7 +118,7 @@ Once the "bump version" commit is pushed, the CI tests will be triggered and run
 Tag the revision locally for the RC. The tag should match to the version in the form of `release-*`. For example,
 
 - If the release is `0.1.0-rc.1`, the tag should `release-0.1.0-rc.1`
-- If the release is `2.0.0-rc.2`, the tag should `release-2.0.0-rc.2`
+- If the release is `2.0.0-beta.2`, the tag should `release-2.0.0-beta.2`
 
 > [!NOTE]
 > The local tag is required by the script for source release upload in the next step.

--- a/release/README.md
+++ b/release/README.md
@@ -31,7 +31,7 @@ This issue tracks the release process as instructed in the [release guide](https
 
 ### Issues
 
-- [ ] All other issues in the [release milestone](https://github.com/apache/hudi-rs/milestone/1) should be closed.
+- [ ] All other issues in the [release milestone](https://github.com/apache/hudi-rs/milestone/xxx) should be closed.
 
 > [!IMPORTANT]
 > Highlight blocker issues if any
@@ -89,8 +89,9 @@ named `release/1.0.x`.
 For a patch release, don't cut a new branch, use its base release branch. For example, if it's `0.3.1`, cherry-pick
 fixes to `release/0.3.x`.
 
-Create and merge a PR to bump the major or minor version on the `main` branch. For example, if the current version
-is `0.3.0`, bump it to `0.5.0` or `1.0.0`.
+Create and merge a PR to bump the major or minor version on the `main` branch, using
+`./release/bump_version_in_main.sh`. For example, if the current version is `0.5.0-dev`, bump it to
+`0.6.0-dev` (minor) or `1.0.0-dev` (major); `main` always carries the `-dev` suffix.
 
 On the release branch, bump the version to indicate pre-release by pushing a commit.
 
@@ -273,7 +274,8 @@ CODE_SIGNING_KEY=<your code-signing key id>
 
 ./release/upload_src_release_to_dev.sh $RELEASE_VER $CODE_SIGNING_KEY
 
-./release/publish_src_release.sh $RELEASE_VER $CODE_SIGNING_KEY
+# re-uses the already-signed artifacts from the dev repo, so no signing key is needed
+./release/publish_src_release.sh $RELEASE_VER
 ```
 
 // TODO support verify local copy
@@ -317,7 +319,7 @@ git cliff release-$PREV_RELEASE_VER..HEAD | pbcopy
 git cliff release-$PREV_RELEASE_VER..HEAD | xclip
 ```
 
-In your fork, create a new branch from `main`, prepend the clipboard content to `changelog.md`, then commit and open a PR to merge into `main`.
+In your fork, create a new branch from `main`, prepend the clipboard content to `CHANGELOG.md`, then commit and open a PR to merge into `main`.
 
 ```shell
 git commit -am "chore: update changelog for x.y.z"

--- a/release/README.md
+++ b/release/README.md
@@ -93,11 +93,8 @@ Create and merge a PR to bump the major or minor version on the `main` branch, u
 `./release/bump_version_in_main.sh`. For example, if the current version is `0.5.0-dev`, bump it to
 `0.6.0-dev` (minor) or `1.0.0-dev` (major); `main` always carries the `-dev` suffix.
 
-On the release branch, bump the version to indicate pre-release by pushing a commit.
-
-- If it is meant for internal testing, go with `alpha.1`, `alpha.2`, etc
-- If it is meant for public testing, go with `beta.1`, `beta.2`, etc
-- If it is ready for voting, go with `rc.1`, `rc.2`, etc
+On the release branch, bump the version to indicate pre-release by pushing a commit. Pre-releases
+use `rc.1`, `rc.2`, etc; the release scripts accept only `X.Y.Z` and `X.Y.Z-rc.W` versions.
 
 ```shell
 RELEASE_VER=x.y.z-rc.1
@@ -118,7 +115,7 @@ Once the "bump version" commit is pushed, the CI tests will be triggered and run
 Tag the revision locally for the RC. The tag should match to the version in the form of `release-*`. For example,
 
 - If the release is `0.1.0-rc.1`, the tag should `release-0.1.0-rc.1`
-- If the release is `2.0.0-beta.2`, the tag should `release-2.0.0-beta.2`
+- If the release is `2.0.0-rc.2`, the tag should `release-2.0.0-rc.2`
 
 > [!NOTE]
 > The local tag is required by the script for source release upload in the next step.

--- a/release/publish_src_release.sh
+++ b/release/publish_src_release.sh
@@ -31,7 +31,9 @@ dist_dirname=hudi-rs-$hudi_version
 
 echo "❗️  Publishing $dist_dirname"
 
-work_dir="$TMPDIR$(date +'%Y-%m-%d-%H-%M-%S')"
+tmp_root="${TMPDIR:-/tmp}"
+work_dir="${tmp_root%/}/$(date +'%Y-%m-%d-%H-%M-%S')"
+mkdir -p "$work_dir"
 
 svn_dev_url="https://dist.apache.org/repos/dist/dev/hudi/$dist_dirname"
 svn_dev_dir="$work_dir/$dist_dirname"

--- a/release/upload_src_release_to_dev.sh
+++ b/release/upload_src_release_to_dev.sh
@@ -40,9 +40,9 @@ hudi_version=$1
 signing_key=$2
 repo=dev
 
-version_pattern="^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$"
+version_pattern="^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$"
 if [[ ! "$hudi_version" =~ $version_pattern ]]; then
-    echo "❌  Version must be in format X.Y.Z or X.Y.Z-rc.W"
+    echo "❌  Version must be in format X.Y.Z or X.Y.Z-{alpha|beta|rc}.W"
     exit 1
 fi
 

--- a/release/upload_src_release_to_dev.sh
+++ b/release/upload_src_release_to_dev.sh
@@ -40,9 +40,9 @@ hudi_version=$1
 signing_key=$2
 repo=dev
 
-version_pattern="^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$"
+version_pattern="^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$"
 if [[ ! "$hudi_version" =~ $version_pattern ]]; then
-    echo "❌  Version must be in format X.Y.Z or X.Y.Z-{alpha|beta|rc}.W"
+    echo "❌  Version must be in format X.Y.Z or X.Y.Z-rc.W"
     exit 1
 fi
 

--- a/release/upload_src_release_to_dev.sh
+++ b/release/upload_src_release_to_dev.sh
@@ -40,6 +40,12 @@ hudi_version=$1
 signing_key=$2
 repo=dev
 
+version_pattern="^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$"
+if [[ ! "$hudi_version" =~ $version_pattern ]]; then
+    echo "❌  Version must be in format X.Y.Z or X.Y.Z-{alpha|beta|rc}.W"
+    exit 1
+fi
+
 echo "❗️  Releasing Hudi version $hudi_version"
 echo "❗️  Uploading to https://dist.apache.org/repos/dist/$repo/hudi/"
 echo "❗️  Using signing key: $signing_key"
@@ -55,7 +61,8 @@ fi
 
 dist_repo_subpath=hudi-rs-$hudi_version
 
-work_dir="$TMPDIR$(date +'%Y-%m-%d-%H-%M-%S')"
+tmp_root="${TMPDIR:-/tmp}"
+work_dir="${tmp_root%/}/$(date +'%Y-%m-%d-%H-%M-%S')"
 src_rel_dir="$work_dir/$dist_repo_subpath"
 echo ">>> Archiving branch $curr_branch to $src_rel_dir"
 mkdir -p "$src_rel_dir"

--- a/release/verify_src_release.sh
+++ b/release/verify_src_release.sh
@@ -29,14 +29,15 @@ fi
 hudi_version=$1
 repo=$2
 
-version_pattern="^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$"
+version_pattern="^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$"
 
 if [[ ! "$hudi_version" =~ $version_pattern ]]; then
-    echo "ERROR: version must be in format X.Y.Z or X.Y.Z-rc.W"
+    echo "ERROR: version must be in format X.Y.Z or X.Y.Z-{alpha|beta|rc}.W"
     exit 1
 fi
 
-work_dir="$TMPDIR$(date +'%Y-%m-%d-%H-%M-%S')/svn_dir"
+tmp_root="${TMPDIR:-/tmp}"
+work_dir="${tmp_root%/}/$(date +'%Y-%m-%d-%H-%M-%S')/svn_dir"
 hudi_artifact="hudi-rs-$hudi_version"
 svn_url="https://dist.apache.org/repos/dist/$repo/hudi/$hudi_artifact"
 echo "Checking out src release from $svn_url to $work_dir"

--- a/release/verify_src_release.sh
+++ b/release/verify_src_release.sh
@@ -29,10 +29,10 @@ fi
 hudi_version=$1
 repo=$2
 
-version_pattern="^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$"
+version_pattern="^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$"
 
 if [[ ! "$hudi_version" =~ $version_pattern ]]; then
-    echo "ERROR: version must be in format X.Y.Z or X.Y.Z-{alpha|beta|rc}.W"
+    echo "ERROR: version must be in format X.Y.Z or X.Y.Z-rc.W"
     exit 1
 fi
 

--- a/release/verify_src_release.sh
+++ b/release/verify_src_release.sh
@@ -29,10 +29,10 @@ fi
 hudi_version=$1
 repo=$2
 
-version_pattern="^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$"
+version_pattern="^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$"
 
 if [[ ! "$hudi_version" =~ $version_pattern ]]; then
-    echo "ERROR: version must be in format X.Y.Z or X.Y.Z-rc.W"
+    echo "ERROR: version must be in format X.Y.Z or X.Y.Z-{alpha|beta|rc}.W"
     exit 1
 fi
 


### PR DESCRIPTION
## Description

Dry-reading the release guide against the release scripts ahead of 0.5.0 turned up several places where following the guide verbatim fails:

- All three scripts built their work dir as `"$TMPDIR$(date ...)"`, which aborts under `set -o nounset` on Linux where `TMPDIR` is unset, and silently produces a wrong path when `TMPDIR` is set without a trailing slash. Now normalized as `${TMPDIR:-/tmp}` with the trailing slash stripped before joining.
- `verify_src_release.sh` rejected the `alpha.N` and `beta.N` pre-release versions the guide prescribes (its regex allowed only `rc`); `upload_src_release_to_dev.sh` validated the version not at all. Both now accept exactly `X.Y.Z` with an optional `-{alpha|beta|rc}.W`.
- `publish_src_release.sh` never created its work dir before `svn co` into a subpath of it.
- Guide fixes: the version-bump example now matches `bump_version_in_main.sh` (`0.5.0-dev` bumps to `0.6.0-dev` or `1.0.0-dev`, keeping the `-dev` suffix); the publish command drops a signing-key argument the script ignores; `changelog.md` becomes `CHANGELOG.md`; the tracking-issue template's hardcoded 0.1.0 milestone link becomes a placeholder.

## How are the changes test-covered

- [ ] N/A
- [ ] Automated tests (unit and/or integration tests)
- [x] Manual tests
  - [x] Details are described below

`bash -n` on all three scripts; exercised the work-dir construction with `TMPDIR` unset, set with a trailing slash (macOS), and set without one; ran the new version regex against accepted (`0.5.0`, `0.5.0-rc.1`, `0.5.0-alpha.2`, `0.5.0-beta.1`) and rejected (`0.5.0-rc1`, `0.5.0-alpha`, `0.5.0-dev`) forms.
