### PR TITLE
build: adopt the MSRV-aware resolver and check the MSRV in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,36 @@ jobs:
             fi
           done
 
+  # The MSRV in Cargo.toml `rust-version` is a published promise, but every
+  # other job builds with the rust-toolchain.toml dev pin, so the promise holds
+  # only while the two happen to agree. They diverged from 2026-05 to 2026-09
+  # (dev pin 1.94, declared MSRV 1.91.1) and the declared floor silently became
+  # unbuildable when aws crates raised theirs. This job compiles with the
+  # toolchain the manifest declares, read from Cargo.toml so it follows future
+  # bumps, and starts pulling real weight the moment the dev pin moves ahead of
+  # the MSRV again.
+  msrv-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler clang libclang-dev
+      - name: Install the MSRV toolchain
+        run: |
+          msrv=$(grep -m1 '^rust-version' Cargo.toml | cut -d'"' -f2)
+          if [ -z "$msrv" ]; then
+            echo "could not read rust-version from Cargo.toml"
+            exit 1
+          fi
+          rustup toolchain install "$msrv" --profile minimal
+          echo "MSRV=$msrv" >> "$GITHUB_ENV"
+      - name: Cache dependencies
+        uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          key: msrv
+      - name: Check the workspace on the MSRV
+        run: cargo +"$MSRV" check --workspace --all-targets --all-features
+
   rust-tests-windows:
     runs-on: windows-2025
     # disable until https://github.com/apache/hudi-rs/issues/445 is resolved

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,14 +153,9 @@ jobs:
             fi
           done
 
-  # The MSRV in Cargo.toml `rust-version` is a published promise, but every
-  # other job builds with the rust-toolchain.toml dev pin, so the promise holds
-  # only while the two happen to agree. They diverged from 2026-05 to 2026-09
-  # (dev pin 1.94, declared MSRV 1.91.1) and the declared floor silently became
-  # unbuildable when aws crates raised theirs. This job compiles with the
-  # toolchain the manifest declares, read from Cargo.toml so it follows future
-  # bumps, and starts pulling real weight the moment the dev pin moves ahead of
-  # the MSRV again.
+  # Every other job builds with the rust-toolchain.toml dev pin; this job
+  # compiles with the MSRV that Cargo.toml declares (read at run time so it
+  # follows bumps), keeping the declared floor buildable once the two diverge.
   msrv-check:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,10 @@ members = [
     "benchmark/tpch",
     "benchmark/filegroup",
 ]
-resolver = "2"
+# Resolver v3 is MSRV-aware: a fresh resolution prefers dependency versions
+# whose rust-version fits the declared MSRV, so the promise stays satisfiable
+# without a committed lockfile (the msrv-check CI job then verifies it).
+resolver = "3"
 
 [workspace.package]
 version = "0.5.0-dev"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,6 @@ members = [
     "benchmark/tpch",
     "benchmark/filegroup",
 ]
-# Resolver v3 is MSRV-aware: a fresh resolution prefers dependency versions
-# whose rust-version fits the declared MSRV, so the promise stays satisfiable
-# without a committed lockfile (the msrv-check CI job then verifies it).
 resolver = "3"
 
 [workspace.package]

--- a/benchmark/filegroup/Cargo.toml
+++ b/benchmark/filegroup/Cargo.toml
@@ -19,6 +19,7 @@
 name = "fg-bench"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [[bin]]
 name = "fg-bench"

--- a/benchmark/tpch/Cargo.toml
+++ b/benchmark/tpch/Cargo.toml
@@ -19,6 +19,7 @@
 name = "tpch"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [[bin]]
 name = "tpch"


### PR DESCRIPTION
## Description

Follow-up to #715, which raised the MSRV but deliberately shipped no CI guard: with `Cargo.lock` gitignored and resolver v2, a naive MSRV job would assert a moving target (whatever the newest semver-compatible dependencies happen to require) and break on unrelated PRs whenever a transitive dependency raises its floor, which is exactly how the 1.91.1 claim rotted unnoticed while every job built on the newer dev pin.

This makes the guard sound in three steps. Resolver v3 makes fresh resolutions MSRV-aware, so dependency selection prefers versions whose `rust-version` fits the declared 1.94.1. The benchmark crates now inherit the workspace `rust-version`, so the floor is uniform across members and a bench-only dependency cannot pull a shared crate past it. The new `msrv-check` job then compiles the workspace with the toolchain the manifest declares (read from `Cargo.toml`, so it follows future bumps); today the dev pin resolves to the same 1.94.1, and the job starts pulling real weight the moment the pin moves ahead of the MSRV again.

One behavior note: since the lockfile is not committed, resolver v3 caps dependency selection at MSRV-compatible versions for every build, and when nothing compatible exists cargo picks a newer version with a warning instead of erroring; the msrv-check job then fails at compile time, which is the alarm this exists to raise. Dependency updates whose floor passes the MSRV stop arriving until the MSRV moves, which is the point.

## How are the changes test-covered

- [ ] N/A
- [ ] Automated tests (unit and/or integration tests)
- [x] Manual tests
  - [x] Details are described below

Regenerated the lockfile from scratch under resolver v3 and compared against a same-day v2-behavior resolution (`CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=allow`): identical, so the switch changes nothing today and only engages when a dependency's floor moves past the MSRV. Ran the job's exact command (`cargo +1.94.1 check --workspace --all-targets --all-features`) to completion on the fresh resolution.
