### PR TITLE
feat(bench): add a merge-on-read mode to the tpch harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,7 @@ clean-coverage: ## Remove coverage reports
 SF ?= 0.001
 ENGINE ?= datafusion
 FORMAT ?= hudi
+TABLE_TYPE ?= cow
 QUERIES ?=
 HUDI_DIR ?=
 PARQUET_DIR ?=
@@ -187,17 +188,17 @@ tpch-generate: ## Generate TPC-H parquet tables (SF=0.001)
 	$(TPCH_DIR)/run.sh generate --scale-factor $(SF)
 
 .PHONY: tpch-create-tables
-tpch-create-tables: ## Create Hudi COW tables from parquet (SF=0.001, requires Spark)
-	$(info --- Create Hudi tables at SF=$(SF) ---)
-	$(TPCH_DIR)/run.sh create-tables --scale-factor $(SF)
+tpch-create-tables: ## Create Hudi tables from parquet (SF=0.001 TABLE_TYPE=cow|mor, requires Spark)
+	$(info --- Create Hudi $(TABLE_TYPE) tables at SF=$(SF) ---)
+	$(TPCH_DIR)/run.sh create-tables --scale-factor $(SF) --table-type $(TABLE_TYPE)
 
 .PHONY: bench-tpch
-bench-tpch: ## Run TPC-H benchmark (ENGINE=datafusion|spark SF=0.001 QUERIES=1,3,6 HUDI_DIR=gs://...)
+bench-tpch: ## Run TPC-H benchmark (ENGINE=datafusion|spark SF=0.001 TABLE_TYPE=cow|mor QUERIES=1,3,6 HUDI_DIR=gs://...)
 	$(info --- Benchmark at SF=$(SF) ---)
 ifeq ($(ENGINE),spark)
-	$(TPCH_DIR)/run.sh bench-spark --scale-factor $(SF) --format $(FORMAT) $(if $(QUERIES),--queries $(QUERIES)) $(if $(HUDI_DIR),--hudi-dir $(HUDI_DIR)) $(if $(PARQUET_DIR),--parquet-dir $(PARQUET_DIR)) --output-dir $(TPCH_RESULTS_DIR)
+	$(TPCH_DIR)/run.sh bench-spark --scale-factor $(SF) --format $(FORMAT) --table-type $(TABLE_TYPE) $(if $(QUERIES),--queries $(QUERIES)) $(if $(HUDI_DIR),--hudi-dir $(HUDI_DIR)) $(if $(PARQUET_DIR),--parquet-dir $(PARQUET_DIR)) --output-dir $(TPCH_RESULTS_DIR)
 else ifeq ($(ENGINE),datafusion)
-	$(TPCH_DIR)/run.sh bench-datafusion --scale-factor $(SF) --format $(FORMAT) $(if $(QUERIES),--queries $(QUERIES)) $(if $(HUDI_DIR),--hudi-dir $(HUDI_DIR)) $(if $(PARQUET_DIR),--parquet-dir $(PARQUET_DIR)) --output-dir $(TPCH_RESULTS_DIR)
+	$(TPCH_DIR)/run.sh bench-datafusion --scale-factor $(SF) --format $(FORMAT) --table-type $(TABLE_TYPE) $(if $(QUERIES),--queries $(QUERIES)) $(if $(HUDI_DIR),--hudi-dir $(HUDI_DIR)) $(if $(PARQUET_DIR),--parquet-dir $(PARQUET_DIR)) --output-dir $(TPCH_RESULTS_DIR)
 else
 	$(error Unknown ENGINE=$(ENGINE). Use datafusion or spark)
 endif

--- a/benchmark/tpch/README.md
+++ b/benchmark/tpch/README.md
@@ -32,7 +32,7 @@
 # 1. Generate parquet data
 make tpch-generate SF=1
 
-# 2. Create Hudi COW tables from parquet
+# 2. Create Hudi tables from parquet (COW by default; TABLE_TYPE=mor for merge-on-read)
 make tpch-create-tables SF=1
 
 # 3. Run benchmarks
@@ -53,18 +53,62 @@ benchmark/tpch/run.sh validate --scale-factor 1
 
 It reports per query and exits non-zero if any of them differ.
 
+### Merge-on-read tables
+
+`--table-type mor` builds the same tables as merge-on-read and follows the bulk
+insert with one update commit, so that every file group carries a log file and
+every read goes through the merge path:
+
+```bash
+benchmark/tpch/run.sh create-tables --scale-factor 1 --table-type mor
+benchmark/tpch/run.sh validate --scale-factor 1 --table-type mor
+benchmark/tpch/run.sh bench-datafusion --scale-factor 1 --table-type mor \
+  --output-dir benchmark/tpch/results
+benchmark/tpch/run.sh compare --scale-factor 1 \
+  --runs datafusion_hudi_sf1,datafusion_hudi-mor_sf1
+```
+
+The update rewrites `--update-fraction` of each table's rows (default 0.001,
+applied as one row in every `round(1/F)` by key hash) with their own values,
+plus the smallest key in every file group so the small tables get their log
+file too. Nothing a query can see changes: the merged rows
+equal the parquet the tables were built from, and `validate` passes unchanged.
+Tables with a real ordering column (`lineitem`, `orders`) keep event-time
+ordering, where the update ties with the base row and the later commit wins;
+the rest merge by commit time.
+
+Because the values are unchanged, `validate` proves the merge a different way:
+for each merge-on-read table it counts the rows whose `_hoodie_commit_time` is
+the update commit's and requires the count to equal the update records that
+commit wrote. A reader that skipped the log files, or let the base row win the
+tie, would come up short. `create-tables` also prints the file layout per table
+and fails if any file group is missing its log file.
+
+Merge-on-read tables live in `data/sf{N}-hudi-mor` by default and persist
+results under the `hudi-mor` format label, so both types can be built from one
+parquet set and compared. `--reader-version 1` pins hudi-rs's previous file
+group reader for a baseline; its results get a `-r1` suffix. That reader has no
+commit-time merge and reads a merge-on-read table without an ordering field
+append-only, so the harness refuses the pin on the default merge-on-read tables
+rather than chart a baseline that merged nothing; to compare the two readers on
+merge-on-read, give every table a `pre_combine_field` in `tables.yaml` and
+rebuild. To see which reader served each file slice, run with
+`RUST_LOG=hudi_core::file_group::reader=debug` and count the lines naming
+"file group reader version 2".
+
 ### Options
 
-| Variable  | Values                                            | Default      |
-|-----------|---------------------------------------------------|--------------|
-| `ENGINE`  | `datafusion`, `spark`                             | `datafusion` |
-| `SF`      | TPC-H scale factor                                | `0.001`      |
-| `QUERIES` | Comma-separated query numbers                     | all 22       |
-| `ENGINES` | Comma-separated engine names (for `tpch-compare`) |              |
+| Variable     | Values                                            | Default      |
+|--------------|---------------------------------------------------|--------------|
+| `ENGINE`     | `datafusion`, `spark`                             | `datafusion` |
+| `SF`         | TPC-H scale factor                                | `0.001`      |
+| `TABLE_TYPE` | `cow`, `mor`                                      | `cow`        |
+| `QUERIES`    | Comma-separated query numbers                     | all 22       |
+| `ENGINES`    | Comma-separated engine names (for `tpch-compare`) |              |
 
-`run.sh` takes the same options plus `--recreate`, `--runs`, `--memory-limit`
-and the `--hudi-dir` / `--parquet-dir` overrides; run it with no arguments for
-the full list.
+`run.sh` takes the same options plus `--recreate`, `--runs`, `--memory-limit`,
+`--update-fraction`, `--reader-version` and the `--hudi-dir` / `--parquet-dir`
+overrides; run it with no arguments for the full list.
 
 ### More examples
 
