### PR TITLE
fix(python): declare the readme so the published package has a description

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -22,6 +22,9 @@ build-backend = "maturin"
 [project]
 name = "hudi"
 description = "Native Python binding for Apache Hudi, based on hudi-rs."
+# maturin stopped falling back to the crate's readme for this metadata, so
+# without this the published package has no description at all.
+readme = "../README.md"
 urls = { repository = "https://github.com/apache/hudi-rs/tree/main/python/" }
 requires-python = ">=3.10"
 keywords = ["apachehudi", "hudi", "datalake", "arrow"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -22,8 +22,6 @@ build-backend = "maturin"
 [project]
 name = "hudi"
 description = "Native Python binding for Apache Hudi, based on hudi-rs."
-# maturin stopped falling back to the crate's readme for this metadata, so
-# without this the published package has no description at all.
 readme = "../README.md"
 urls = { repository = "https://github.com/apache/hudi-rs/tree/main/python/" }
 requires-python = ">=3.10"


### PR DESCRIPTION
## Description

closes #761

https://pypi.org/project/hudi/0.5.0rc2/ renders an empty page, where https://pypi.org/project/hudi/0.4.0/ shows the README. pypi.org builds that page from the metadata inside the uploaded artifacts, and from 0.5.0-rc.2 they carry none: the wheel's `METADATA` is 27 lines against 366 for 0.4.0, with no `Description-Content-Type`.

`python/pyproject.toml` has never declared a `readme`, in this release or any earlier one. What changed is the build tool:

| | 0.4.0 | 0.5.0-rc.2 |
| --- | --- | --- |
| built by | maturin 1.9.0 | maturin 1.15.0 |
| wheel `METADATA` | 366 lines | 27 lines |
| description | 12260 chars | none |

maturin 1.9.0 fell back to the crate's `readme` field, which resolves through `readme.workspace = true` to the repository README. maturin 1.15.0 no longer applies that fallback, so the description disappeared with no change on our side: `pyproject.toml` requires `maturin>=1.5,<2.0` and CI pins nothing further, so the build resolves whatever is current at release time. Declaring `readme` explicitly is both the fix and the thing that stops a future maturin release from moving this again.

Worth separating out two things visible on the same page that are **not** this bug:

- The missing `License :: OSI Approved :: Apache Software License` classifier is intended. #467 moved to the PEP 639 SPDX form, so the metadata now carries `License-Expression: Apache-2.0`.
- `Requires-Python: >=3.10` is intended, from #535.

PyPI offers no way to edit a description after upload, and a version's files cannot be replaced, so 0.5.0-rc.2 keeps its empty page permanently. This is for the final 0.5.0 and every release after, and does not warrant a new release candidate on its own.

## How are the changes test-covered

- [x] N/A
- [ ] Automated tests (unit and/or integration tests)
- [x] Manual tests
  - [x] Details are described below

Built both artifact kinds from this tree with maturin 1.15.0, the version that produced the broken 0.5.0-rc.2 artifacts:

| artifact | before | after |
| --- | --- | --- |
| wheel `METADATA` | 27 lines, no `Description-Content-Type` | 525 lines, `text/markdown; charset=UTF-8; variant=GFM` |
| sdist `PKG-INFO` | 27 lines | 525 lines |

`License-Expression: Apache-2.0` and `Requires-Python: >=3.10` are unchanged by this.
