### PR TITLE
build(release): bump version to 0.6.0-dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.0-dev"
+version = "0.6.0-dev"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.94.1"

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -16,7 +16,7 @@
 # under the License.
 
 cmake_minimum_required(VERSION 3.20)
-project(hudi-cpp VERSION 0.5.0)
+project(hudi-cpp VERSION 0.6.0)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/cpp/Cargo.toml
+++ b/cpp/Cargo.toml
@@ -32,8 +32,8 @@ name = "hudi"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-hudi = { path = "../crates/hudi", version = "0.5.0-dev" }
-hudi-test = { path = "../crates/test", version = "0.5.0-dev" }
+hudi = { path = "../crates/hudi", version = "0.6.0-dev" }
+hudi-test = { path = "../crates/test", version = "0.6.0-dev" }
 cxx = { version = "1.0" }
 arrow = { workspace = true , features = ["ffi"]}
 arrow-array = { workspace = true , features = ["ffi"]}

--- a/crates/datafusion/Cargo.toml
+++ b/crates/datafusion/Cargo.toml
@@ -36,7 +36,7 @@ default = ["spill-rocksdb"]
 spill-rocksdb = ["hudi-core/spill-rocksdb"]
 
 [dependencies]
-hudi-core = { version = "0.5.0-dev", path = "../core", default-features = false, features = [
+hudi-core = { version = "0.6.0-dev", path = "../core", default-features = false, features = [
     "datafusion",
 ] }
 # arrow

--- a/crates/hudi/Cargo.toml
+++ b/crates/hudi/Cargo.toml
@@ -28,8 +28,8 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-hudi-core = { version = "0.5.0-dev", path = "../core", default-features = false }
-hudi-datafusion = { version = "0.5.0-dev", path = "../datafusion", optional = true, default-features = false }
+hudi-core = { version = "0.6.0-dev", path = "../core", default-features = false }
+hudi-datafusion = { version = "0.6.0-dev", path = "../datafusion", optional = true, default-features = false }
 
 [features]
 default = ["spill-rocksdb"]

--- a/crates/jvm-ffi/Cargo.toml
+++ b/crates/jvm-ffi/Cargo.toml
@@ -39,6 +39,6 @@ crate-type = ["cdylib", "rlib"]
 ffi-test-hooks = []
 
 [dependencies]
-hudi = { path = "../hudi", version = "0.5.0-dev" }
+hudi = { path = "../hudi", version = "0.6.0-dev" }
 arrow = { workspace = true, features = ["ffi"] }
 tokio = { workspace = true }


### PR DESCRIPTION
## Description

Cutting 0.5.0 release and bump version to 0.6.0-dev

## How are the changes test-covered

- [x] N/A
- [ ] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below