@@ -107,9 +151,9 @@ benchmark/tpch/run.sh create-tables --scale-factor 100 \
 Pointing `--parquet-dir` at the Hudi table itself is a further option: a
 parquet scan of that directory reads the same files the Hudi tables are made
 of, so file sizing and sort order are held constant and only the read path
-differs. That is sound only for a table with a single commit, as here, since a
-plain scan has no notion of file slices and would read superseded versions of
-an updated table.
+differs. That is sound only for a copy-on-write table, which has a single
+commit: a plain scan has no notion of file slices, so on a merge-on-read table
+it would read the base files and miss the log files.
 
 Credentials come from the environment for both engines: DataFusion reads the
 `AWS_*` / `GOOGLE_*` / `AZURE_*` variables, and on a cloud VM with an attached

--- a/benchmark/tpch/config/tables.yaml
+++ b/benchmark/tpch/config/tables.yaml
@@ -17,37 +17,47 @@
 
 # Common TPC-H table definitions shared across all scale factors.
 # Per-scale-factor configs (sf*.yaml) override shuffle_parallelism.
+#
+# pre_combine_field is set only where the table has a real ordering column;
+# the others merge by commit time, since ordering a table by its own key
+# would give every record the same ordering value as its update.
+#
+# update_field is the column the merge-on-read update commit assigns. It is
+# assigned its own value: the update exists to give every file group a log
+# file to merge, not to change what a query returns.
 
 tables:
   customer:
     primary_key: c_custkey
-    pre_combine_field: c_custkey
     record_size_estimate: 87
+    update_field: c_comment
   lineitem:
     primary_key: l_orderkey,l_linenumber
     pre_combine_field: l_shipdate
     record_size_estimate: 36
+    update_field: l_comment
   nation:
     primary_key: n_nationkey
-    pre_combine_field: n_nationkey
     record_size_estimate: 160
+    update_field: n_comment
   orders:
     primary_key: o_orderkey
     pre_combine_field: o_orderdate
     record_size_estimate: 35
+    update_field: o_comment
   part:
     primary_key: p_partkey
-    pre_combine_field: p_partkey
     record_size_estimate: 32
+    update_field: p_comment
   partsupp:
     primary_key: ps_partkey,ps_suppkey
-    pre_combine_field: ps_partkey
     record_size_estimate: 48
+    update_field: ps_comment
   region:
     primary_key: r_regionkey
-    pre_combine_field: r_regionkey
     record_size_estimate: 800
+    update_field: r_comment
   supplier:
     primary_key: s_suppkey
-    pre_combine_field: s_suppkey
     record_size_estimate: 88
+    update_field: s_comment

--- a/benchmark/tpch/run.sh
+++ b/benchmark/tpch/run.sh
@@ -43,6 +43,8 @@ write_env_report() {
   local out_file="$1"
   local sf="$2"
   local data_dir="$3"
+  local table_type="${4:-cow}"
+  local reader_version="${5:-}"
 
   local cpu_model cpu_count mem_total
   if [ -r /proc/cpuinfo ]; then
@@ -120,6 +122,8 @@ write_env_report() {
     echo "spark:           $("$SPARK_HOME/bin/spark-submit" --version 2>&1 | awk '/version/ {print $NF; exit}')"
     echo "hudi bundle:     $HUDI_SPARK_BUNDLE"
     echo "config:          config/sf$sf.yaml"
+    echo "table type:      $table_type"
+    echo "reader version:  ${reader_version:-(hudi-rs default)}"
   } > "$out_file"
 }
 
@@ -161,6 +165,36 @@ is_cloud_url() {
   esac
 }
 
+require_table_type() {
+  case "$1" in
+    cow|mor) ;;
+    *) echo "Error: unknown table type '$1'. Use 'cow' or 'mor'." >&2; exit 1 ;;
+  esac
+}
+
+# Where tables of one type live by default. The two types get separate
+# directories so both can be built from the same parquet and benchmarked
+# against each other.
+default_hudi_dir() {
+  local sf="$1" table_type="$2"
+  case "$table_type" in
+    mor) echo "$SCRIPT_DIR/data/sf$sf-hudi-mor" ;;
+    *)   echo "$SCRIPT_DIR/data/sf$sf-hudi" ;;
+  esac
+}
+
+# The format label results are persisted under. Merge-on-read gets its own so
+# a run does not overwrite the copy-on-write numbers, and a pinned reader
+# version likewise, since the point of pinning one is to compare against the
+# other.
+hudi_format_label() {
+  local table_type="$1" reader_version="${2:-}"
+  local label="hudi"
+  [ "$table_type" = "mor" ] && label="hudi-mor"
+  [ -n "$reader_version" ] && label="$label-r$reader_version"
+  echo "$label"
+}
+
 # A data dir symlinked to an instance store dangles once a stop/start wipes it.
 # Name that, because the failure it otherwise produces is create_dir_all
 # reporting EEXIST for a directory that does not exist.
@@ -176,9 +210,13 @@ require_usable_data_dir() {
 # Fail with the missing table names rather than letting the engine report a
 # missing path once the run is already under way.
 require_hudi_tables() {
-  local hudi_dir="$1"
-  if ! "$TPCH_BIN" check-tables --hudi-base "$hudi_dir"; then
+  local hudi_dir="$1" table_type="${2:-}"
+  if ! "$TPCH_BIN" check-tables --hudi-base "$hudi_dir" \
+       ${table_type:+--table-type "$table_type"} >/dev/null; then
     echo "Error: run 'create-tables' first, or point --hudi-dir at existing tables." >&2
+    if [ -n "$table_type" ]; then
+      echo "Tables of the other type are refused; --table-type picks which one runs." >&2
+    fi
     exit 1
   fi
 }
@@ -189,7 +227,7 @@ Usage: $0 <command> [options]
 
 Commands:
   generate          Generate TPC-H parquet data
-  create-tables     Create Hudi COW tables from parquet via Spark SQL
+  create-tables     Create Hudi tables from parquet via Spark SQL (COW, or MOR with an update commit)
   bench-spark       Run TPC-H queries against Hudi tables via Spark SQL
   bench-datafusion  Run TPC-H queries against Hudi tables via DataFusion
   compare           Compare persisted benchmark results with bar charts
@@ -199,8 +237,18 @@ Commands:
 Options (per command):
   --scale-factor N  TPC-H scale factor [all commands] (default: $DEFAULT_SCALE_FACTOR)
   --format F        Table format: hudi or parquet [bench-*, compare] (default: auto)
+  --table-type T    Hudi table type: cow or mor [create-tables, bench-*, validate, env-report]
+                    (default: cow). mor adds an update commit that leaves one log file in
+                    every file group, and reads it through the merge path.
+  --update-fraction F
+                    Fraction of each table's rows the mor update commit rewrites, applied as
+                    one row in every round(1/F) [create-tables] (default: 0.001)
+  --reader-version N
+                    hudi-rs file group reader version, 1 or 2 [bench-datafusion, validate]
+                    (default: the hudi-rs default, currently 2)
   --recreate        Rebuild tables that already exist [create-tables] (default: reuse them)
-  --hudi-dir D      Hudi data directory or cloud URL [create-tables, bench-*] (default: data/sf{N}-hudi)
+  --hudi-dir D      Hudi data directory or cloud URL [create-tables, bench-*] (default:
+                    data/sf{N}-hudi, or data/sf{N}-hudi-mor with --table-type mor)
   --parquet-dir D   Parquet data directory or cloud URL [generate, create-tables, bench-*,
                     validate] (default: data/sf{N}-parquet)
   --queries Q       Comma-separated query numbers [bench-*, validate] (default: all 22)
@@ -217,7 +265,10 @@ Options (per command):
 Examples:
   $0 generate --scale-factor 1
   $0 create-tables --scale-factor 1
+  $0 create-tables --scale-factor 1 --table-type mor
   $0 create-tables --scale-factor 100 --hudi-dir s3://bucket/sf100-hudi
+  $0 bench-datafusion --scale-factor 1 --table-type mor
+  $0 validate --scale-factor 1 --table-type mor
   $0 bench-spark --scale-factor 1 --queries 1,3,6
   $0 bench-datafusion --scale-factor 1 --queries 1,3,6
   $0 bench-datafusion --scale-factor 100 --hudi-dir gs://bucket/sf100-hudi
@@ -258,24 +309,35 @@ cmd_create_tables() {
   local custom_hudi_dir=""
   local custom_parquet_dir=""
   local recreate=0
+  local table_type="cow"
+  local update_fraction=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --scale-factor) sf="$2"; shift 2 ;;
       --hudi-dir) custom_hudi_dir="$2"; shift 2 ;;
       --parquet-dir) custom_parquet_dir="$2"; shift 2 ;;
       --recreate) recreate=1; shift ;;
