### PR TITLE
build: mark hudi-jvm-ffi as not published

### DIFF
--- a/crates/jvm-ffi/Cargo.toml
+++ b/crates/jvm-ffi/Cargo.toml
@@ -18,6 +18,9 @@
 
 [package]
 name = "hudi-jvm-ffi"
+# Not published to crates.io yet; the release workflow's publish matrix
+# deliberately excludes it.
+publish = false
 version.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Description

Per the 0.5.0 release discussion in #713: `hudi-jvm-ffi` does not ship to crates.io for this release. The release workflow's publish matrix already excludes it (hudi-core, hudi-datafusion, hudi); `publish = false` records that intent in the manifest and guards against an accidental `cargo publish`.

## How are the changes test-covered

- [x] N/A
- [ ] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
