### PR TITLE
fix(release): set the macOS deployment target for the x86_64 wheel build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,10 @@ jobs:
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
           MATURIN_REPOSITORY: pypi
+          # RocksDB uses C++17 aligned allocation, available on macOS 10.13+,
+          # while the x86_64 build otherwise runs at rustc's 10.12 floor and
+          # fails to compile. arm64 already floors at 11.0.
+          MACOSX_DEPLOYMENT_TARGET: ${{ matrix.target == 'x86_64-apple-darwin' && '10.13' || '11.0' }}
         with:
           target: ${{ matrix.target }}
           command: publish


### PR DESCRIPTION
## Description

A dry run of the release wheel matrix (requested in the 0.5.0 validation on #713) caught a publish-time failure: the x86_64-apple-darwin wheel fails to compile RocksDB because the build runs at rustc's 10.12 deployment floor when `MACOSX_DEPLOYMENT_TARGET` is unset, and RocksDB uses C++17 aligned allocation, available from macOS 10.13. This is the first release that compiles the spill tier on that target, so the tagged publish would have died mid-release. The fix sets the floor explicitly per matrix target: 10.13 for x86_64 (wheel tag becomes `macosx_10_13_x86_64`; CPython 3.13 does not support 10.12 anyway) and 11.0 for arm64, which is its existing floor and leaves that wheel tag unchanged.

Two side notes for the release manager: the Windows wheel built clean in the same dry run, so both previously untested targets are now covered; and the release job runs on floating `macos-latest` (currently a macOS 26 image), which is exactly where the dry run validated this fix, though pinning to `macos-15` to match CI is a reasonable follow-up.

## How are the changes test-covered

- [ ] N/A
- [ ] Automated tests (unit and/or integration tests)
- [x] Manual tests
  - [x] Details are described below

Reproduced and fixed on a fork dry run of the publish matrix with `command: build`: the run without the env fails in RocksDB's clock cache with the aligned-allocation errors at `-mmacosx-version-min=10.12`; with this change both matrix targets produce wheels (x86_64 41 MB, plus the Windows job at 37 MB). Also verified locally: the cross build fails without the env and succeeds at exactly 10.13, producing `hudi-0.5.0.dev0-cp310-abi3-macosx_10_13_x86_64.whl`.