+      --table-type) table_type="$2"; shift 2 ;;
+      --update-fraction) update_fraction="$2"; shift 2 ;;
       *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
     esac
   done
+  require_table_type "$table_type"
+  if [ -n "$update_fraction" ] && [ "$table_type" != "mor" ]; then
+    echo "Error: --update-fraction applies to --table-type mor only." >&2
+    exit 1
+  fi
 
-  local hudi_dir="${custom_hudi_dir:-$SCRIPT_DIR/data/sf$sf-hudi}"
+  local hudi_dir="${custom_hudi_dir:-$(default_hudi_dir "$sf" "$table_type")}"
 
   build_tpch
 
   # Rebuilding is the expensive step at scale, so existing tables are reused
-  # unless --recreate says otherwise.
-  if [ "$recreate" -eq 0 ] && "$TPCH_BIN" check-tables --hudi-base "$hudi_dir" 2>/dev/null; then
-    echo "Reusing existing Hudi tables at: $hudi_dir"
+  # unless --recreate says otherwise. The type is checked too, so a directory
+  # of the other type is rebuilt rather than silently benchmarked as this one.
+  if [ "$recreate" -eq 0 ] && \
+     "$TPCH_BIN" check-tables --hudi-base "$hudi_dir" --table-type "$table_type" >/dev/null 2>&1; then
+    echo "Reusing existing Hudi $table_type tables at: $hudi_dir"
     echo "Pass --recreate to rebuild them."
     return 0
   fi
@@ -300,19 +362,35 @@ cmd_create_tables() {
 
   local sql_file
   sql_file="$(mktemp)"
-  "$TPCH_BIN" render-ctas --scale-factor "$sf" \
+  "$TPCH_BIN" render-ctas --scale-factor "$sf" --table-type "$table_type" \
     --parquet-base "$parquet_dir" --hudi-base "$hudi_dir" > "$sql_file"
+  # The update commit runs in the same session as the bulk insert: the tables
+  # are already registered there, and a second session would have to re-register
+  # them against a catalog that may still name another run's location.
+  if [ "$table_type" = "mor" ]; then
+    "$TPCH_BIN" render-updates --scale-factor "$sf" \
+      ${update_fraction:+--update-fraction "$update_fraction"} >> "$sql_file"
+  fi
 
   read_spark_args --scale-factor "$sf" --command create-tables
 
-  echo "Creating Hudi COW tables from parquet (sf$sf)..."
+  if [ "$table_type" = "mor" ]; then
+    echo "Creating Hudi MOR tables from parquet (sf$sf), then an update commit..."
+  else
+    echo "Creating Hudi COW tables from parquet (sf$sf)..."
+  fi
   "$SPARK_HOME/bin/spark-sql" \
     --packages "$HUDI_SPARK_BUNDLE" \
     "${SPARK_ARGS[@]}" \
     -f "$sql_file"
 
   rm -f "$sql_file"
-  echo "Hudi COW tables created at: $hudi_dir"
+  echo "Hudi $table_type tables created at: $hudi_dir"
+
+  # For mor, this also prints the file layout and fails if any file group is
+  # missing its log file, so a benchmark never runs on a merge path that was
+  # never written.
+  "$TPCH_BIN" check-tables --hudi-base "$hudi_dir" --table-type "$table_type"
 }
 
 cmd_bench_spark() {
@@ -324,6 +402,7 @@ cmd_bench_spark() {
   local format="hudi"
   local custom_hudi_dir=""
   local custom_parquet_dir=""
+  local table_type="cow"
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --scale-factor) sf="$2"; shift 2 ;;
@@ -334,9 +413,11 @@ cmd_bench_spark() {
       --format) format="$2"; shift 2 ;;
       --hudi-dir) custom_hudi_dir="$2"; shift 2 ;;
       --parquet-dir) custom_parquet_dir="$2"; shift 2 ;;
+      --table-type) table_type="$2"; shift 2 ;;
       *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
     esac
   done
+  require_table_type "$table_type"
 
   build_tpch
 
@@ -351,15 +432,17 @@ cmd_bench_spark() {
     iterations="${iterations:-$cfg_iterations}"
   fi
 
-  local hudi_dir="${custom_hudi_dir:-$SCRIPT_DIR/data/sf$sf-hudi}"
+  local hudi_dir="${custom_hudi_dir:-$(default_hudi_dir "$sf" "$table_type")}"
   local parquet_dir="${custom_parquet_dir:-$SCRIPT_DIR/data/sf$sf-parquet}"
 
   local data_dir=""
   local bench_data_arg=""
+  local format_label="$format"
   case "$format" in
     hudi)
       data_dir="$hudi_dir"
       bench_data_arg="--hudi-base"
+      format_label="$(hudi_format_label "$table_type")"
       ;;
     parquet)
       data_dir="$parquet_dir"
@@ -373,7 +456,7 @@ cmd_bench_spark() {
     exit 1
   fi
   if [ "$format" = "hudi" ]; then
-    require_hudi_tables "$data_dir"
+    require_hudi_tables "$data_dir" "$table_type"
   fi
 
   read_spark_args --scale-factor "$sf" --command bench
@@ -395,7 +478,7 @@ cmd_bench_spark() {
     bench_args+=(--queries "$queries")
   fi
 
-  echo "Running Spark SQL benchmark ($format)..."
+  echo "Running Spark SQL benchmark ($format_label)..."
   "$SPARK_HOME/bin/spark-submit" \
     --packages "$HUDI_SPARK_BUNDLE" \
     "${SPARK_ARGS[@]}" \
@@ -406,8 +489,9 @@ cmd_bench_spark() {
   local parse_args=(parse-spark-output --input "$output_file")
   if [ -n "$output_dir" ]; then
     mkdir -p "$output_dir"
-    parse_args+=(--output-dir "$output_dir" --engine-label spark --format-label "$format" --display-name "spark+hudi" --scale-factor "$sf")
-    write_env_report "$output_dir/environment.txt" "$sf" "$data_dir"
+    parse_args+=(--output-dir "$output_dir" --engine-label spark --format-label "$format_label" \
+                 --display-name "spark+$format_label" --scale-factor "$sf")
+    write_env_report "$output_dir/environment.txt" "$sf" "$data_dir" "$table_type" "n/a (spark)"
   fi
   "$TPCH_BIN" "${parse_args[@]}"
   rm -rf "$tmp_dir"
@@ -422,6 +506,8 @@ cmd_bench_datafusion() {
   local output_dir=""
   local custom_hudi_dir=""
   local custom_parquet_dir=""
+  local table_type="cow"
+  local reader_version=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --scale-factor) sf="$2"; shift 2 ;;
@@ -432,11 +518,14 @@ cmd_bench_datafusion() {
       --output-dir) output_dir="$2"; shift 2 ;;
       --hudi-dir) custom_hudi_dir="$2"; shift 2 ;;
       --parquet-dir) custom_parquet_dir="$2"; shift 2 ;;
+      --table-type) table_type="$2"; shift 2 ;;
+      --reader-version) reader_version="$2"; shift 2 ;;
       *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
     esac
   done
