### PR TITLE
fix(ci): publish the release only after every artifact has built

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,34 +36,11 @@ jobs:
             exit 1
           fi
 
-  release-crates:
-    name: Release to crates.io
-    needs: validate-release-tag
-    runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 1
-      matrix:
-        # order matters here as later crates depend on previous ones
-        package:
-          - "hudi-core"
-          - "hudi-datafusion"
-          - "hudi"
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Install protobuf compiler
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
-
-      - name: cargo publish
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: |
-          cargo publish -p ${{ matrix.package }} --all-features
-
-  release-pypi-mac:
-    name: PyPI release on Mac
+  # Build every artifact before anything is uploaded. crates.io refuses a second
+  # publish of the same version, so a build that fails after a sibling job has
+  # already uploaded strands the release on a version that cannot be reused.
+  build-mac:
+    name: Build wheels on Mac
     needs: validate-release-tag
     strategy:
       fail-fast: false
@@ -79,22 +56,24 @@ jobs:
       - name: Install protobuf compiler
         run: brew install protobuf
 
-      - name: Publish to pypi (without sdist)
+      - name: Build wheel
         uses: PyO3/maturin-action@v1
         env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-          MATURIN_REPOSITORY: pypi
           # RocksDB uses C++17 aligned allocation, available on macOS 10.13+,
           # while the x86_64 build otherwise runs at rustc's 10.12 floor and
           # fails to compile. arm64 already floors at 11.0.
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.target == 'x86_64-apple-darwin' && '10.13' || '11.0' }}
         with:
           target: ${{ matrix.target }}
-          command: publish
-          args: --skip-existing -m python/Cargo.toml --no-sdist
+          command: build
+          args: --release -m python/Cargo.toml --out dist
+      - uses: actions/upload-artifact@v7
+        with:
+          name: wheels-mac-${{ matrix.target }}
+          path: dist
 
-  release-pypi-windows:
-    name: PyPI release on Windows
+  build-windows:
+    name: Build wheels on Windows
     needs: validate-release-tag
     runs-on: windows-latest
     steps:
@@ -106,34 +85,28 @@ jobs:
       - name: Install protobuf compiler
         run: choco install protoc --yes
 
-      - name: Publish to pypi (without sdist)
+      - name: Build wheel
         uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-          MATURIN_REPOSITORY: pypi
         with:
           target: x86_64-pc-windows-msvc
-          command: publish
-          args: --skip-existing -m python/Cargo.toml --no-sdist
+          command: build
+          args: --release -m python/Cargo.toml --out dist
+      - uses: actions/upload-artifact@v7
+        with:
+          name: wheels-windows
+          path: dist
 
-  release-pypi-manylinux:
-    name: PyPI release manylinux
+  build-manylinux:
+    name: Build wheels and sdist on manylinux
     needs: validate-release-tag
-    # aarch64 builds on a native ARM runner so this job and the CI wheel-build
-    # job use the same image; cross-building it from x86_64 would exercise a
-    # container CI never touches. It also drops the ring workaround that the
-    # cross build needed (briansmith/ring#1728).
     strategy:
       fail-fast: false
       matrix:
         include:
           - runner: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            # the sdist rides along with exactly one leg
-            args: --skip-existing -m python/Cargo.toml
           - runner: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
-            args: --skip-existing -m python/Cargo.toml --no-sdist
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
@@ -141,15 +114,66 @@ jobs:
         with:
           python-version: '3.13'
 
-      - name: Publish manylinux to pypi
+      - name: Build sdist
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: -m python/Cargo.toml --out dist
+
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          command: build
+          args: --release -m python/Cargo.toml --out dist
+          manylinux: '2014'
+          before-script-linux: |
+            source .github/scripts/manylinux-build-deps.sh
+      - uses: actions/upload-artifact@v7
+        with:
+          name: wheels-manylinux-${{ matrix.target }}
+          path: dist
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: [ build-mac, build-windows, build-manylinux ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+          path: dist
+      - name: Upload to pypi
         uses: PyO3/maturin-action@v1
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
           MATURIN_REPOSITORY: pypi
         with:
-          target: ${{ matrix.target }}
-          command: publish
-          args: ${{ matrix.args }}
-          manylinux: '2014'
-          before-script-linux: |
-            source .github/scripts/manylinux-build-deps.sh
+          command: upload
+          # --non-interactive so a missing token fails here rather than blocking
+          # on a credential prompt until the job times out.
+          args: --skip-existing --non-interactive dist/*
+
+  publish-crates:
+    name: Publish to crates.io
+    needs: [ build-mac, build-windows, build-manylinux ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install protobuf compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      # One invocation rather than a crate at a time: cargo packages and
+      # verifies all three before uploading any, and works out the order itself,
+      # so a failure part-way cannot leave one crate published at a version the
+      # workflow can never re-run.
+      - name: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          cargo publish -p hudi-core -p hudi-datafusion -p hudi --all-features


### PR DESCRIPTION
## Description

closes #754

Rebased on `main` now that #751 has merged; this is a single commit against it.

The four publish jobs each hung off `validate-release-tag` and uploaded as soon as their own build succeeded, with nothing gating one on another. A single build failure therefore left the others already published, and crates.io refuses a second publish of the same version, so the release has to move to a new RC number rather than being fixed in place. That is how `0.5.0-rc.1` ended up permanently taken while its PyPI release has no Linux wheel and no sdist.

This splits the workflow in two. `build-mac`, `build-windows` and `build-manylinux` build every wheel plus the sdist and upload them as workflow artifacts. `publish-pypi` and `publish-crates` both list all three in `needs`, so neither starts unless every build succeeded, and `publish-pypi` uploads the artifacts rather than rebuilding. A build failure now costs a re-run instead of a version number.

## How are the changes test-covered

- [x] N/A
- [ ] Automated tests (unit and/or integration tests)
- [ ] Manual tests
  - [ ] Details are described below

The workflow only runs on a pushed release tag, so the publish half cannot be exercised on a pull request without consuming a real version. The build half is the same maturin-action invocation the `manylinux-wheel-build` job from #751 runs on every PR, and the job graph was checked by parsing the workflow:

```
validate-release-tag
  build-mac            needs=validate-release-tag
  build-windows        needs=validate-release-tag
  build-manylinux      needs=validate-release-tag
  publish-pypi         needs=[build-mac, build-windows, build-manylinux]
  publish-crates       needs=[build-mac, build-windows, build-manylinux]
```

Given that, it is worth landing this after the next RC ships rather than before, so the RC is not the first thing to exercise a rewritten publish path.

