### PR TITLE
fix(ci): install a modern protoc for the manylinux wheel build

### DIFF
--- a/.github/scripts/manylinux-build-deps.sh
+++ b/.github/scripts/manylinux-build-deps.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Install the system build dependencies for a manylinux wheel.
+#
+# Both release steps and the CI job that guards them run this one script, so a
+# change cannot land in some of them and not others.
+#
+# protoc: the distro package is 2.5.0 on the CentOS 7 base, which predates the
+# --experimental_allow_proto3_optional flag prost-build passes when it compiles
+# lance-encoding/lance-file's .proto files.
+#
+# libclang: librocksdb-sys generates its bindings with bindgen, which needs a
+# libclang the base image does not carry; the distro clang is 3.4, older than
+# bindgen supports. Callers must point LIBCLANG_PATH at the directory printed
+# at the end, since an exported variable would not survive this subshell.
+#
+# perl-IPC-Cmd: needed by openssl.
+
+set -euo pipefail
+
+PROTOC_VERSION=36.1
+
+case "$(uname -m)" in
+  x86_64)
+    protoc_arch=x86_64
+    protoc_sha256=c4bc672d9d49214dc8cafdceadf4df92182d6ca8e3ec65a56b2d7de5602669b4
+    ;;
+  aarch64)
+    protoc_arch=aarch_64
+    protoc_sha256=237a68856edf1bd28b6204bddd0596c1cf46d298bc29c620012540b2e44c73e7
+    ;;
+  *)
+    echo "unsupported architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+curl -fsSL -o /tmp/protoc.zip \
+  "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${protoc_arch}.zip"
+
+# The wheels this produces are published and signed, so verify the archive
+# rather than trusting whatever the download returned.
+echo "${protoc_sha256}  /tmp/protoc.zip" | sha256sum -c -
+
+unzip -qo /tmp/protoc.zip -d /usr/local bin/protoc 'include/*'
+chmod +x /usr/local/bin/protoc
+protoc --version
+
+yum install -y llvm-toolset-7.0-clang-libs perl-IPC-Cmd
+
+# libclang.so links against the LLVM runtime in the same prefix, so make the
+# loader aware of it rather than relying on a symlink out of the prefix.
+libclang_dir=/opt/rh/llvm-toolset-7.0/root/usr/lib64
+echo "$libclang_dir" >/etc/ld.so.conf.d/llvm-toolset-7.0.conf
+ldconfig
+
+test -e "$libclang_dir/libclang.so" || {
+  echo "libclang.so not found under $libclang_dir" >&2
+  exit 1
+}
+echo "libclang: $libclang_dir"

--- a/.github/scripts/manylinux-build-deps.sh
+++ b/.github/scripts/manylinux-build-deps.sh
@@ -28,8 +28,9 @@
 #
 # libclang: librocksdb-sys generates its bindings with bindgen, which needs a
 # libclang the base image does not carry; the distro clang is 3.4, older than
-# bindgen supports. Callers must point LIBCLANG_PATH at the directory printed
-# at the end, since an exported variable would not survive this subshell.
+# bindgen supports. It is linked into a standard directory rather than exported
+# through LIBCLANG_PATH, because maturin-action forwards only its own env vars
+# into the container and would drop one set on the step.
 #
 # perl-IPC-Cmd: needed by openssl.
 
@@ -68,11 +69,20 @@ yum install -y llvm-toolset-7.0-clang-libs perl-IPC-Cmd
 # libclang.so links against the LLVM runtime in the same prefix, so make the
 # loader aware of it rather than relying on a symlink out of the prefix.
 libclang_dir=/opt/rh/llvm-toolset-7.0/root/usr/lib64
-echo "$libclang_dir" >/etc/ld.so.conf.d/llvm-toolset-7.0.conf
-ldconfig
-
 test -e "$libclang_dir/libclang.so" || {
   echo "libclang.so not found under $libclang_dir" >&2
   exit 1
 }
