### PR TITLE
docs(core): correct stale HFile reasoning in metadata-table reader routing

### DIFF
--- a/crates/core/src/file_group/reader.rs
+++ b/crates/core/src/file_group/reader.rs
@@ -436,10 +436,15 @@ impl FileGroupReader {
 
     /// Which merge implementation serves this read.
     ///
-    /// A metadata table is always served by version 1 whatever the
-    /// setting says: its base files and log blocks are HFile, which the
-    /// file group reader version 2 has no support for. That is permanent, not
-    /// transitional.
+    /// A metadata table is always served by version 1 whatever the setting
+    /// says. Not for want of HFile support — the version 2 engine reads HFile
+    /// base files and log blocks — but because a metadata table's record key,
+    /// merge rule and partition come from its own configuration rather than
+    /// the data table's. The version 2 path for metadata tables is
+    /// the dedicated [`MetadataTableV2Reader`], which reads through the same
+    /// engine with that configuration in hand.
+    ///
+    /// [`MetadataTableV2Reader`]: crate::metadata::table::v2_reader::MetadataTableV2Reader
     ///
     /// The value is read raw rather than through `get_or_default`, which falls
     /// back to the default when a value fails to parse. A typo in the version
@@ -523,11 +528,14 @@ impl FileGroupReader {
 
         // Unreachable while `file_group_reader_version` routes a metadata table
         // to version 1 above; kept so a future change to that routing fails
-        // loudly here rather than reaching a reader that cannot read HFile.
+        // loudly here rather than merging metadata records under the data
+        // table's key, merge rule and partition semantics.
         if self.is_metadata_table() {
             return Err(CoreError::Unsupported(
-                "File group reader version 2 cannot read a metadata table's HFile \
-                 base files and log blocks"
+                "A metadata table is not read through the generic version 2 path: \
+                 its record key, merge rule and partition come from its own \
+                 configuration. Version 1 serves it here; MetadataTableV2Reader \
+                 is the version 2 path for metadata tables"
                     .to_string(),
             ));
         }
@@ -2301,8 +2309,8 @@ mod file_group_reader_version_tests {
     /// The guard inside the check, reached only if the dispatch's metadata
     /// routing were ever removed. Asserted directly because the dispatch answers
     /// metadata tables before the check runs, so no read can reach it today —
-    /// which is exactly why it must keep erroring rather than fall through to a
-    /// reader that cannot read HFile.
+    /// which is exactly why it must keep erroring rather than merge metadata
+    /// records under the data table's key, merge rule and partition semantics.
     #[tokio::test]
     async fn test_version_two_unsupported_reason_metadata_table_returns_error() -> Result<()> {
         use crate::config::HudiConfigs;

--- a/crates/core/src/file_group/reader_v2/adapter.rs
+++ b/crates/core/src/file_group/reader_v2/adapter.rs
@@ -230,9 +230,10 @@ mod tests {
         )]))
     }
 
-    /// A metadata table is refused rather than attempted. The merge-on-read
-    /// reader has no HFile support, so letting it try would fail somewhere
-    /// deeper and less clearly.
+    /// A metadata table is refused rather than attempted. Not for want of
+    /// HFile support: its record key, merge rule and partition come from its
+    /// own configuration, so letting this path try would fail somewhere deeper
+    /// and less clearly.
     #[test]
     fn refuses_a_metadata_table() {
         let reason = refuse_reason(true, Some(&schema())).expect("should refuse");


### PR DESCRIPTION
## Description

The comments around metadata-table routing in `FileGroupReader` still claimed that file group reader version 2 cannot read HFile, a claim #706 made stale: the version 2 engine reads HFile base files and log blocks on an ordinary table, and metadata tables are served through the version 2 engine by the dedicated `MetadataTableV2Reader`. This rewrites those comments (and the unreachable guard's error string) to give the real reason metadata tables route to version 1 in this generic path: a metadata table's record key, merge rule and partition come from its own configuration rather than the data table's, matching the authoritative wording in `adapter::refuse_reason`. Comments and one unreachable error string only, no behavior change.

## How are the changes test-covered

- [x] N/A
- [ ] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
