### PR TITLE
fix(release): reject an expired signing key in the src release verification

### DIFF
--- a/release/verify_src_release.sh
+++ b/release/verify_src_release.sh
@@ -70,7 +70,15 @@ echo "<<< OK"
 echo ">>> Verifying signature..."
 curl -s "https://dist.apache.org/repos/dist/$repo/hudi/KEYS" >"$work_dir/KEYS"
 gpg -q --import "$work_dir/KEYS"
-gpg --verify "$pub_key" "$src"
+# gpg exits 0 for a good signature made by an expired or revoked key, reporting
+# EXPKEYSIG/REVKEYSIG instead of GOODSIG. ASF requires GOODSIG, so match on the
+# status output rather than the exit code.
+# human-readable output goes to stderr and stays visible; status goes to the file
+gpg --verify --status-fd 1 "$pub_key" "$src" >"$work_dir/gpg_status"
+if ! grep -q '^\[GNUPG:\] GOODSIG ' "$work_dir/gpg_status"; then
+  echo "ERROR: signature is not a GOODSIG (expired, revoked, or untrusted key)."
+  exit 1
+fi
 echo "<<< OK"
 
 echo "Un-tarring the source release artifact"
@@ -100,7 +108,7 @@ fi
 echo "<<< OK"
 
 echo ">>> Verifying licenses..."
-docker run -it --rm -v $(pwd):/github/workspace apache/skywalking-eyes header check
+docker run -i --rm -v $(pwd):/github/workspace apache/skywalking-eyes header check
 echo "<<< OK"
 
 echo ">>> Verifying no binary files..."

--- a/release/verify_src_release.sh
+++ b/release/verify_src_release.sh
@@ -76,7 +76,7 @@ gpg -q --import "$work_dir/KEYS"
 # human-readable output goes to stderr and stays visible; status goes to the file
 gpg --verify --status-fd 1 "$pub_key" "$src" >"$work_dir/gpg_status"
 if ! grep -q '^\[GNUPG:\] GOODSIG ' "$work_dir/gpg_status"; then
-  echo "ERROR: signature is not a GOODSIG (expired, revoked, or untrusted key)."
+  echo "ERROR: signature is not a GOODSIG (expired or revoked signing key)."
   exit 1
 fi
 echo "<<< OK"


### PR DESCRIPTION
## Description

closes #752

`gpg --verify` exits 0 for a good signature made by an expired or revoked key, emitting `EXPKEYSIG`/`REVKEYSIG` instead of `GOODSIG`, so the bare call under `errexit` accepted a release whose signing key was no longer valid. ASF's release-signing guidance requires `GOODSIG`, so this matches on `--status-fd` output rather than the exit code.

The license check also ran its container with `docker run -it`. Without a TTY that fails immediately, and under `errexit` that skipped both the license check and the binary-file check after it. The `-t` is not needed for a non-interactive container.

## How are the changes test-covered

- [x] N/A
- [ ] Automated tests (unit and/or integration tests)
- [x] Manual tests
  - [x] Details are described below

The signature regression was reproduced with a throwaway key created and used to sign under `--faked-system-time`, expiring before the present, so the signature was made while the key was valid:

| check | result |
| --- | --- |
| `gpg --verify` exit code | `0`, the old check passes |
| status line emitted | `[GNUPG:] EXPKEYSIG ...` |
| this change's check | rejects, exits 1 |

The whole script was then run against the real `0.5.0-rc.1` artifacts in the dev repo. It reports `GOODSIG` and passes, and now reaches the license check (533 files, 0 invalid) and the binary-file check, both of which the `-it` failure previously skipped.