+  require_table_type "$table_type"
 
-  local hudi_dir="${custom_hudi_dir:-$SCRIPT_DIR/data/sf$sf-hudi}"
+  local hudi_dir="${custom_hudi_dir:-$(default_hudi_dir "$sf" "$table_type")}"
   local parquet_dir="${custom_parquet_dir:-$SCRIPT_DIR/data/sf$sf-parquet}"
 
   # Determine which formats to bench
@@ -477,13 +566,14 @@ cmd_bench_datafusion() {
   build_tpch
 
   if [ "$use_hudi" = true ]; then
-    require_hudi_tables "$hudi_dir"
+    require_hudi_tables "$hudi_dir" "$table_type"
   fi
 
   local base_args=(bench --scale-factor "$sf")
   [ -n "$queries" ] && base_args+=(--queries "$queries")
   [ -n "$iterations" ] && base_args+=(--iterations "$iterations")
   [ -n "$warmup" ] && base_args+=(--warmup "$warmup")
+  [ -n "$reader_version" ] && base_args+=(--reader-version "$reader_version")
 
   local persisting=false
   if [ -n "$output_dir" ]; then
@@ -494,7 +584,7 @@ cmd_bench_datafusion() {
     # when only the parquet leg runs.
     local reported_dir="$hudi_dir"
     [ "$use_hudi" = false ] && reported_dir="$parquet_dir"
-    write_env_report "$output_dir/environment.txt" "$sf" "$reported_dir"
+    write_env_report "$output_dir/environment.txt" "$sf" "$reported_dir" "$table_type" "$reader_version"
   fi
 
   # One invocation per format. Results are keyed by engine and format label, so
@@ -514,7 +604,9 @@ cmd_bench_datafusion() {
   }
 
   if [ "$use_hudi" = true ]; then
-    run_datafusion_bench hudi --hudi-dir "$hudi_dir" "datafusion+hudi-rs"
+    local hudi_label
+    hudi_label="$(hudi_format_label "$table_type" "$reader_version")"
+    run_datafusion_bench "$hudi_label" --hudi-dir "$hudi_dir" "datafusion+hudi-rs${hudi_label#hudi}"
   fi
   if [ "$use_parquet" = true ]; then
     run_datafusion_bench parquet --parquet-dir "$parquet_dir" "datafusion+parquet"
@@ -529,6 +621,8 @@ cmd_validate() {
   local custom_parquet_dir=""
   local queries=""
   local memory_limit=""
+  local table_type="cow"
+  local reader_version=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --scale-factor) sf="$2"; shift 2 ;;
@@ -536,11 +630,14 @@ cmd_validate() {
       --parquet-dir) custom_parquet_dir="$2"; shift 2 ;;
       --queries) queries="$2"; shift 2 ;;
       --memory-limit) memory_limit="$2"; shift 2 ;;
+      --table-type) table_type="$2"; shift 2 ;;
+      --reader-version) reader_version="$2"; shift 2 ;;
       *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
     esac
   done
+  require_table_type "$table_type"
 
-  local hudi_dir="${custom_hudi_dir:-$SCRIPT_DIR/data/sf$sf-hudi}"
+  local hudi_dir="${custom_hudi_dir:-$(default_hudi_dir "$sf" "$table_type")}"
   local parquet_dir="${custom_parquet_dir:-$SCRIPT_DIR/data/sf$sf-parquet}"
 
   if ! is_cloud_url "$parquet_dir" && [ ! -d "$parquet_dir" ]; then
@@ -550,11 +647,12 @@ cmd_validate() {
   fi
 
   build_tpch
-  require_hudi_tables "$hudi_dir"
+  require_hudi_tables "$hudi_dir" "$table_type"
 
   local validate_args=(validate --scale-factor "$sf" --hudi-dir "$hudi_dir" --parquet-dir "$parquet_dir")
   [ -n "$queries" ] && validate_args+=(--queries "$queries")
   [ -n "$memory_limit" ] && validate_args+=(--memory-limit "$memory_limit")
+  [ -n "$reader_version" ] && validate_args+=(--reader-version "$reader_version")
 
   "$TPCH_BIN" "${validate_args[@]}"
 }
@@ -564,18 +662,21 @@ cmd_validate() {
 cmd_env_report() {
   local sf="$DEFAULT_SCALE_FACTOR"
   local custom_hudi_dir=""
+  local table_type="cow"
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --scale-factor) sf="$2"; shift 2 ;;
       --hudi-dir) custom_hudi_dir="$2"; shift 2 ;;
+      --table-type) table_type="$2"; shift 2 ;;
       *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
     esac
   done
+  require_table_type "$table_type"
 
   local results_dir="$SCRIPT_DIR/results"
   mkdir -p "$results_dir"
   write_env_report "$results_dir/environment.txt" "$sf" \
-    "${custom_hudi_dir:-$SCRIPT_DIR/data/sf$sf-hudi}"
+    "${custom_hudi_dir:-$(default_hudi_dir "$sf" "$table_type")}" "$table_type"
   cat "$results_dir/environment.txt"
 }
 

--- a/benchmark/tpch/src/config.rs
+++ b/benchmark/tpch/src/config.rs
@@ -21,6 +21,7 @@ use std::collections::BTreeMap;
 use std::fmt::Write;
 use std::path::{Path, PathBuf};
 
+use clap::ValueEnum;
 use serde::Deserialize;
 
 /// Canonical table ordering for SQL output (matches TPC-H dependency order).
@@ -28,12 +29,34 @@ const TABLE_ORDER: &[&str] = &[
     "nation", "region", "part", "supplier", "partsupp", "customer", "orders", "lineitem",
 ];
 
+/// Hudi table type the benchmark tables are created as.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub enum TableType {
+    /// Copy-on-write: one commit, base files only.
+    Cow,
+    /// Merge-on-read: the bulk insert plus one update commit that leaves a log
+    /// file in every file group.
+    Mor,
+}
+
+impl TableType {
+    /// The value Spark SQL's `type` table property takes.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TableType::Cow => "cow",
+            TableType::Mor => "mor",
+        }
+    }
+}
+
 /// Common table definition shared across all scale factors (from tables.yaml).
 #[derive(Deserialize)]
 struct CommonTableConfig {
     primary_key: String,
-    pre_combine_field: String,
+    /// Absent when the table has no real ordering column; see tables.yaml.
+    pre_combine_field: Option<String>,
     record_size_estimate: u32,
+    update_field: String,
 }
 
 /// Common tables file (tables.yaml).
