### PR TITLE
build(python): bound the datafusion extra to the 54.x major

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -53,7 +53,9 @@ lint = [
     "mypy==2.3.1",
 ]
 datafusion = [
-    "datafusion==54.0.0",
+    # The FFI contract is per DataFusion major: keep the Python package on the
+    # same major as the Rust workspace's datafusion dependency.
+    "datafusion>=54.0.0,<55",
 ]
 
 [tool.maturin]

--- a/python/src/datafusion_internal.rs
+++ b/python/src/datafusion_internal.rs
@@ -56,7 +56,7 @@ fn extract_codec(session: Bound<PyAny>) -> PyResult<FFI_LogicalExtensionCodec> {
     // holds. It does not settle which `datafusion-ffi` built it, because the
     // name carries no version: a `datafusion` wheel built against another major
     // would present the same name over a different layout. Holding the two in
-    // step is what the pinned `datafusion` extra in pyproject.toml is for.
+    // step is what the major-bounded `datafusion` extra in pyproject.toml is for.
     let codec = unsafe { codec.cast::<FFI_LogicalExtensionCodec>().as_ref() };
     Ok(codec.clone())
 }


### PR DESCRIPTION
## Description

The `hudi[datafusion]` extra pinned `datafusion==54.0.0` exactly. The FFI contract between the wheel and the Python `datafusion` package is per major version, so bound the extra to the 54.x major instead. This is forward-looking rather than a fix for a current skew: 54.0.0 is the only published 54.x on PyPI, so the range resolves identically today, but a future 54.x Python release no longer requires a hudi release to consume. Also rewords the source comment in `datafusion_internal.rs` that described the extra as pinned.

Tradeoff acknowledged: the exact pin meant a new datafusion minor arrived as a reviewable dependabot bump, while the range lets local installs float within the major; `test_datafusion_ffi.py` is the compensating guard, and an incompatibility across majors still cannot slip in.

## How are the changes test-covered

- [ ] N/A
- [ ] Automated tests (unit and/or integration tests)
- [x] Manual tests
  - [x] Details are described below

Verified the range resolves to the same 54.0.0 currently installed, and the DataFusion Python integration examples pass against it (register the table provider, run SQL, compare row counts).