-echo "libclang: $libclang_dir"
+
+# Register the prefix so the LLVM runtime libclang links against resolves, then
+# link libclang itself where bindgen already looks.
+echo "$libclang_dir" >/etc/ld.so.conf.d/llvm-toolset-7.0.conf
+ln -sf "$libclang_dir/libclang.so" /usr/lib64/libclang.so
+ln -sf "$libclang_dir/libclang.so.7" /usr/lib64/libclang.so.7
+ldconfig
+
+ldconfig -p | grep -q 'libclang\.so ' || {
+  echo "libclang.so is not in the loader cache" >&2
+  exit 1
+}
+echo "libclang: $(ldconfig -p | grep -m1 'libclang\.so ')"

--- a/.github/scripts/manylinux-build-deps.sh
+++ b/.github/scripts/manylinux-build-deps.sh
@@ -28,9 +28,13 @@
 #
 # libclang: librocksdb-sys generates its bindings with bindgen, which needs a
 # libclang the base image does not carry; the distro clang is 3.4, older than
-# bindgen supports. It is linked into a standard directory rather than exported
-# through LIBCLANG_PATH, because maturin-action forwards only its own env vars
-# into the container and would drop one set on the step.
+# bindgen supports. bindgen also needs clang's builtin headers (stdbool.h and
+# friends), which libclang cannot locate on its own when loaded from the SCL
+# prefix, so both are handed over explicitly. The exports only reach the build
+# if this script is SOURCED from before-script-linux, not executed: a step-level
+# `env:` never enters the container (maturin-action forwards only its own
+# variables), while the before-script runs in the same shell as the build - the
+# long-standing CFLAGS_aarch64 export below relies on the same behavior.
 #
 # perl-IPC-Cmd: needed by openssl.
 
@@ -64,7 +68,7 @@ unzip -qo /tmp/protoc.zip -d /usr/local bin/protoc 'include/*'
 chmod +x /usr/local/bin/protoc
 protoc --version
 
-yum install -y llvm-toolset-7.0-clang-libs perl-IPC-Cmd
+yum install -y llvm-toolset-7.0-clang llvm-toolset-7.0-clang-libs perl-IPC-Cmd
 
 # libclang.so links against the LLVM runtime in the same prefix, so make the
 # loader aware of it rather than relying on a symlink out of the prefix.
@@ -74,15 +78,17 @@ test -e "$libclang_dir/libclang.so" || {
   exit 1
 }
 
-# Register the prefix so the LLVM runtime libclang links against resolves, then
-# link libclang itself where bindgen already looks.
+# Register the prefix so the LLVM runtime libclang links against resolves.
 echo "$libclang_dir" >/etc/ld.so.conf.d/llvm-toolset-7.0.conf
-ln -sf "$libclang_dir/libclang.so" /usr/lib64/libclang.so
-ln -sf "$libclang_dir/libclang.so.7" /usr/lib64/libclang.so.7
 ldconfig
 