@@ -53,9 +76,17 @@ struct ScaleFactorOverrides {
 /// Merged table config used at runtime.
 pub struct TableConfig {
     pub primary_key: String,
-    pub pre_combine_field: String,
+    pub pre_combine_field: Option<String>,
     pub record_size_estimate: u32,
+    pub update_field: String,
     pub shuffle_parallelism: u32,
+}
+
+impl TableConfig {
+    /// The primary key columns, in declaration order.
+    fn key_columns(&self) -> Vec<&str> {
+        self.primary_key.split(',').map(str::trim).collect()
+    }
 }
 
 pub struct ScaleFactorConfig {
@@ -151,6 +182,7 @@ impl ScaleFactorConfig {
                     primary_key: common_table.primary_key,
                     pre_combine_field: common_table.pre_combine_field,
                     record_size_estimate: common_table.record_size_estimate,
+                    update_field: common_table.update_field,
                     shuffle_parallelism,
                 },
             );
@@ -164,7 +196,12 @@ impl ScaleFactorConfig {
     }
 
     /// Generate CTAS SQL for creating Hudi tables from parquet sources.
-    pub fn render_ctas_sql(&self, parquet_base: &str, hudi_base: &str) -> String {
+    pub fn render_ctas_sql(
+        &self,
+        parquet_base: &str,
+        hudi_base: &str,
+        table_type: TableType,
+    ) -> String {
         let mut sql = String::new();
         for &name in TABLE_ORDER {
             let Some(table) = self.tables.get(name) else {
@@ -176,9 +213,18 @@ impl ScaleFactorConfig {
             writeln!(sql, "CREATE TABLE {name} USING hudi").unwrap();
             writeln!(sql, "LOCATION '{hudi_base}/{name}'").unwrap();
             writeln!(sql, "TBLPROPERTIES (").unwrap();
-            writeln!(sql, "  type = 'cow',").unwrap();
+            writeln!(sql, "  type = '{}',", table_type.as_str()).unwrap();
             writeln!(sql, "  primaryKey = '{}',", table.primary_key).unwrap();
-            writeln!(sql, "  preCombineField = '{}',", table.pre_combine_field).unwrap();
+            match &table.pre_combine_field {
+                Some(field) => writeln!(sql, "  preCombineField = '{field}',").unwrap(),
+                // Hudi infers this when no ordering field is given; stated so
+                // the rendered SQL says how the update commit is merged.
+                None => writeln!(
+                    sql,
+                    "  'hoodie.record.merge.mode' = 'COMMIT_TIME_ORDERING',"
+                )
+                .unwrap(),
+            }
             writeln!(sql, "  'hoodie.table.name' = '{name}',").unwrap();
             writeln!(
                 sql,
@@ -196,6 +242,55 @@ impl ScaleFactorConfig {
             writeln!(sql).unwrap();
         }
         sql
+    }
+
+    /// Generate the update commit that gives every file group a log file.
+    ///
+    /// One `UPDATE` per table, run in the session that created the tables. Two
+    /// clauses select the rows: a hash of the key picks one row in every
+    /// `round(1 / update_fraction)` uniformly (exactly the fraction only when
+    /// that reciprocal is whole), and the smallest key in each file group is
+    /// added so a table too small for the fraction to land a row still gets
+    /// its log file.
+    /// The assigned value is the column's own, so the merged rows, and every
+    /// query over them, are identical to the parquet the table was built
+    /// from — which is what lets `validate` run unchanged against a
+    /// merge-on-read table.
+    pub fn render_update_sql(&self, update_fraction: f64) -> Result<String, String> {
+        if !(update_fraction > 0.0 && update_fraction <= 1.0) {
+            return Err(format!(
+                "update fraction must be in (0, 1], got {update_fraction}"
+            ));
+        }
+        let modulus = (1.0 / update_fraction).round().max(1.0) as u64;
+
+        let mut sql = String::new();
+        for &name in TABLE_ORDER {
+            let Some(table) = self.tables.get(name) else {
+                continue;
+            };
+            let keys = table.key_columns();
+            let key_list = keys.join(", ");
+            let first_key = keys
+                .iter()
+                .map(|k| format!("first_key.{k}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let field = &table.update_field;
+            writeln!(sql, "UPDATE {name} SET {field} = {field}").unwrap();
+            writeln!(sql, "WHERE pmod(hash({key_list}), {modulus}) = 0").unwrap();
+            writeln!(sql, "   OR ({key_list}) IN (").unwrap();
+            writeln!(sql, "     SELECT {first_key} FROM (").unwrap();
+            writeln!(
+                sql,
+                "       SELECT min(struct({key_list})) AS first_key FROM {name} GROUP BY _hoodie_file_name"
+            )
+            .unwrap();
+            writeln!(sql, "     )").unwrap();
+            writeln!(sql, "   );").unwrap();
+            writeln!(sql).unwrap();
+        }
+        Ok(sql)
     }
 
     /// Generate benchmark SQL: table registrations followed by query iterations.
@@ -260,5 +355,77 @@ impl ScaleFactorConfig {
         }
 
         Ok(args)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sf1() -> ScaleFactorConfig {
+        ScaleFactorConfig::load(1.0).expect("sf1 config loads")
+    }
+
+    fn statements_for(sql: &str, table: &str) -> Vec<String> {
+        sql.split(";\n")
+            .filter(|stmt| {
+                stmt.contains(&format!(" {table} ")) || stmt.contains(&format!(" {table}\n"))
+            })
+            .map(|stmt| stmt.to_string())
+            .collect()
+    }
+
+    #[test]
+    fn test_render_ctas_sql_mor_sets_table_type_per_table() {
+        let sql = sf1().render_ctas_sql("/pq", "/hudi", TableType::Mor);
+        assert_eq!(sql.matches("type = 'mor',").count(), 8);
+        assert!(!sql.contains("type = 'cow'"));
+        let cow = sf1().render_ctas_sql("/pq", "/hudi", TableType::Cow);
+        assert_eq!(cow.matches("type = 'cow',").count(), 8);
+    }
+
+    #[test]
+    fn test_render_ctas_sql_ordering_follows_pre_combine_field() {
+        let sql = sf1().render_ctas_sql("/pq", "/hudi", TableType::Mor);
+        let lineitem = statements_for(&sql, "lineitem").join(";");
+        assert!(lineitem.contains("preCombineField = 'l_shipdate'"));
+        assert!(!lineitem.contains("COMMIT_TIME_ORDERING"));
+        let customer = statements_for(&sql, "customer").join(";");
+        assert!(!customer.contains("preCombineField"));
+        assert!(customer.contains("'hoodie.record.merge.mode' = 'COMMIT_TIME_ORDERING'"));
+    }
+
+    #[test]
+    fn test_render_update_sql_assigns_update_field_to_itself() {
+        let sql = sf1().render_update_sql(0.001).expect("renders");
+        assert_eq!(sql.matches("UPDATE ").count(), 8);
+        assert!(sql.contains("UPDATE lineitem SET l_comment = l_comment"));
+        assert!(sql.contains("UPDATE customer SET c_comment = c_comment"));
+    }
+
+    #[test]
+    fn test_render_update_sql_fraction_becomes_hash_modulus() {
+        let sql = sf1().render_update_sql(0.001).expect("renders");
+        assert!(sql.contains("pmod(hash(o_orderkey), 1000) = 0"));
+        let sql = sf1().render_update_sql(0.25).expect("renders");
+        assert!(sql.contains("pmod(hash(o_orderkey), 4) = 0"));
+    }
+
+    #[test]
+    fn test_render_update_sql_composite_key_selects_first_key_per_file_group() {
+        let sql = sf1().render_update_sql(0.001).expect("renders");
+        assert!(sql.contains("OR (l_orderkey, l_linenumber) IN ("));
+        assert!(sql.contains("SELECT first_key.l_orderkey, first_key.l_linenumber FROM ("));
+        assert!(sql.contains(
+            "SELECT min(struct(l_orderkey, l_linenumber)) AS first_key FROM lineitem GROUP BY _hoodie_file_name"
+        ));
+    }
+
+    #[test]
+    fn test_render_update_sql_rejects_fraction_outside_unit_interval() {
+        for bad in [0.0, -0.1, 1.5, f64::NAN] {
+            let err = sf1().render_update_sql(bad).expect_err("rejects");
+            assert!(err.contains("update fraction"), "{err}");
+        }
     }
 }

--- a/benchmark/tpch/src/main.rs
+++ b/benchmark/tpch/src/main.rs
@@ -40,7 +40,13 @@ use datafusion::execution::memory_pool::FairSpillPool;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::prelude::SessionConfig;
 use hudi::HudiDataSource;
+use hudi::config::ReadOptions;
+use hudi::config::read::HudiReadConfig;
+use hudi::config::table::HudiTableConfig;
+use hudi::table::Table as HudiTable;
 use serde::{Deserialize, Serialize};
+
+use config::TableType;
 
 /// The 8 TPC-H tables.
 const TPCH_TABLES: &[&str] = &[
@@ -85,12 +91,32 @@ enum Commands {
         /// Hudi output base path (e.g., /opt/hudi or gs://bucket/path)
         #[arg(long)]
         hudi_base: String,
+
+        /// Table type to create
+        #[arg(long, value_enum, default_value_t = TableType::Cow)]
+        table_type: TableType,
+    },
+    /// Render the update commit for merge-on-read tables (one UPDATE per table)
+    RenderUpdates {
+        /// TPC-H scale factor (loads config/sf{N}.yaml)
+        #[arg(long)]
+        scale_factor: f64,
+
+        /// Fraction of each table's rows to update, in (0, 1]; applied as one row in
+        /// every round(1/F) by key hash, so it is exact only when 1/F is whole
+        #[arg(long, default_value_t = 0.001)]
+        update_fraction: f64,
     },
     /// Verify every TPC-H Hudi table is readable at a base path
     CheckTables {
         /// Hudi tables base path (e.g., /opt/hudi or s3://bucket/path)
         #[arg(long)]
         hudi_base: String,
+
+        /// Also require this table type; `mor` requires a log file in every
+        /// file group and prints the file layout per table
+        #[arg(long, value_enum)]
+        table_type: Option<TableType>,
     },
     /// Render benchmark SQL (table registrations + query iterations)
     RenderBenchSql {
@@ -171,6 +197,10 @@ enum Commands {
         /// Display name for charts (e.g., "datafusion+hudi-rs"); defaults to engine_label
         #[arg(long)]
         display_name: Option<String>,
+
+        /// File group reader version to read Hudi tables with (1 or 2; hudi-rs default if omitted)
+        #[arg(long)]
+        reader_version: Option<u8>,
     },
     /// Validate Hudi query results against Parquet (runs each query once, compares output)
     Validate {
@@ -193,6 +223,10 @@ enum Commands {
         /// DataFusion memory limit (e.g., "3g", "512m"); unlimited if not set
         #[arg(long)]
         memory_limit: Option<String>,
+
+        /// File group reader version to read Hudi tables with (1 or 2; hudi-rs default if omitted)
+        #[arg(long)]
+        reader_version: Option<u8>,
     },
     /// Parse Spark benchmark JSON output into a timing table
     ParseSparkOutput {
@@ -230,6 +264,11 @@ enum Commands {
         #[arg(long)]
         runs: String,
     },
+}
+
+/// Carry a hudi-rs error through the DataFusion result type the commands share.
+fn core_error(e: hudi::error::CoreError) -> datafusion::error::DataFusionError {
+    datafusion::error::DataFusionError::External(Box::new(e))
 }
 
 /// Check if a path string is a cloud URL.
@@ -354,13 +393,38 @@ async fn main() -> Result<()> {
             scale_factor,
             parquet_base,
             hudi_base,
+            table_type,
         } => {
             let cfg = config::ScaleFactorConfig::load(scale_factor)
                 .map_err(|e| datafusion::error::DataFusionError::Plan(format!("{e}")))?;
-            print!("{}", cfg.render_ctas_sql(&parquet_base, &hudi_base));
+            print!(
+                "{}",
+                cfg.render_ctas_sql(&parquet_base, &hudi_base, table_type)
+            );
             Ok(())
         }
-        Commands::CheckTables { hudi_base } => {
+        Commands::RenderUpdates {
+            scale_factor,
+            update_fraction,
+        } => {
+            let cfg = config::ScaleFactorConfig::load(scale_factor)
+                .map_err(|e| datafusion::error::DataFusionError::Plan(format!("{e}")))?;
+            let sql = cfg
+                .render_update_sql(update_fraction)
+                .map_err(datafusion::error::DataFusionError::Plan)?;
+            print!("{sql}");
+            Ok(())
+        }
+        Commands::CheckTables {
+            hudi_base,
+            table_type,
+        } => {
+            // With a type to check, the layout check opens each table itself
+            // and names the one that fails, so the presence check would only
+            // open them all a second time.
+            if let Some(expected) = table_type {
+                return check_table_layout(&hudi_base, expected).await;
+            }
             let missing = missing_hudi_tables(&hudi_base).await?;
             if missing.is_empty() {
                 Ok(())
@@ -419,6 +483,7 @@ async fn main() -> Result<()> {
             engine_label,
             format_label,
             display_name,
+            reader_version,
         } => {
             let cfg = config::ScaleFactorConfig::load(scale_factor)
                 .map_err(|e| datafusion::error::DataFusionError::Plan(format!("{e}")))?;
@@ -440,6 +505,7 @@ async fn main() -> Result<()> {
                 engine_label.as_deref(),
                 format_label.as_deref(),
                 display_name.as_deref(),
+                &hudi_read_options(reader_version),
             )
             .await
         }
@@ -449,6 +515,7 @@ async fn main() -> Result<()> {
             scale_factor,
             queries,
             memory_limit,
+            reader_version,
         } => {
             let cfg = config::ScaleFactorConfig::load(scale_factor)
                 .map_err(|e| datafusion::error::DataFusionError::Plan(format!("{e}")))?;
@@ -456,7 +523,15 @@ async fn main() -> Result<()> {
             if memory_limit.is_some() {
                 df_conf.memory_limit = memory_limit;
             }
-            run_validate(&hudi_dir, &parquet_dir, scale_factor, queries, &df_conf).await
+            run_validate(
+                &hudi_dir,
+                &parquet_dir,
+                scale_factor,
+                queries,
+                &df_conf,
+                &hudi_read_options(reader_version),
+            )
+            .await
         }
         Commands::ParseSparkOutput {
             input,
@@ -539,16 +614,184 @@ fn hudi_table_uri(resolved_base: &str, table_name: &str) -> Result<String> {
     }
 }
 
+/// Hudi read options the benchmark passes to every table it opens.
+///
+/// Only the file group reader version is settable, and only when asked for:
+/// an omitted version leaves hudi-rs's own default in charge, so the
+/// benchmark measures what a consumer gets without configuring anything.
+fn hudi_read_options(reader_version: Option<u8>) -> Vec<(String, String)> {
+    reader_version
+        .map(|v| {
+            vec![(
+                HudiReadConfig::FileGroupReaderVersion.as_ref().to_string(),
+                v.to_string(),
+            )]
+        })
+        .unwrap_or_default()
+}
+
 /// Register all 8 TPC-H Hudi tables. Supports local paths and cloud URLs.
-async fn register_hudi_tables(ctx: &SessionContext, base_dir: &str) -> Result<()> {
+async fn register_hudi_tables(
+    ctx: &SessionContext,
+    base_dir: &str,
+    hudi_options: &[(String, String)],
+) -> Result<()> {
     let resolved = resolve_path(base_dir).map_err(datafusion::error::DataFusionError::Plan)?;
+
+    let pins_version_one = hudi_options
+        .iter()
+        .any(|(k, v)| k == HudiReadConfig::FileGroupReaderVersion.as_ref() && v.trim() == "1");
 
     for table_name in TPCH_TABLES {
         let table_uri = hudi_table_uri(&resolved, table_name)?;
-        let hudi = HudiDataSource::new(&table_uri).await?;
+        if pins_version_one {
+            refuse_append_only_baseline(&table_uri, table_name).await?;
+        }
+        let hudi = HudiDataSource::new_with_options(&table_uri, hudi_options.to_vec()).await?;
         ctx.register_table(*table_name, Arc::new(hudi))?;
     }
     Ok(())
+}
+
+/// Refuse a reader version 1 baseline on a merge-on-read table it would not merge.
+///
+/// Version 1 has no commit-time merge: a table without an ordering field is
+/// read append-only, base rows and log rows both returned. A benchmark of that
+/// would be labelled a merge baseline while merging nothing, and `validate`
+/// would only catch it after the fact through duplicate rows. Version 2 infers
+/// commit-time ordering for the same table, so this applies to the pin alone.
+async fn refuse_append_only_baseline(table_uri: &str, table_name: &str) -> Result<()> {
+    let table = HudiTable::new(table_uri).await.map_err(core_error)?;
+    if !table.is_mor() {
+        return Ok(());
+    }
+    let options = table.hudi_options();
+    // The deprecated alias too: a table written before the rename carries only that.
+    let has_ordering_field = [
+        HudiTableConfig::OrderingFields.as_ref(),
+        "hoodie.table.precombine.field",
+    ]
+    .iter()
+    .any(|key| options.get(*key).is_some_and(|v| !v.trim().is_empty()));
+    if has_ordering_field {
+        return Ok(());
+    }
+    Err(datafusion::error::DataFusionError::Plan(format!(
+        "{table_name} is merge-on-read with no ordering field, which file group reader \
+         version 1 reads append-only rather than merging by commit time; a version 1 \
+         baseline on it would measure no merge. Give the table a pre_combine_field in \
+         tables.yaml and rebuild it, or drop --reader-version."
+    )))
+}
+
+/// Bytes as a short human-readable size.
+fn format_bytes(bytes: u64) -> String {
+    const KIB: f64 = 1024.0;
+    let b = bytes as f64;
+    if b >= KIB * KIB * KIB {
+        format!("{:.1} GiB", b / (KIB * KIB * KIB))
+    } else if b >= KIB * KIB {
+        format!("{:.1} MiB", b / (KIB * KIB))
+    } else if b >= KIB {
+        format!("{:.1} KiB", b / KIB)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+/// What one table's file slices look like on storage.
+struct TableLayout {
+    file_groups: usize,
+    slices_with_logs: usize,
+    log_files: usize,
+    log_bytes: u64,
+}
+
+async fn table_layout(table: &HudiTable) -> Result<TableLayout> {
+    let slices = table
+        .get_file_slices(&ReadOptions::new())
+        .await
+        .map_err(core_error)?;
+    let mut layout = TableLayout {
+        file_groups: slices.len(),
+        slices_with_logs: 0,
+        log_files: 0,
+        log_bytes: 0,
+    };
+    for slice in &slices {
+        if slice.has_log_file() {
+            layout.slices_with_logs += 1;
+        }
+        layout.log_files += slice.log_files.len();
+        layout.log_bytes += slice
+            .log_files
+            .iter()
+            .filter_map(|log| log.file_metadata.as_ref())
+            .map(|meta| meta.size)
+            .sum::<u64>();
+    }
+    Ok(layout)
+}
+
+/// Check every table is of `expected` type and, for merge-on-read, that every
+/// file group carries a log file — the layout the update commit exists to
+/// produce. A merge-on-read table whose file groups have nothing to merge would
+/// benchmark as copy-on-write while being labelled otherwise.
+async fn check_table_layout(base_dir: &str, expected: TableType) -> Result<()> {
+    let resolved = resolve_path(base_dir).map_err(datafusion::error::DataFusionError::Plan)?;
+    let mut problems = Vec::new();
+
+    for table_name in TPCH_TABLES {
+        let table_uri = hudi_table_uri(&resolved, table_name)?;
+        let table = match HudiTable::new(&table_uri).await {
+            Ok(table) => table,
+            Err(e) => {
+                problems.push(format!("{table_name}: cannot be opened: {e}"));
+                continue;
+            }
+        };
+        let table_type = table.table_type();
+        let is_expected = match expected {
+            TableType::Cow => !table.is_mor(),
+            TableType::Mor => table.is_mor(),
+        };
+        if !is_expected {
+            problems.push(format!(
+                "{table_name}: table type is {table_type}, expected {}",
+                expected.as_str()
+            ));
+            continue;
+        }
+        if expected == TableType::Cow {
+            continue;
+        }
+        let layout = table_layout(&table).await?;
+        println!(
+            "{table_name}: {} file groups, {} with log files ({} log files, {})",
+            layout.file_groups,
+            layout.slices_with_logs,
+            layout.log_files,
+            format_bytes(layout.log_bytes)
+        );
+        if layout.file_groups == 0 {
+            problems.push(format!("{table_name}: no file groups"));
+        } else if layout.slices_with_logs < layout.file_groups {
+            problems.push(format!(
+                "{table_name}: {} of {} file groups have no log file",
+                layout.file_groups - layout.slices_with_logs,
+                layout.file_groups
+            ));
+        }
+    }
+
+    if problems.is_empty() {
+        Ok(())
+    } else {
+        Err(datafusion::error::DataFusionError::Plan(format!(
+            "Hudi tables at {base_dir} do not have the expected layout:\n  {}",
+            problems.join("\n  ")
+        )))
+    }
 }
 
 /// Register all 8 TPC-H parquet tables. Supports local paths and cloud URLs.
@@ -836,6 +1079,7 @@ async fn run_bench(
     engine_label: Option<&str>,
     format_label: Option<&str>,
     display_name: Option<&str>,
+    hudi_options: &[(String, String)],
 ) -> Result<()> {
     if hudi_dir.is_none() && parquet_dir.is_none() {
         return Err(datafusion::error::DataFusionError::Plan(
@@ -854,7 +1098,7 @@ async fn run_bench(
         let ctx =
             create_session_context(df_conf).map_err(datafusion::error::DataFusionError::Plan)?;
         println!("Registering Hudi tables from {hudi_dir}");
-        register_hudi_tables(&ctx, hudi_dir).await?;
+        register_hudi_tables(&ctx, hudi_dir, hudi_options).await?;
         println!("Benchmarking Hudi...");
         let results = bench_source(&ctx, &query_nums, warmup, iterations, scale_factor).await;
         print_single_table("Hudi", &results);
@@ -886,12 +1130,16 @@ async fn run_bench(
 }
 
 /// Run validation: query both Hudi and Parquet once, compare results.
+///
+/// For merge-on-read tables, also check that the update commit's records
+/// surface in the merged rows — see [`verify_merged_updates`].
 async fn run_validate(
     hudi_dir: &str,
     parquet_dir: &str,
     scale_factor: f64,
     queries: Option<String>,
     df_conf: &config::DataFusionConfig,
+    hudi_options: &[(String, String)],
 ) -> Result<()> {
     let query_nums = parse_query_numbers(queries);
 
@@ -902,7 +1150,7 @@ async fn run_validate(
     println!("Registering Hudi tables from {hudi_dir}");
     let hudi_ctx =
         create_session_context(df_conf).map_err(datafusion::error::DataFusionError::Plan)?;
-    register_hudi_tables(&hudi_ctx, hudi_dir).await?;
+    register_hudi_tables(&hudi_ctx, hudi_dir, hudi_options).await?;
 
     println!("Registering Parquet tables from {parquet_dir}");
     let parquet_ctx =
@@ -917,13 +1165,139 @@ async fn run_validate(
 
     let failed = print_validation_table(&query_nums, &hudi_results, &parquet_results);
 
+    if !failed.is_empty() {
+        let names: Vec<String> = failed.iter().map(|qn| format!("Q{qn:02}")).collect();
+        return Err(datafusion::error::DataFusionError::Plan(format!(
+            "Hudi results differ from parquet for {}",
+            names.join(", ")
+        )));
+    }
+
+    verify_merged_updates(&hudi_ctx, hudi_dir).await
+}
+
+/// Total records the write stats of one commit report as updates.
+fn update_records_in_commit(metadata_json: &str) -> std::result::Result<u64, String> {
+    let metadata: serde_json::Value =
+        serde_json::from_str(metadata_json).map_err(|e| format!("Invalid commit metadata: {e}"))?;
+    let partitions = metadata
+        .get("partitionToWriteStats")
+        .and_then(|v| v.as_object())
+        .ok_or("Commit metadata has no partitionToWriteStats")?;
+    Ok(partitions
+        .values()
+        .filter_map(|stats| stats.as_array())
+        .flatten()
+        .filter_map(|stat| stat.get("numUpdateWrites").and_then(|v| v.as_u64()))
+        .sum())
+}
+
+/// Check that each merge-on-read table's latest delta commit is what the
+/// reader returns for the rows it touched.
+///
+/// The update commit rewrites rows with their own values, so no query can tell
+/// whether the log records were merged or ignored — the results are identical
+/// either way. `_hoodie_commit_time` can: a row that came from the log carries
+/// the delta commit's time, one served from the base file the bulk insert's.
+/// So the rows stamped with the delta commit must number exactly the update
+/// records that commit wrote. Fewer means log records were dropped or lost a
+/// tie they should have won; more means duplicates.
+///
+/// Copy-on-write tables have no delta commits and are skipped.
+async fn verify_merged_updates(ctx: &SessionContext, hudi_dir: &str) -> Result<()> {
+    let resolved = resolve_path(hudi_dir).map_err(datafusion::error::DataFusionError::Plan)?;
+
+    let mut table = Table::new();
+    table.set_header(vec![
+        "Table",
+        "Delta commit",
+        "Update records",
+        "Rows merged",
+        "Status",
+    ]);
+    let mut checked = 0;
+    let mut failed = Vec::new();
+
+    for table_name in TPCH_TABLES {
+        let hudi_table = HudiTable::new(&hudi_table_uri(&resolved, table_name)?)
+            .await
+            .map_err(core_error)?;
+        if !hudi_table.is_mor() {
+            continue;
+        }
+        let timeline = hudi_table.get_timeline();
+        let Some(delta_commit) = timeline
+            .get_completed_deltacommits(true)
+            .await
+            .map_err(core_error)?
+            .into_iter()
+            .next()
+        else {
+            table.add_row(vec![
+                Cell::new(table_name),
+                Cell::new("-"),
+                Cell::new("-"),
+                Cell::new("-"),
+                Cell::new("no delta commit"),
+            ]);
+            failed.push(table_name.to_string());
+            continue;
+        };
+        let metadata = timeline
+            .get_instant_metadata_in_json(&delta_commit)
+            .await
+            .map_err(core_error)?;
+        let expected = update_records_in_commit(&metadata)
+            .map_err(datafusion::error::DataFusionError::Plan)?;
+
+        let sql = format!(
+            "SELECT count(*) FROM {table_name} WHERE _hoodie_commit_time = '{}'",
+            delta_commit.timestamp
+        );
+        let batches = ctx.sql(&sql).await?.collect().await?;
+        let merged = batches
+            .first()
+            .and_then(|b| {
+                b.column(0)
+                    .as_any()
+                    .downcast_ref::<arrow_array::Int64Array>()
+            })
+            .filter(|col| !col.is_empty())
+            .map(|col| col.value(0))
+            .ok_or_else(|| {
+                datafusion::error::DataFusionError::Plan(format!(
+                    "count query on {table_name} returned no row"
+                ))
+            })?;
+        let merged = u64::try_from(merged).unwrap_or(0);
+
+        let status = if merged == expected { "OK" } else { "MISMATCH" };
+        if merged != expected {
+            failed.push(table_name.to_string());
+        }
+        checked += 1;
+        table.add_row(vec![
+            Cell::new(table_name),
+            Cell::new(&delta_commit.timestamp),
+            Cell::new(expected),
+            Cell::new(merged),
+            Cell::new(status),
+        ]);
+    }
+
+    if checked == 0 && failed.is_empty() {
+        return Ok(());
+    }
+    println!();
+    println!("Merge-on-read update records merged by the reader:");
+    println!("{table}");
+
     if failed.is_empty() {
         Ok(())
     } else {
-        let names: Vec<String> = failed.iter().map(|qn| format!("Q{qn:02}")).collect();
         Err(datafusion::error::DataFusionError::Plan(format!(
-            "Hudi results differ from parquet for {}",
-            names.join(", ")
+            "Update records not fully merged for {}",
+            failed.join(", ")
         )))
     }
 }


### PR DESCRIPTION
## Description

The TPC-H harness only built copy-on-write tables, so it could not measure what the merge path costs on top of a plain base file read. This adds `--table-type mor` to `create-tables`, `bench-*` and `validate`: the same CTAS creates merge-on-read tables, and one `UPDATE` per table in the same Spark session follows it, so that every file group carries exactly one log file and every read goes through the file group reader's merge path.

The update rewrites `--update-fraction` of each table's rows (default 0.001) with their own values, plus the smallest key in every file group so the small tables get a log file too. Query results are identical to the parquet source, which keeps `validate` meaningful on the merge-on-read tables. Tables without a real ordering column (everything but `lineitem` and `orders`) now merge by commit time instead of using their own key as `preCombineField`.

Because the values are unchanged, `validate` proves the merge through `_hoodie_commit_time`: for each MOR table it counts the rows stamped with the update commit and requires the count to equal `numUpdateWrites` from that commit's metadata. `create-tables` prints the file layout per table and fails if any file group is missing its log file. Merge-on-read tables default to `data/sf{N}-hudi-mor` and persist under the `hudi-mor` format label, so both types can be built from one parquet set and compared. `--reader-version 1` pins the previous file group reader as a baseline (results get a `-r1` suffix). That reader has no commit-time merge and would read the default merge-on-read tables append-only, so the harness refuses the pin on them and says how to build tables both readers merge. One side effect on the existing Spark leg: a `--format parquet` run is now labelled `spark+parquet` instead of `spark+hudi`.

## How are the changes test-covered

- [ ] N/A
- [x] Automated tests (unit and/or integration tests)
- [x] Manual tests
  - [x] Details are described below

Unit tests cover the CTAS and UPDATE renderers (table type, ordering mode, hash modulus, composite keys, first key per file group, fraction bounds).

End to end at SF 0.01 with Spark 3.5.8 and `hudi-spark3.5-bundle_2.12:1.1.1` on a table version 9 layout: `create-tables --table-type mor` produced 8 tables, each with 1 file group and 1 log file; `validate --table-type mor` passed 22/22 queries against parquet and the merge check matched on all 8 tables (for example 77 update records written, 77 rows merged for `lineitem`). With `RUST_LOG=hudi_core::file_group::reader=debug`, every one of the 93 file slice reads in that run was served by file group reader version 2 and none by version 1. `bench-datafusion` with `--table-type mor` and the existing COW path both ran and persisted under distinct labels, and `compare --runs` charts them side by side; `--reader-version 1` on the merge-on-read tables is refused with the message above. The COW path was re-run (`create-tables`, `validate`, `bench-datafusion`) to confirm the ordering-mode change did not alter it.