-ldconfig -p | grep -q 'libclang\.so ' || {
-  echo "libclang.so is not in the loader cache" >&2
+clang_include=$(ls -d "$libclang_dir"/clang/*/include 2>/dev/null | head -n 1)
+test -n "$clang_include" || {
+  echo "clang builtin headers not found under $libclang_dir/clang" >&2
   exit 1
 }
-echo "libclang: $(ldconfig -p | grep -m1 'libclang\.so ')"
+
+export LIBCLANG_PATH="$libclang_dir"
+export BINDGEN_EXTRA_CLANG_ARGS="-I$clang_include"
+echo "libclang: $LIBCLANG_PATH"
+echo "clang builtin headers: $clang_include"

--- a/.github/scripts/manylinux-build-deps.sh
+++ b/.github/scripts/manylinux-build-deps.sh
@@ -38,6 +38,11 @@
 #
 # perl-IPC-Cmd: needed by openssl.
 
+# This script is sourced, not executed, so that the exports below land in the
+# same shell the build runs in. Keep the caller's shell options: the strictness
+# is for this script, and leaking `set -u` in particular would turn any unset
+# variable in a future maturin-action release into a release-time failure.
+_deps_saved_opts=$(set +o)
 set -euo pipefail
 
 PROTOC_VERSION=36.1
@@ -73,22 +78,34 @@ yum install -y llvm-toolset-7.0-clang llvm-toolset-7.0-clang-libs perl-IPC-Cmd
 # libclang.so links against the LLVM runtime in the same prefix, so make the
 # loader aware of it rather than relying on a symlink out of the prefix.
 libclang_dir=/opt/rh/llvm-toolset-7.0/root/usr/lib64
-test -e "$libclang_dir/libclang.so" || {
+if [ ! -e "$libclang_dir/libclang.so" ]; then
   echo "libclang.so not found under $libclang_dir" >&2
-  exit 1
-}
+  return 1 2>/dev/null || exit 1
+fi
 
 # Register the prefix so the LLVM runtime libclang links against resolves.
 echo "$libclang_dir" >/etc/ld.so.conf.d/llvm-toolset-7.0.conf
 ldconfig
 
-clang_include=$(ls -d "$libclang_dir"/clang/*/include 2>/dev/null | head -n 1)
-test -n "$clang_include" || {
+# Assign in a condition context: a bare `var=$(...)` takes the substitution's
+# status, so a non-matching glob would trip errexit before the check below.
+clang_include=""
+for candidate in "$libclang_dir"/clang/*/include; do
+  if [ -e "$candidate/stdbool.h" ]; then
+    clang_include=$candidate
+    break
+  fi
+done
+if [ -z "$clang_include" ]; then
   echo "clang builtin headers not found under $libclang_dir/clang" >&2
-  exit 1
-}
+  return 1 2>/dev/null || exit 1
+fi
 
 export LIBCLANG_PATH="$libclang_dir"
 export BINDGEN_EXTRA_CLANG_ARGS="-I$clang_include"
 echo "libclang: $LIBCLANG_PATH"
 echo "clang builtin headers: $clang_include"
+
+# Restore the caller's shell options; the exports above survive.
+eval "$_deps_saved_opts"
+unset _deps_saved_opts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,7 +339,7 @@ jobs:
           # release steps are provably the same environment.
           manylinux: '2014'
           before-script-linux: |
-            bash .github/scripts/manylinux-build-deps.sh
+            source .github/scripts/manylinux-build-deps.sh
 
   publish-coverage:
     name: Publish coverage reports to codecov.io

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,42 +309,39 @@ jobs:
 
   manylinux-wheel-build:
     name: Build the manylinux wheel
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - runner: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-gnu
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
-      # Builds the wheel in the same container, with the same before-script, that
-      # the release workflow publishes from. Regular CI runs on ubuntu-latest,
-      # whose apt protoc is new enough for lance-encoding's prost-build, so a
-      # container-only break (see #750) stays invisible until a release tag is
-      # pushed - by which point the version is burnt on crates.io and cannot be
-      # reused. This job is the same build minus the upload.
-      - name: Build manylinux x86_64 wheel
+      # Builds the wheel in the same container, running the same dependency
+      # script, that the release workflow publishes from. Regular CI runs on the
+      # host, whose apt protoc is new enough for lance-encoding's prost-build and
+      # which carries libclang for librocksdb-sys, so a container-only break (see
+      # #750) stays invisible until a release tag is pushed - by which point the
+      # version is burnt on crates.io and cannot be reused.
+      - name: Build wheel
         uses: PyO3/maturin-action@v1
+        env:
+          LIBCLANG_PATH: /opt/rh/llvm-toolset-7.0/root/usr/lib64
         with:
-          target: x86_64-unknown-linux-gnu
+          target: ${{ matrix.target }}
           command: build
           args: --release -m python/Cargo.toml
-          # Pin the container explicitly. Left at the default the action builds
-          # this target straight on the runner, which defeats the point of the
-          # job and is not what the release publishes from.
+          # Pin the image rather than relying on the default, so this job and the
+          # release steps are provably the same environment.
           manylinux: '2014'
           before-script-linux: |
-            set -eu
-            PROTOC_VERSION=36.1
-            case "$(uname -m)" in
-              x86_64)  protoc_arch=x86_64 ;;
-              aarch64) protoc_arch=aarch_64 ;;
-              *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
-            esac
-            curl -fsSL -o /tmp/protoc.zip \
-              "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${protoc_arch}.zip"
-            unzip -qo /tmp/protoc.zip -d /usr/local bin/protoc 'include/*'
-            chmod +x /usr/local/bin/protoc
-            protoc --version
-            yum install -y perl-IPC-Cmd
+            bash .github/scripts/manylinux-build-deps.sh
 
   publish-coverage:
     name: Publish coverage reports to codecov.io

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,6 +327,10 @@ jobs:
           target: x86_64-unknown-linux-gnu
           command: build
           args: --release -m python/Cargo.toml
+          # Pin the container explicitly. Left at the default the action builds
+          # this target straight on the runner, which defeats the point of the
+          # job and is not what the release publishes from.
+          manylinux: '2014'
           before-script-linux: |
             set -eu
             PROTOC_VERSION=36.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,6 +307,41 @@ jobs:
         run: |
           sudo chown -R $(id -u):$(id -g) $GITHUB_WORKSPACE/.cargo $GITHUB_WORKSPACE/target $GITHUB_WORKSPACE/python/target $GITHUB_WORKSPACE/.uv-cache || true
 
+  manylinux-wheel-build:
+    name: Build the manylinux wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+      # Builds the wheel in the same container, with the same before-script, that
+      # the release workflow publishes from. Regular CI runs on ubuntu-latest,
+      # whose apt protoc is new enough for lance-encoding's prost-build, so a
+      # container-only break (see #750) stays invisible until a release tag is
+      # pushed - by which point the version is burnt on crates.io and cannot be
+      # reused. This job is the same build minus the upload.
+      - name: Build manylinux x86_64 wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          target: x86_64-unknown-linux-gnu
+          command: build
+          args: --release -m python/Cargo.toml
+          before-script-linux: |
+            set -eu
+            PROTOC_VERSION=36.1
+            case "$(uname -m)" in
+              x86_64)  protoc_arch=x86_64 ;;
+              aarch64) protoc_arch=aarch_64 ;;
+              *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+            esac
+            curl -fsSL -o /tmp/protoc.zip \
+              "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${protoc_arch}.zip"
+            unzip -qo /tmp/protoc.zip -d /usr/local bin/protoc 'include/*'
+            chmod +x /usr/local/bin/protoc
+            protoc --version
+            yum install -y perl-IPC-Cmd
+
   publish-coverage:
     name: Publish coverage reports to codecov.io
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,8 +331,6 @@ jobs:
       # version is burnt on crates.io and cannot be reused.
       - name: Build wheel
         uses: PyO3/maturin-action@v1
-        env:
-          LIBCLANG_PATH: /opt/rh/llvm-toolset-7.0/root/usr/lib64
         with:
           target: ${{ matrix.target }}
           command: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,12 +334,21 @@ jobs:
         with:
           target: ${{ matrix.target }}
           command: build
-          args: --release -m python/Cargo.toml
+          args: --release -m python/Cargo.toml --out dist
           # Pin the image rather than relying on the default, so this job and the
           # release steps are provably the same environment.
           manylinux: '2014'
           before-script-linux: |
             source .github/scripts/manylinux-build-deps.sh
+      # A wheel that compiles is not necessarily a wheel that loads: the
+      # bindings rocksdb generates come from the container's older libclang, and
+      # bad bindings tend to surface on import or first use rather than at
+      # compile time. Each runner installs the wheel it just built.
+      - name: Import the built wheel
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+          python -c "import hudi; print(hudi.__file__)"
 
   publish-coverage:
     name: Publish coverage reports to codecov.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,9 +135,25 @@ jobs:
           target: x86_64-unknown-linux-gnu
           command: publish
           args: --skip-existing -m python/Cargo.toml
-          # protobuf-compiler is needed by lance-encoding/lance-file's prost-build;
+          # CentOS 7's protobuf-compiler package is protoc 2.5.0, which predates
+          # the --experimental_allow_proto3_optional flag that prost-build passes
+          # when it compiles lance-encoding/lance-file's .proto files. Install an
+          # official protoc release instead of the distro one.
           # perl-IPC-Cmd is needed by openssl.
-          before-script-linux: yum install -y protobuf-compiler perl-IPC-Cmd
+          before-script-linux: |
+            set -eu
+            PROTOC_VERSION=36.1
+            case "$(uname -m)" in
+              x86_64)  protoc_arch=x86_64 ;;
+              aarch64) protoc_arch=aarch_64 ;;
+              *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+            esac
+            curl -fsSL -o /tmp/protoc.zip \
+              "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${protoc_arch}.zip"
+            unzip -qo /tmp/protoc.zip -d /usr/local bin/protoc 'include/*'
+            chmod +x /usr/local/bin/protoc
+            protoc --version
+            yum install -y perl-IPC-Cmd
 
       - name: Publish manylinux to pypi aarch64 (without sdist)
         uses: PyO3/maturin-action@v1
@@ -148,8 +164,23 @@ jobs:
           target: aarch64-unknown-linux-gnu
           command: publish
           args: --skip-existing -m python/Cargo.toml --no-sdist
+          # CentOS 7's protobuf-compiler package is protoc 2.5.0, which predates
+          # the --experimental_allow_proto3_optional flag that prost-build passes
+          # when it compiles lance-encoding/lance-file's .proto files. Install an
+          # official protoc release instead of the distro one.
           before-script-linux: |
-            yum install -y protobuf-compiler
+            set -eu
+            PROTOC_VERSION=36.1
+            case "$(uname -m)" in
+              x86_64)  protoc_arch=x86_64 ;;
+              aarch64) protoc_arch=aarch_64 ;;
+              *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+            esac
+            curl -fsSL -o /tmp/protoc.zip \
+              "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${protoc_arch}.zip"
+            unzip -qo /tmp/protoc.zip -d /usr/local bin/protoc 'include/*'
+            chmod +x /usr/local/bin/protoc
+            protoc --version
             # We can remove this once we upgrade to 2_28.
             # https://github.com/briansmith/ring/issues/1728
             export CFLAGS_aarch64_unknown_linux_gnu="-D__ARM_ARCH=8"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,7 @@ jobs:
           target: x86_64-unknown-linux-gnu
           command: publish
           args: --skip-existing -m python/Cargo.toml
+          manylinux: '2014'
           # CentOS 7's protobuf-compiler package is protoc 2.5.0, which predates
           # the --experimental_allow_proto3_optional flag that prost-build passes
           # when it compiles lance-encoding/lance-file's .proto files. Install an
@@ -164,6 +165,7 @@ jobs:
           target: aarch64-unknown-linux-gnu
           command: publish
           args: --skip-existing -m python/Cargo.toml --no-sdist
+          manylinux: '2014'
           # CentOS 7's protobuf-compiler package is protoc 2.5.0, which predates
           # the --experimental_allow_proto3_optional flag that prost-build passes
           # when it compiles lance-encoding/lance-file's .proto files. Install an

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,37 +119,37 @@ jobs:
   release-pypi-manylinux:
     name: PyPI release manylinux
     needs: validate-release-tag
-    runs-on: ubuntu-latest
+    # aarch64 builds on a native ARM runner so this job and the CI wheel-build
+    # job use the same image; cross-building it from x86_64 would exercise a
+    # container CI never touches. It also drops the ring workaround that the
+    # cross build needed (briansmith/ring#1728).
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            # the sdist rides along with exactly one leg
+            args: --skip-existing -m python/Cargo.toml
+          - runner: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-gnu
+            args: --skip-existing -m python/Cargo.toml --no-sdist
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 
-      - name: Publish manylinux to pypi x86_64 (with sdist)
+      - name: Publish manylinux to pypi
         uses: PyO3/maturin-action@v1
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
           MATURIN_REPOSITORY: pypi
         with:
-          target: x86_64-unknown-linux-gnu
+          target: ${{ matrix.target }}
           command: publish
-          args: --skip-existing -m python/Cargo.toml
+          args: ${{ matrix.args }}
           manylinux: '2014'
           before-script-linux: |
             source .github/scripts/manylinux-build-deps.sh
-      - name: Publish manylinux to pypi aarch64 (without sdist)
-        uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-          MATURIN_REPOSITORY: pypi
-        with:
-          target: aarch64-unknown-linux-gnu
-          command: publish
-          args: --skip-existing -m python/Cargo.toml --no-sdist
-          manylinux: '2014'
-          before-script-linux: |
-            source .github/scripts/manylinux-build-deps.sh
-            # We can remove this once we upgrade to 2_28.
-            # https://github.com/briansmith/ring/issues/1728
-            export CFLAGS_aarch64_unknown_linux_gnu="-D__ARM_ARCH=8"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,8 +131,6 @@ jobs:
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
           MATURIN_REPOSITORY: pypi
-          # bindgen finds libclang here; the install script prints this path.
-          LIBCLANG_PATH: /opt/rh/llvm-toolset-7.0/root/usr/lib64
         with:
           target: x86_64-unknown-linux-gnu
           command: publish
@@ -145,8 +143,6 @@ jobs:
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
           MATURIN_REPOSITORY: pypi
-          # bindgen finds libclang here; the install script prints this path.
-          LIBCLANG_PATH: /opt/rh/llvm-toolset-7.0/root/usr/lib64
         with:
           target: aarch64-unknown-linux-gnu
           command: publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
           args: --skip-existing -m python/Cargo.toml
           manylinux: '2014'
           before-script-linux: |
-            bash .github/scripts/manylinux-build-deps.sh
+            source .github/scripts/manylinux-build-deps.sh
       - name: Publish manylinux to pypi aarch64 (without sdist)
         uses: PyO3/maturin-action@v1
         env:
@@ -149,7 +149,7 @@ jobs:
           args: --skip-existing -m python/Cargo.toml --no-sdist
           manylinux: '2014'
           before-script-linux: |
-            bash .github/scripts/manylinux-build-deps.sh
+            source .github/scripts/manylinux-build-deps.sh
             # We can remove this once we upgrade to 2_28.
             # https://github.com/briansmith/ring/issues/1728
             export CFLAGS_aarch64_unknown_linux_gnu="-D__ARM_ARCH=8"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,58 +131,29 @@ jobs:
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
           MATURIN_REPOSITORY: pypi
+          # bindgen finds libclang here; the install script prints this path.
+          LIBCLANG_PATH: /opt/rh/llvm-toolset-7.0/root/usr/lib64
         with:
           target: x86_64-unknown-linux-gnu
           command: publish
           args: --skip-existing -m python/Cargo.toml
           manylinux: '2014'
-          # CentOS 7's protobuf-compiler package is protoc 2.5.0, which predates
-          # the --experimental_allow_proto3_optional flag that prost-build passes
-          # when it compiles lance-encoding/lance-file's .proto files. Install an
-          # official protoc release instead of the distro one.
-          # perl-IPC-Cmd is needed by openssl.
           before-script-linux: |
-            set -eu
-            PROTOC_VERSION=36.1
-            case "$(uname -m)" in
-              x86_64)  protoc_arch=x86_64 ;;
-              aarch64) protoc_arch=aarch_64 ;;
-              *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
-            esac
-            curl -fsSL -o /tmp/protoc.zip \
-              "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${protoc_arch}.zip"
-            unzip -qo /tmp/protoc.zip -d /usr/local bin/protoc 'include/*'
-            chmod +x /usr/local/bin/protoc
-            protoc --version
-            yum install -y perl-IPC-Cmd
-
+            bash .github/scripts/manylinux-build-deps.sh
       - name: Publish manylinux to pypi aarch64 (without sdist)
         uses: PyO3/maturin-action@v1
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
           MATURIN_REPOSITORY: pypi
+          # bindgen finds libclang here; the install script prints this path.
+          LIBCLANG_PATH: /opt/rh/llvm-toolset-7.0/root/usr/lib64
         with:
           target: aarch64-unknown-linux-gnu
           command: publish
           args: --skip-existing -m python/Cargo.toml --no-sdist
           manylinux: '2014'
-          # CentOS 7's protobuf-compiler package is protoc 2.5.0, which predates
-          # the --experimental_allow_proto3_optional flag that prost-build passes
-          # when it compiles lance-encoding/lance-file's .proto files. Install an
-          # official protoc release instead of the distro one.
           before-script-linux: |
-            set -eu
-            PROTOC_VERSION=36.1
-            case "$(uname -m)" in
-              x86_64)  protoc_arch=x86_64 ;;
-              aarch64) protoc_arch=aarch_64 ;;
-              *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
-            esac
-            curl -fsSL -o /tmp/protoc.zip \
-              "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${protoc_arch}.zip"
-            unzip -qo /tmp/protoc.zip -d /usr/local bin/protoc 'include/*'
-            chmod +x /usr/local/bin/protoc
-            protoc --version
+            bash .github/scripts/manylinux-build-deps.sh
             # We can remove this once we upgrade to 2_28.
             # https://github.com/briansmith/ring/issues/1728
             export CFLAGS_aarch64_unknown_linux_gnu="-D__ARM_ARCH=8"


### PR DESCRIPTION
## Description

closes #750

The manylinux `before-script-linux` installed protoc with `yum install -y protobuf-compiler`, which on the CentOS 7 base resolves to protoc 2.5.0. That predates `--experimental_allow_proto3_optional`, the flag prost-build passes when compiling lance-encoding's protos, so the publish step fails now that lance is a hard dependency of hudi-core. This installs a pinned, sha256-verified official protoc release instead, from a single script (`.github/scripts/manylinux-build-deps.sh`) shared by both release steps and the CI job, so a version bump cannot land in some call sites and not others. The aarch64 step had the same latent bug and only escaped because the x86_64 step aborts the job first. Getting the container to build also surfaced that `librocksdb-sys`'s bindgen finds no usable libclang on the CentOS 7 base; the script installs the LLVM 7 toolset and exports `LIBCLANG_PATH` and `BINDGEN_EXTRA_CLANG_ARGS`, and is sourced from `before-script-linux` because a step-level `env:` never enters the container.

Regular CI runs on ubuntu-latest, whose apt protoc is current, so nothing exercised the container until a tag was pushed and the crates.io version was already burnt. The new `manylinux-wheel-build` job runs the same maturin-action against the same pinned image with the same dependency script, on both targets (aarch64 on the native ARM runner the python tests already use), differing only in `build` instead of `publish`, so the break shows up on the pull request. Both legs pass on this PR. It is deliberately not path-gated: no lockfile is committed, so dependency versions resolve fresh on every run and a break can arrive with no file in the repo changing.

Verified against `quay.io/pypa/manylinux2014`: the yum package gives `libprotoc 2.5.0` and rejects the flag, while the new script gives `libprotoc 36.1` and `lance-encoding v11.0.0` then compiles cleanly.

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [x] Manual tests
  - [x] Details are described below

The `manylinux-wheel-build` CI job added here is itself the automated coverage: it fails on this change's `main` parent and passes with it.

Manually, in the release container (`quay.io/pypa/manylinux2014`):

| step | result |
| --- | --- |
| `yum install protobuf-compiler` then `protoc --version` | `libprotoc 2.5.0` |
| that protoc with `--experimental_allow_proto3_optional` | rejected, `Missing value for flag` |
| this change's script, then `protoc --version` | `libprotoc 36.1` |
| `cargo build` of `lance-encoding v11.0.0` | finished, exit 0 |
| `cargo build` of `librocksdb-sys v0.16.0` with the exported paths | finished, exit 0 |

